### PR TITLE
feat(cancellation): FE-06 nuevas razones LEGAL_OBLIGATIONS y CHANGE_O…

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -339,6 +339,8 @@
       "reasonCannotAttend": "Cannot attend",
       "reasonIllness": "Illness",
       "reasonInabilityToTravel": "Inability to travel",
+      "reasonLegalObligations": "Legal obligations",
+      "reasonChangeOfPlans": "Change of plans",
       "goBack": "Go back",
       "confirmCancellation": "Confirm Cancellation",
       "rescheduleBooking": "Reschedule Booking",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -340,6 +340,8 @@
       "reasonCannotAttend": "No puedo asistir",
       "reasonIllness": "Enfermedad",
       "reasonInabilityToTravel": "Incapacidad para viajar",
+      "reasonLegalObligations": "Obligaciones legales",
+      "reasonChangeOfPlans": "Cambio de planes",
       "goBack": "Volver",
       "confirmCancellation": "Confirmar Cancelación",
       "rescheduleBooking": "Reagendar Reserva",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -339,6 +339,8 @@
       "reasonCannotAttend": "Não posso comparecer",
       "reasonIllness": "Doença",
       "reasonInabilityToTravel": "Incapacidade de viajar",
+      "reasonLegalObligations": "Obrigações legais",
+      "reasonChangeOfPlans": "Mudança de planos",
       "goBack": "Voltar",
       "confirmCancellation": "Confirmar Cancelamento",
       "rescheduleBooking": "Reagendar Reserva",

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
@@ -773,6 +773,8 @@
                             <option value="CANNOT_ATTEND">{{ 'provider-tour-management.modal.reasonCannotAttend' | translate }}</option>
                             <option value="ILLNESS">{{ 'provider-tour-management.modal.reasonIllness' | translate }}</option>
                             <option value="INABILITY_TO_TRAVEL">{{ 'provider-tour-management.modal.reasonInabilityToTravel' | translate }}</option>
+                            <option value="LEGAL_OBLIGATIONS">{{ 'provider-tour-management.modal.reasonLegalObligations' | translate }}</option>
+                            <option value="CHANGE_OF_PLANS">{{ 'provider-tour-management.modal.reasonChangeOfPlans' | translate }}</option>
                         </select>
                     </div>
                 </div>

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -1498,9 +1498,11 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
     const mapping: { [key: string]: string } = {
       'CANNOT_ATTEND': 'No puede asistir',
       'ILLNESS': 'Enfermedad',
+      'INABILITY_TO_TRAVEL': 'Incapacidad para viajar',
+      'LEGAL_OBLIGATIONS': 'Obligaciones legales',
+      'CHANGE_OF_PLANS': 'Cambio de planes',
       'WEATHER': 'Condiciones climáticas',
       'EMERGENCY': 'Emergencia',
-      'CHANGE_OF_PLANS': 'Cambio de planes',
       'DISSATISFIED': 'Insatisfacción con el servicio',
       'DUPLICATE': 'Reserva duplicada',
       'OTHER': 'Otro motivo',
@@ -1885,7 +1887,9 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
     const reasonMap: { [key: string]: string } = {
       'CANNOT_ATTEND': 'CANNOT_ATTEND',
       'ILLNESS': 'ILLNESS',
-      'INABILITY_TO_TRAVEL': 'INABILITY_TO_TRAVEL'
+      'INABILITY_TO_TRAVEL': 'INABILITY_TO_TRAVEL',
+      'LEGAL_OBLIGATIONS': 'LEGAL_OBLIGATIONS',
+      'CHANGE_OF_PLANS': 'CHANGE_OF_PLANS'
     };
 
     const apiReason = reasonMap[this.cancellationReason];


### PR DESCRIPTION
…F_PLANS

Cierra el bucle end-to-end del PR backend #166 (BE-05). Ahora el turista puede elegir estos 2 motivos desde la UI de cancelacion en la pantalla de proveedor (provider-tour-management).

Cambios en provider-tour-management:

1. HTML (dropdown de razones): agregadas 2 opciones nuevas:
   - LEGAL_OBLIGATIONS -> reasonLegalObligations
   - CHANGE_OF_PLANS -> reasonChangeOfPlans

2. TypeScript reasonMap (validacion del motivo enviado al API): incluye los 2 valores nuevos como aceptados. Sin ellos, el confirmCancellation rechazaba el envio.

3. TypeScript formatCancellationReason (mapeo codigo -> label ES para mostrar en detalles): agregados los 2 valores nuevos.

Aprovechamos para cerrar un bug preexistente:

INABILITY_TO_TRAVEL ya estaba en el HTML del dropdown y en la validacion TS, pero faltaba en formatCancellationReason. Resultado: si una reserva tenia esta razon guardada, se mostraba como texto crudo. Ahora se formatea como "Incapacidad para viajar". Fix chico de consistencia.

i18n en 3 idiomas:
- reasonLegalObligations: "Obligaciones legales" / "Legal obligations" / "Obrigacoes legais"
- reasonChangeOfPlans: "Cambio de planes" / "Change of plans" / "Mudanca de planos"

Verificacion:
- npx tsc --noEmit: sin errores en los archivos tocados. Existe un error preexistente en localized-name.pipe.spec.ts que no forma parte de este cambio.
- Todos los otros usos de CancellationReasonEnum en el proyecto siguen funcionando: reservation.service.ts (nota de doc), reservation.model.ts (tipo union) y payment.dto.ts (referencia informativa) no requieren ajuste porque no enumeran los valores validos.

Sin cambios en:
- reservation.model.ts: usa string, acepta cualquier valor.
- payment.dto.ts: idem.
- Backend: los enums LEGAL_OBLIGATIONS y CHANGE_OF_PLANS ya existen en CancellationReasonEnum del backend (PR #166) y la columna reservation.cancellation_reason es VARCHAR(20) — ambos strings caben.