### PR TITLE
feat(admin): FE-04 panel de administración de app_config

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1737,5 +1737,83 @@
       "phoneLabel": "Contact phone:",
       "addressLabel": "Our address:"
     }
+  },
+  "app-config-admin": {
+    "sidebarLink": "Settings",
+    "title": "System settings",
+    "description": "Adjust operational values without redeploying. Changes apply on the next request.",
+    "groups": {
+      "booking": "Bookings and cart",
+      "payoutsAndCredits": "Provider payouts and credits",
+      "gallery": "Tour gallery",
+      "kybDocs": "KYB (provider documents)",
+      "authProtection": "Authentication protection"
+    },
+    "table": {
+      "setting": "Setting",
+      "value": "Current value",
+      "actions": "Actions",
+      "loading": "Loading…",
+      "errorLoading": "Failed to load",
+      "save": "Save",
+      "saving": "Saving…",
+      "reset": "Revert",
+      "on": "On",
+      "off": "Off"
+    },
+    "swal": {
+      "savedTitle": "Setting saved",
+      "savedText": "Will apply on the next request ({{ key }}).",
+      "errorTitle": "Could not save",
+      "errorText": "Error saving {{ key }}: {{ message }}"
+    },
+    "holdMinutes": {
+      "label": "Cart hold minutes",
+      "description": "Time the tourist has to complete payment before the TEMPORAL reservation expires."
+    },
+    "payoutBufferDays": {
+      "label": "Payout buffer days",
+      "description": "Days between the reservation date and when the payout to the provider becomes available."
+    },
+    "creditExpirationMonths": {
+      "label": "Credit validity months",
+      "description": "Duration of a credit issued after a cancellation before it expires."
+    },
+    "galleryMaxSizeMb": {
+      "label": "Max image size (MB)",
+      "description": "Images larger than this size are rejected when syncing the gallery."
+    },
+    "galleryMinWidthPx": {
+      "label": "Min image width (px)",
+      "description": "Minimum accepted width to ensure visual quality."
+    },
+    "galleryMaxImagesPerTour": {
+      "label": "Max images per tour",
+      "description": "Total number of images a tour can have in its gallery."
+    },
+    "kybRequireMandatoryDocs": {
+      "label": "Require mandatory KYB documents",
+      "description": "When on, the provider submit is rejected if mandatory documents are missing."
+    },
+    "authRateLimitEnabled": {
+      "label": "Rate limit on /auth",
+      "description": "Enables the temporary block of an IP that makes too many requests to auth endpoints."
+    },
+    "authRateLimitPerMinute": {
+      "label": "Requests per IP per minute",
+      "description": "Rate limiter threshold. When exceeded, HTTP 429 is returned."
+    },
+    "authLockoutEnabled": {
+      "label": "Account lockout on failed logins",
+      "description": "Enables temporary account lockout after N consecutive failed login attempts."
+    },
+    "authLockoutMaxAttempts": {
+      "label": "Allowed failed attempts",
+      "description": "Number of failed attempts before applying lockout."
+    },
+    "authLockoutBaseBackoffSeconds": {
+      "label": "Base backoff seconds",
+      "description": "Lockout seconds after reaching the max. Each new failure doubles this value (24h cap)."
+    }
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1738,5 +1738,83 @@
       "phoneLabel": "Teléfono de contacto:",
       "addressLabel": "Nuestra dirección:"
     }
+  },
+  "app-config-admin": {
+    "sidebarLink": "Configuraciones",
+    "title": "Configuraciones del sistema",
+    "description": "Ajusta valores operativos sin necesidad de redesplegar. Los cambios se aplican al próximo request.",
+    "groups": {
+      "booking": "Reservas y carrito",
+      "payoutsAndCredits": "Pagos a proveedores y créditos",
+      "gallery": "Galería de tours",
+      "kybDocs": "KYB (documentos de proveedores)",
+      "authProtection": "Protección de autenticación"
+    },
+    "table": {
+      "setting": "Configuración",
+      "value": "Valor actual",
+      "actions": "Acciones",
+      "loading": "Cargando…",
+      "errorLoading": "No se pudo cargar",
+      "save": "Guardar",
+      "saving": "Guardando…",
+      "reset": "Revertir",
+      "on": "Activo",
+      "off": "Inactivo"
+    },
+    "swal": {
+      "savedTitle": "Configuración guardada",
+      "savedText": "Se aplicará al próximo request ({{ key }}).",
+      "errorTitle": "No se pudo guardar",
+      "errorText": "Error guardando {{ key }}: {{ message }}"
+    },
+    "holdMinutes": {
+      "label": "Minutos del hold del carrito",
+      "description": "Tiempo que el turista tiene para completar el pago antes de que la reserva TEMPORAL expire."
+    },
+    "payoutBufferDays": {
+      "label": "Días de buffer para payout",
+      "description": "Días desde la fecha de la reserva hasta que el pago al proveedor queda disponible."
+    },
+    "creditExpirationMonths": {
+      "label": "Meses de vigencia de crédito",
+      "description": "Duración del crédito emitido tras una cancelación antes de que expire."
+    },
+    "galleryMaxSizeMb": {
+      "label": "Tamaño máximo por imagen (MB)",
+      "description": "Imágenes que superan este tamaño son rechazadas al sincronizar la galería."
+    },
+    "galleryMinWidthPx": {
+      "label": "Ancho mínimo de imagen (px)",
+      "description": "Ancho mínimo aceptado para asegurar calidad visual."
+    },
+    "galleryMaxImagesPerTour": {
+      "label": "Máximo de imágenes por tour",
+      "description": "Cantidad total de imágenes que un tour puede tener en su galería."
+    },
+    "kybRequireMandatoryDocs": {
+      "label": "Exigir documentos KYB obligatorios",
+      "description": "Cuando está activo, la solicitud del proveedor se rechaza si faltan documentos marcados como obligatorios."
+    },
+    "authRateLimitEnabled": {
+      "label": "Rate limit en /auth",
+      "description": "Activa el bloqueo temporal de una IP que hace demasiados requests a los endpoints de autenticación."
+    },
+    "authRateLimitPerMinute": {
+      "label": "Requests permitidos por IP por minuto",
+      "description": "Umbral del rate limiter. Al excederlo se devuelve HTTP 429."
+    },
+    "authLockoutEnabled": {
+      "label": "Bloqueo de cuenta tras intentos fallidos",
+      "description": "Activa el bloqueo temporal de la cuenta tras N intentos de login fallidos consecutivos."
+    },
+    "authLockoutMaxAttempts": {
+      "label": "Intentos fallidos permitidos",
+      "description": "Cantidad de intentos fallidos antes de aplicar el lockout."
+    },
+    "authLockoutBaseBackoffSeconds": {
+      "label": "Backoff base en segundos",
+      "description": "Segundos de bloqueo tras alcanzar el máximo. Cada nuevo fallo duplica este valor (cap 24h)."
+    }
   }
 }

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1738,5 +1738,83 @@
       "phoneLabel": "Telefone de contato:",
       "addressLabel": "Nosso endereço:"
     }
+  },
+  "app-config-admin": {
+    "sidebarLink": "Configurações",
+    "title": "Configurações do sistema",
+    "description": "Ajuste valores operacionais sem precisar de redeploy. As alterações se aplicam na próxima requisição.",
+    "groups": {
+      "booking": "Reservas e carrinho",
+      "payoutsAndCredits": "Pagamentos a fornecedores e créditos",
+      "gallery": "Galeria de passeios",
+      "kybDocs": "KYB (documentos do fornecedor)",
+      "authProtection": "Proteção de autenticação"
+    },
+    "table": {
+      "setting": "Configuração",
+      "value": "Valor atual",
+      "actions": "Ações",
+      "loading": "Carregando…",
+      "errorLoading": "Falha ao carregar",
+      "save": "Salvar",
+      "saving": "Salvando…",
+      "reset": "Reverter",
+      "on": "Ativo",
+      "off": "Inativo"
+    },
+    "swal": {
+      "savedTitle": "Configuração salva",
+      "savedText": "Será aplicada na próxima requisição ({{ key }}).",
+      "errorTitle": "Não foi possível salvar",
+      "errorText": "Erro salvando {{ key }}: {{ message }}"
+    },
+    "holdMinutes": {
+      "label": "Minutos do hold do carrinho",
+      "description": "Tempo que o turista tem para completar o pagamento antes que a reserva TEMPORAL expire."
+    },
+    "payoutBufferDays": {
+      "label": "Dias de buffer para o payout",
+      "description": "Dias entre a data da reserva e quando o pagamento ao fornecedor fica disponível."
+    },
+    "creditExpirationMonths": {
+      "label": "Meses de validade do crédito",
+      "description": "Duração do crédito emitido após um cancelamento antes de expirar."
+    },
+    "galleryMaxSizeMb": {
+      "label": "Tamanho máximo por imagem (MB)",
+      "description": "Imagens maiores que este tamanho são rejeitadas ao sincronizar a galeria."
+    },
+    "galleryMinWidthPx": {
+      "label": "Largura mínima da imagem (px)",
+      "description": "Largura mínima aceita para garantir qualidade visual."
+    },
+    "galleryMaxImagesPerTour": {
+      "label": "Máximo de imagens por passeio",
+      "description": "Total de imagens que um passeio pode ter na sua galeria."
+    },
+    "kybRequireMandatoryDocs": {
+      "label": "Exigir documentos KYB obrigatórios",
+      "description": "Quando ativo, o envio da solicitação do fornecedor é rejeitado se faltarem documentos obrigatórios."
+    },
+    "authRateLimitEnabled": {
+      "label": "Rate limit em /auth",
+      "description": "Ativa o bloqueio temporário de um IP que faz requisições demais nos endpoints de autenticação."
+    },
+    "authRateLimitPerMinute": {
+      "label": "Requisições permitidas por IP por minuto",
+      "description": "Limiar do rate limiter. Ao exceder retorna HTTP 429."
+    },
+    "authLockoutEnabled": {
+      "label": "Bloqueio de conta após falhas",
+      "description": "Ativa o bloqueio temporário da conta após N tentativas consecutivas de login com falha."
+    },
+    "authLockoutMaxAttempts": {
+      "label": "Tentativas com falha permitidas",
+      "description": "Quantidade de tentativas com falha antes de aplicar o lockout."
+    },
+    "authLockoutBaseBackoffSeconds": {
+      "label": "Backoff base em segundos",
+      "description": "Segundos de bloqueio ao atingir o máximo. Cada nova falha dobra este valor (cap 24h)."
+    }
   }
 }

--- a/src/app/pages/admin/app-config-admin/app-config-admin.component.html
+++ b/src/app/pages/admin/app-config-admin/app-config-admin.component.html
@@ -1,0 +1,95 @@
+<div class="app-config-admin">
+  <div class="row mb-4">
+    <div class="col-12">
+      <h3>{{ 'app-config-admin.title' | translate }}</h3>
+      <p class="text-muted">{{ 'app-config-admin.description' | translate }}</p>
+    </div>
+  </div>
+
+  <div class="row" *ngFor="let group of groups">
+    <div class="col-12">
+      <div class="card mb-4">
+        <div class="card-header">
+          <h5 class="mb-0">{{ group.labelKey | translate }}</h5>
+        </div>
+        <div class="card-body p-0">
+          <table class="table mb-0 align-middle">
+            <thead class="table-light">
+              <tr>
+                <th style="width: 40%;">{{ 'app-config-admin.table.setting' | translate }}</th>
+                <th style="width: 30%;">{{ 'app-config-admin.table.value' | translate }}</th>
+                <th style="width: 30%;">{{ 'app-config-admin.table.actions' | translate }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let item of group.items">
+                <td>
+                  <div class="fw-medium">{{ item.labelKey | translate }}</div>
+                  <div class="text-muted small">{{ item.descriptionKey | translate }}</div>
+                  <code class="small">{{ item.key }}</code>
+                </td>
+                <td>
+                  <ng-container *ngIf="item.loading">
+                    <span class="text-muted">{{ 'app-config-admin.table.loading' | translate }}</span>
+                  </ng-container>
+
+                  <ng-container *ngIf="!item.loading && item.errorLoading">
+                    <span class="text-danger small">{{ 'app-config-admin.table.errorLoading' | translate }}</span>
+                  </ng-container>
+
+                  <ng-container *ngIf="!item.loading && !item.errorLoading">
+                    <input
+                      *ngIf="item.type === 'number'"
+                      type="number"
+                      min="0"
+                      class="form-control"
+                      [(ngModel)]="item.currentValue"
+                      [name]="item.key"
+                    />
+
+                    <div *ngIf="item.type === 'boolean'" class="form-check form-switch">
+                      <input
+                        type="checkbox"
+                        class="form-check-input"
+                        [checked]="item.currentValue === 1"
+                        (change)="toggleBoolean(item)"
+                        [id]="'toggle-' + item.key"
+                      />
+                      <label class="form-check-label" [for]="'toggle-' + item.key">
+                        <span *ngIf="item.currentValue === 1" class="text-success fw-medium">
+                          {{ 'app-config-admin.table.on' | translate }}
+                        </span>
+                        <span *ngIf="item.currentValue !== 1" class="text-muted">
+                          {{ 'app-config-admin.table.off' | translate }}
+                        </span>
+                      </label>
+                    </div>
+                  </ng-container>
+                </td>
+                <td>
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-primary me-2"
+                    [disabled]="!isDirty(item) || item.saving || item.loading || item.errorLoading"
+                    (click)="save(item)"
+                  >
+                    <span *ngIf="!item.saving">{{ 'app-config-admin.table.save' | translate }}</span>
+                    <span *ngIf="item.saving">{{ 'app-config-admin.table.saving' | translate }}</span>
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-outline-secondary"
+                    [disabled]="!isDirty(item) || item.saving"
+                    (click)="resetItem(item)"
+                  >
+                    {{ 'app-config-admin.table.reset' | translate }}
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/admin/app-config-admin/app-config-admin.component.scss
+++ b/src/app/pages/admin/app-config-admin/app-config-admin.component.scss
@@ -1,0 +1,18 @@
+.app-config-admin {
+  .card-header {
+    background-color: #f8f9fa;
+  }
+
+  .table {
+    code {
+      color: #6c757d;
+      background: #f1f3f5;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+
+    .form-check-input {
+      cursor: pointer;
+    }
+  }
+}

--- a/src/app/pages/admin/app-config-admin/app-config-admin.component.ts
+++ b/src/app/pages/admin/app-config-admin/app-config-admin.component.ts
@@ -1,0 +1,265 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { forkJoin, of } from 'rxjs';
+import { catchError, finalize, map } from 'rxjs/operators';
+import Swal from 'sweetalert2';
+import { AppConfigService, RawConfigValue } from '../../../shared/services/app-config.service';
+
+type ConfigInputType = 'number' | 'boolean';
+
+/**
+ * Grupo visual para agrupar configs relacionadas en la UI. Puramente
+ * cosmetico; no tiene efecto en el backend.
+ */
+interface ConfigGroup {
+  labelKey: string;
+  items: ConfigItem[];
+}
+
+/**
+ * Metadata de una config configurable via este panel. La lista completa se
+ * define abajo en CONFIG_GROUPS. Nombre y descripcion se resuelven via
+ * ngx-translate.
+ */
+interface ConfigItem {
+  key: string;
+  labelKey: string;
+  descriptionKey: string;
+  type: ConfigInputType;
+  currentValue: number | null;
+  originalValue: number | null;
+  loading: boolean;
+  saving: boolean;
+  errorLoading: boolean;
+}
+
+/**
+ * Lista fija de configuraciones escalares/booleanas que este panel puede editar.
+ * Se excluye CANCELLATION_POLICY porque su formato es JSON i18n complejo y
+ * merece un editor dedicado (v2).
+ */
+const CONFIG_GROUPS: ConfigGroup[] = [
+  {
+    labelKey: 'app-config-admin.groups.booking',
+    items: [
+      {
+        key: 'HOLD_MINUTES',
+        labelKey: 'app-config-admin.holdMinutes.label',
+        descriptionKey: 'app-config-admin.holdMinutes.description',
+        type: 'number',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      }
+    ]
+  },
+  {
+    labelKey: 'app-config-admin.groups.payoutsAndCredits',
+    items: [
+      {
+        key: 'PAYOUT_BUFFER_DAYS',
+        labelKey: 'app-config-admin.payoutBufferDays.label',
+        descriptionKey: 'app-config-admin.payoutBufferDays.description',
+        type: 'number',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      },
+      {
+        key: 'CREDIT_EXPIRATION_MONTHS',
+        labelKey: 'app-config-admin.creditExpirationMonths.label',
+        descriptionKey: 'app-config-admin.creditExpirationMonths.description',
+        type: 'number',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      }
+    ]
+  },
+  {
+    labelKey: 'app-config-admin.groups.gallery',
+    items: [
+      {
+        key: 'GALLERY_MAX_SIZE_MB',
+        labelKey: 'app-config-admin.galleryMaxSizeMb.label',
+        descriptionKey: 'app-config-admin.galleryMaxSizeMb.description',
+        type: 'number',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      },
+      {
+        key: 'GALLERY_MIN_WIDTH_PX',
+        labelKey: 'app-config-admin.galleryMinWidthPx.label',
+        descriptionKey: 'app-config-admin.galleryMinWidthPx.description',
+        type: 'number',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      },
+      {
+        key: 'GALLERY_MAX_IMAGES_PER_TOUR',
+        labelKey: 'app-config-admin.galleryMaxImagesPerTour.label',
+        descriptionKey: 'app-config-admin.galleryMaxImagesPerTour.description',
+        type: 'number',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      }
+    ]
+  },
+  {
+    labelKey: 'app-config-admin.groups.kybDocs',
+    items: [
+      {
+        key: 'KYB_REQUIRE_MANDATORY_DOCS',
+        labelKey: 'app-config-admin.kybRequireMandatoryDocs.label',
+        descriptionKey: 'app-config-admin.kybRequireMandatoryDocs.description',
+        type: 'boolean',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      }
+    ]
+  },
+  {
+    labelKey: 'app-config-admin.groups.authProtection',
+    items: [
+      {
+        key: 'AUTH_RATE_LIMIT_ENABLED',
+        labelKey: 'app-config-admin.authRateLimitEnabled.label',
+        descriptionKey: 'app-config-admin.authRateLimitEnabled.description',
+        type: 'boolean',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      },
+      {
+        key: 'AUTH_RATE_LIMIT_PER_MINUTE',
+        labelKey: 'app-config-admin.authRateLimitPerMinute.label',
+        descriptionKey: 'app-config-admin.authRateLimitPerMinute.description',
+        type: 'number',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      },
+      {
+        key: 'AUTH_LOCKOUT_ENABLED',
+        labelKey: 'app-config-admin.authLockoutEnabled.label',
+        descriptionKey: 'app-config-admin.authLockoutEnabled.description',
+        type: 'boolean',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      },
+      {
+        key: 'AUTH_LOCKOUT_MAX_ATTEMPTS',
+        labelKey: 'app-config-admin.authLockoutMaxAttempts.label',
+        descriptionKey: 'app-config-admin.authLockoutMaxAttempts.description',
+        type: 'number',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      },
+      {
+        key: 'AUTH_LOCKOUT_BASE_BACKOFF_SECONDS',
+        labelKey: 'app-config-admin.authLockoutBaseBackoffSeconds.label',
+        descriptionKey: 'app-config-admin.authLockoutBaseBackoffSeconds.description',
+        type: 'number',
+        currentValue: null, originalValue: null, loading: true, saving: false, errorLoading: false
+      }
+    ]
+  }
+];
+
+@Component({
+  selector: 'app-app-config-admin',
+  templateUrl: './app-config-admin.component.html',
+  styleUrls: ['./app-config-admin.component.scss'],
+  standalone: true,
+  imports: [CommonModule, FormsModule, TranslateModule]
+})
+export class AppConfigAdminComponent implements OnInit {
+
+  groups: ConfigGroup[] = JSON.parse(JSON.stringify(CONFIG_GROUPS));
+
+  constructor(
+    private appConfigService: AppConfigService,
+    private translate: TranslateService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadAllConfigs();
+  }
+
+  /**
+   * Carga en paralelo el valor actual de cada config declarada.
+   * Los errores individuales se marcan por-fila sin bloquear las demas
+   * (util si por alguna razon una key todavia no fue seeded).
+   */
+  private loadAllConfigs(): void {
+    const requests = this.allItems().map(item =>
+      this.appConfigService.getConfig(item.key).pipe(
+        map((raw: RawConfigValue) => ({ item, raw, ok: true as const })),
+        catchError(() => of({ item, raw: null, ok: false as const }))
+      )
+    );
+
+    forkJoin(requests).subscribe(results => {
+      results.forEach(({ item, raw, ok }) => {
+        item.loading = false;
+        if (!ok || !raw) {
+          item.errorLoading = true;
+          return;
+        }
+        const extracted = this.extractScalar(raw);
+        item.currentValue = extracted;
+        item.originalValue = extracted;
+      });
+    });
+  }
+
+  private allItems(): ConfigItem[] {
+    return this.groups.flatMap(g => g.items);
+  }
+
+  /**
+   * Extrae el numero del JSON crudo. El backend usa la convencion
+   * { "value": N } para escalares. Si el formato es distinto retornamos
+   * null y la fila se marca como error de lectura.
+   */
+  private extractScalar(raw: RawConfigValue): number | null {
+    const v = (raw as { value?: unknown }).value;
+    if (typeof v === 'number') return v;
+    if (typeof v === 'string') {
+      const parsed = Number(v);
+      return Number.isFinite(parsed) ? parsed : null;
+    }
+    return null;
+  }
+
+  isDirty(item: ConfigItem): boolean {
+    return item.currentValue !== item.originalValue;
+  }
+
+  save(item: ConfigItem): void {
+    if (item.saving || !this.isDirty(item) || item.currentValue === null) return;
+    item.saving = true;
+
+    this.appConfigService.updateConfig(item.key, { value: item.currentValue })
+      .pipe(finalize(() => (item.saving = false)))
+      .subscribe({
+        next: () => {
+          item.originalValue = item.currentValue;
+          Swal.fire({
+            icon: 'success',
+            title: this.translate.instant('app-config-admin.swal.savedTitle'),
+            text: this.translate.instant('app-config-admin.swal.savedText', { key: item.key }),
+            timer: 2000,
+            showConfirmButton: false
+          });
+        },
+        error: (err) => {
+          const message = err?.error?.error ?? err?.message ?? 'error';
+          Swal.fire({
+            icon: 'error',
+            title: this.translate.instant('app-config-admin.swal.errorTitle'),
+            text: this.translate.instant('app-config-admin.swal.errorText', { key: item.key, message })
+          });
+        }
+      });
+  }
+
+  resetItem(item: ConfigItem): void {
+    item.currentValue = item.originalValue;
+  }
+
+  /**
+   * Toggle 0/1 para inputs de tipo boolean; el modelo del backend usa
+   * enteros (0=OFF, 1=ON) porque asi convive con el metodo AppConfigService.getInt.
+   */
+  toggleBoolean(item: ConfigItem): void {
+    if (item.currentValue === null) return;
+    item.currentValue = item.currentValue === 1 ? 0 : 1;
+  }
+}

--- a/src/app/pages/admin/dashboard/dashboard.component.html
+++ b/src/app/pages/admin/dashboard/dashboard.component.html
@@ -51,6 +51,10 @@
             <a class="d-flex align-items-center" style="cursor: pointer;" (click)="toggleProviderPayments()"><i
                 class="isax isax-wallet-2"></i> Ordenes de pago</a>
           </li>
+          <li>
+            <a class="d-flex align-items-center" style="cursor: pointer;" (click)="toggleAppConfig()"><i
+                class="isax isax-setting-2"></i> {{ 'app-config-admin.sidebarLink' | translate }}</a>
+          </li>
         </ul>
       </div>
     </div>
@@ -60,7 +64,7 @@
   <!-- Contenido principal -->
   <div class="col-xl-9 col-lg-8">
     <div class="dashboard-container">
-      <div *ngIf="!mostrarSolicitudes && !mostrarTourList && !mostrarMaritimeReports && !mostrarProviderPayments">
+      <div *ngIf="!mostrarSolicitudes && !mostrarTourList && !mostrarMaritimeReports && !mostrarProviderPayments && !mostrarAppConfig">
         <div class="row">
           <div class="col-12">
             <h3>Dashboard de Administración</h3>
@@ -182,6 +186,13 @@
       <div *ngIf="mostrarProviderPayments" class="row mt-3">
         <div class="col-12">
           <app-provider-payments></app-provider-payments>
+        </div>
+      </div>
+
+      <!-- Configuraciones del sistema (FE-04) -->
+      <div *ngIf="mostrarAppConfig" class="row mt-3">
+        <div class="col-12">
+          <app-app-config-admin></app-app-config-admin>
         </div>
       </div>
     </div>

--- a/src/app/pages/admin/dashboard/dashboard.component.ts
+++ b/src/app/pages/admin/dashboard/dashboard.component.ts
@@ -27,6 +27,7 @@ export class DashboardComponent implements OnInit {
   mostrarTourList: boolean = false;
   mostrarMaritimeReports: boolean = false;
   mostrarProviderPayments: boolean = false;
+  mostrarAppConfig: boolean = false;
 
   // Referencia al enum para usar en el template
   readonly StatusEnum = RequestsProvidersStatus;
@@ -51,6 +52,7 @@ export class DashboardComponent implements OnInit {
     this.mostrarSolicitudes = false;
     this.mostrarMaritimeReports = false;
     this.mostrarProviderPayments = false;
+    this.mostrarAppConfig = false;
     this.mostrarTourList = !this.mostrarTourList;
   }
 
@@ -59,6 +61,7 @@ export class DashboardComponent implements OnInit {
     this.mostrarTourList = false;
     this.mostrarMaritimeReports = false;
     this.mostrarProviderPayments = false;
+    this.mostrarAppConfig = false;
     this.mostrarSolicitudes = !this.mostrarSolicitudes;
 
     if (this.mostrarSolicitudes) {
@@ -70,6 +73,7 @@ export class DashboardComponent implements OnInit {
     this.mostrarTourList = false;
     this.mostrarSolicitudes = false;
     this.mostrarProviderPayments = false;
+    this.mostrarAppConfig = false;
     this.mostrarMaritimeReports = !this.mostrarMaritimeReports;
   }
 
@@ -77,7 +81,16 @@ export class DashboardComponent implements OnInit {
     this.mostrarTourList = false;
     this.mostrarSolicitudes = false;
     this.mostrarMaritimeReports = false;
+    this.mostrarAppConfig = false;
     this.mostrarProviderPayments = !this.mostrarProviderPayments;
+  }
+
+  toggleAppConfig(): void {
+    this.mostrarTourList = false;
+    this.mostrarSolicitudes = false;
+    this.mostrarMaritimeReports = false;
+    this.mostrarProviderPayments = false;
+    this.mostrarAppConfig = !this.mostrarAppConfig;
   }
 
   toggleDashboard(): void {
@@ -85,6 +98,7 @@ export class DashboardComponent implements OnInit {
     this.mostrarSolicitudes = false;
     this.mostrarMaritimeReports = false;
     this.mostrarProviderPayments = false;
+    this.mostrarAppConfig = false;
   }
 
   cargarSolicitudes(): void {

--- a/src/app/pages/admin/dashboard/dashboard.module.ts
+++ b/src/app/pages/admin/dashboard/dashboard.module.ts
@@ -6,6 +6,7 @@ import { SharedModule } from '../../../shared/shared-module';
 import { TourAdminModule } from '../tour-admin/tour-admin.module';
 import { MaritimeActivityReportsComponent } from '../../maritime-activity-reports/maritime-activity-reports.component';
 import { ProviderPaymentsModule } from '../../providers/provider-payments/provider-payments.module';
+import { AppConfigAdminComponent } from '../app-config-admin/app-config-admin.component';
 
 @NgModule({
   declarations: [
@@ -17,7 +18,8 @@ import { ProviderPaymentsModule } from '../../providers/provider-payments/provid
     SharedModule,
     TourAdminModule,
     MaritimeActivityReportsComponent,
-    ProviderPaymentsModule
+    ProviderPaymentsModule,
+    AppConfigAdminComponent
   ]
 })
-export class DashboardModule { } 
+export class DashboardModule { }

--- a/src/app/shared/services/app-config.service.ts
+++ b/src/app/shared/services/app-config.service.ts
@@ -1,0 +1,50 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+
+/**
+ * Formato del value que persiste el backend en la columna JSONB config_value.
+ * Para las claves escalares (numeros y feature flags 0/1) siempre usa el
+ * patron { "value": N }. Para CANCELLATION_POLICY es un JSON estructurado
+ * distinto (no atendido en este panel).
+ */
+export interface AppConfigValue {
+  value: number;
+}
+
+/**
+ * Respuesta cruda del backend para GET /config/{key}.
+ * El controller AppConfigController devuelve el Map<String,Object> almacenado
+ * directamente; para claves escalares eso es { "value": N }.
+ */
+export type RawConfigValue = Record<string, unknown>;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppConfigService {
+  private readonly apiUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Obtiene el valor crudo de una configuracion por su clave.
+   * @throws 404 si la clave no existe en la BD (fuera del enum ConfigKeyEnum).
+   */
+  getConfig(configKey: string): Observable<RawConfigValue> {
+    return this.http.get<RawConfigValue>(`${this.apiUrl}/config/${configKey}`);
+  }
+
+  /**
+   * Upsert de una configuracion por clave. Solo ADMIN.
+   * El backend espera { value: {...}, description?: string }.
+   * Retorna el AppConfig completo guardado (id, config_key, config_value, ...).
+   */
+  updateConfig(configKey: string, value: AppConfigValue, description?: string): Observable<unknown> {
+    return this.http.put(`${this.apiUrl}/config/${configKey}`, {
+      value,
+      description
+    });
+  }
+}


### PR DESCRIPTION
Agrega un panel visible solo para el rol ADMIN para editar en caliente los 12 flags/settings de la tabla app_config, sin redeploy ni scripts SQL.

- Nuevo AppConfigAdminComponent (standalone) con 5 grupos: booking, payoutsAndCredits, gallery, kybDocs, authProtection.
- Nuevo AppConfigService (GET/PUT /config/{key}).
- Carga en paralelo con forkJoin + catchError por item.
- Save/reset por item, edición inline con inputs numéricos y toggles booleanos.
- Integrado al DashboardComponent siguiendo el patrón toggleX existente (nuevo mostrarAppConfig + toggleAppConfig, link en sidebar).
- i18n completo en es/en/pt.

Excluye CANCELLATION_POLICY (requiere editor JSON dedicado, va en un item aparte).