### PR TITLE
feat(gallery): FE-03 validador pre-upload de galería

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1815,5 +1815,22 @@
       "label": "Base backoff seconds",
       "description": "Lockout seconds after reaching the max. Each new failure doubles this value (24h cap)."
     }
+  },
+  "tour-gallery": {
+    "uploadTitle": "Upload gallery images",
+    "limitsHint": "JPEG, PNG or WebP · Max {{maxSize}} MB per image · Landscape orientation · Minimum width {{minWidth}} px · Up to {{maxImages}} images total",
+    "currentCount": "{{current}} of {{max}} images in the gallery",
+    "issueCodes": {
+      "TOO_LARGE": "Exceeds the maximum allowed size",
+      "INVALID_FORMAT": "Unsupported format (use JPEG, PNG or WebP)",
+      "NOT_LANDSCAPE": "Must be landscape (width ≥ height)",
+      "WIDTH_TOO_SMALL": "Width below the minimum allowed",
+      "TOO_MANY_IMAGES": "Exceeds the maximum number of images per tour"
+    },
+    "errors": {
+      "validationTitle": "Some images do not meet the rules",
+      "generic": "An error occurred, please try again",
+      "genericTitle": "Could not save the gallery"
+    }
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1816,5 +1816,22 @@
       "label": "Backoff base en segundos",
       "description": "Segundos de bloqueo tras alcanzar el máximo. Cada nuevo fallo duplica este valor (cap 24h)."
     }
+  },
+  "tour-gallery": {
+    "uploadTitle": "Subir imágenes de la galería",
+    "limitsHint": "JPEG, PNG o WebP · Máx {{maxSize}} MB por imagen · Orientación horizontal · Ancho mínimo {{minWidth}} px · Hasta {{maxImages}} imágenes en total",
+    "currentCount": "{{current}} de {{max}} imágenes en la galería",
+    "issueCodes": {
+      "TOO_LARGE": "Excede el tamaño máximo permitido",
+      "INVALID_FORMAT": "Formato no soportado (usa JPEG, PNG o WebP)",
+      "NOT_LANDSCAPE": "Debe ser horizontal (ancho ≥ alto)",
+      "WIDTH_TOO_SMALL": "Ancho por debajo del mínimo permitido",
+      "TOO_MANY_IMAGES": "Excede el número máximo de imágenes por tour"
+    },
+    "errors": {
+      "validationTitle": "Algunas imágenes no cumplen las reglas",
+      "generic": "Ha ocurrido un error, por favor intente de nuevo",
+      "genericTitle": "No se pudo guardar la galería"
+    }
   }
 }

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1816,5 +1816,22 @@
       "label": "Backoff base em segundos",
       "description": "Segundos de bloqueio ao atingir o máximo. Cada nova falha dobra este valor (cap 24h)."
     }
+  },
+  "tour-gallery": {
+    "uploadTitle": "Enviar imagens da galeria",
+    "limitsHint": "JPEG, PNG ou WebP · Máx {{maxSize}} MB por imagem · Orientação horizontal · Largura mínima {{minWidth}} px · Até {{maxImages}} imagens no total",
+    "currentCount": "{{current}} de {{max}} imagens na galeria",
+    "issueCodes": {
+      "TOO_LARGE": "Excede o tamanho máximo permitido",
+      "INVALID_FORMAT": "Formato não suportado (use JPEG, PNG ou WebP)",
+      "NOT_LANDSCAPE": "Deve ser horizontal (largura ≥ altura)",
+      "WIDTH_TOO_SMALL": "Largura abaixo do mínimo permitido",
+      "TOO_MANY_IMAGES": "Excede o número máximo de imagens por passeio"
+    },
+    "errors": {
+      "validationTitle": "Algumas imagens não atendem às regras",
+      "generic": "Ocorreu um erro, tente novamente",
+      "genericTitle": "Não foi possível salvar a galeria"
+    }
   }
 }

--- a/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.html
+++ b/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.html
@@ -41,9 +41,14 @@
               <div
                 class="file-upload drag-file w-100 d-flex align-items-center justify-content-center flex-column mb-2">
                 <span class="upload-img d-block mb-2"><i class="isax isax-document-upload fs-24"></i></span>
-                <h6 class="mb-1">Upload Gallery Images</h6>
-                <p class="mb-0">Image size should below 5MB</p>
-                <input type="file" accept="image/*" maxFileSize="50000" (change)="onFileSelected($event)" multiple>
+                <h6 class="mb-1">{{ 'tour-gallery.uploadTitle' | translate }}</h6>
+                <p class="mb-0 text-muted small">
+                  {{ 'tour-gallery.limitsHint' | translate: { maxSize: limits.maxSizeMb, minWidth: limits.minWidthPx, maxImages: limits.maxImagesPerTour } }}
+                </p>
+                <p class="mb-0 text-muted small">
+                  {{ 'tour-gallery.currentCount' | translate: { current: galleries.length, max: limits.maxImagesPerTour } }}
+                </p>
+                <input type="file" accept="image/jpeg,image/png,image/webp" (change)="onFileSelected($event)" multiple>
               </div>
               <div *ngIf="this.galleries.length > 0">
 

--- a/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.ts
+++ b/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.ts
@@ -1,11 +1,40 @@
 import { Component, OnInit } from "@angular/core";
 import { FormArray, FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { ActivatedRoute, Router } from "@angular/router";
-import { TourService } from "../tour.service";
+import { HttpErrorResponse } from "@angular/common/http";
 import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
-import { Gallery, Tour } from "../../../../shared/dto/tour-response.dto";
 import { MatSnackBar } from "@angular/material/snack-bar";
+import { TranslateService } from "@ngx-translate/core";
+import { catchError, forkJoin, of } from "rxjs";
+import Swal from "sweetalert2";
+
+import { TourService } from "../tour.service";
+import { Gallery, Tour } from "../../../../shared/dto/tour-response.dto";
 import { I18nFieldService } from "../../../../shared/services/i18n-field.service";
+import {
+  AppConfigService,
+  RawConfigValue,
+} from "../../../../shared/services/app-config.service";
+
+interface GalleryLimits {
+  maxSizeMb: number;
+  minWidthPx: number;
+  maxImagesPerTour: number;
+}
+
+interface GalleryIssue {
+  fileName: string;
+  code: string;
+  message?: string;
+}
+
+const DEFAULT_LIMITS: GalleryLimits = {
+  maxSizeMb: 5,
+  minWidthPx: 800,
+  maxImagesPerTour: 7,
+};
+
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
 @Component({
   selector: "app-tour-gallery",
@@ -23,7 +52,7 @@ export class TourGalleryComponent implements OnInit {
   submitted: boolean = false;
   errorMessage: string = "";
 
-  MAX_FILE_SIZE_IN_MB: number = 5;
+  limits: GalleryLimits = { ...DEFAULT_LIMITS };
 
   constructor(
     private router: Router,
@@ -31,7 +60,9 @@ export class TourGalleryComponent implements OnInit {
     private route: ActivatedRoute,
     private tourService: TourService,
     private _snackBar: MatSnackBar,
-    private i18nService: I18nFieldService
+    private i18nService: I18nFieldService,
+    private appConfigService: AppConfigService,
+    private translate: TranslateService
   ) {
     this.tourId = +(this.route.snapshot.paramMap.get("id") || 0);
 
@@ -41,12 +72,47 @@ export class TourGalleryComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.loadLimits();
     this.getTour();
     this.getTourGalleries();
   }
 
   get galleries(): FormArray {
     return this.tourGalleryForm.get("galleries") as FormArray;
+  }
+
+  private loadLimits(): void {
+    forkJoin({
+      maxSizeMb: this.appConfigService.getConfig("GALLERY_MAX_SIZE_MB").pipe(
+        catchError(() => of(null))
+      ),
+      minWidthPx: this.appConfigService.getConfig("GALLERY_MIN_WIDTH_PX").pipe(
+        catchError(() => of(null))
+      ),
+      maxImagesPerTour: this.appConfigService
+        .getConfig("GALLERY_MAX_IMAGES_PER_TOUR")
+        .pipe(catchError(() => of(null))),
+    }).subscribe((values) => {
+      this.limits = {
+        maxSizeMb: this.readNumber(values.maxSizeMb, DEFAULT_LIMITS.maxSizeMb),
+        minWidthPx: this.readNumber(
+          values.minWidthPx,
+          DEFAULT_LIMITS.minWidthPx
+        ),
+        maxImagesPerTour: this.readNumber(
+          values.maxImagesPerTour,
+          DEFAULT_LIMITS.maxImagesPerTour
+        ),
+      };
+    });
+  }
+
+  private readNumber(raw: RawConfigValue | null, fallback: number): number {
+    const value = raw?.["value"];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    return fallback;
   }
 
   newGallery(): FormGroup {
@@ -137,19 +203,20 @@ export class TourGalleryComponent implements OnInit {
                 duration: 5000,
               });
             } else {
-              this.errorMessage =
-                "Ha ocurrido un error, por favor intente de nuevo";
+              this.errorMessage = this.translate.instant(
+                "tour-gallery.errors.generic"
+              );
             }
           },
-          error: (err) => {
+          error: (err: HttpErrorResponse) => {
             this.loading = false;
             console.error("Error saving tour gallery.");
             console.error(err);
-
-            this.errorMessage =
-              "Ha ocurrido un error, por favor intente de nuevo";
+            this.handleBackendError(err);
           },
         });
+    } else {
+      this.loading = false;
     }
   }
 
@@ -172,38 +239,179 @@ export class TourGalleryComponent implements OnInit {
   }
 
   onFileSelected(event: any): void {
-    const files: FileList = event.target.files;
-
-    if (files) {
-      for (let i = 0; i < files.length; i++) {
-        const file = files.item(i);
-        const fileSize = file && file.size ? file.size / 1024 / 1024 : 0;
-
-        if (file) {
-          if (fileSize <= this.MAX_FILE_SIZE_IN_MB) {
-            // Create a FileReader to read the file as Data URL for preview
-            const reader = new FileReader();
-            reader.onload = (e: any) => {
-              this.addGallery();
-
-              this.galleries.at(this.galleries.length - 1).patchValue({
-                imageUrl: e.target.result,
-                description: file.name,
-                orderIndex: this.galleries.length,
-                file: file,
-              });
-
-              this.galleries.markAsDirty();
-            };
-            reader.readAsDataURL(file);
-          } else {
-            this._snackBar.open(`Image: ${file.name} is too large`, "", {
-              duration: 5000,
-            });
-          }
-        }
-      }
+    const input = event.target as HTMLInputElement;
+    const files: FileList | null = input.files;
+    if (!files || files.length === 0) {
+      return;
     }
+
+    const filesArray = Array.from(files);
+    const rejectedIssues: GalleryIssue[] = [];
+
+    const remainingSlots = Math.max(
+      0,
+      this.limits.maxImagesPerTour - this.galleries.length
+    );
+
+    const filesToInspect = filesArray.slice(0, remainingSlots);
+    const filesOverflow = filesArray.slice(remainingSlots);
+    filesOverflow.forEach((file) =>
+      rejectedIssues.push({ fileName: file.name, code: "TOO_MANY_IMAGES" })
+    );
+
+    const asyncCandidates: File[] = [];
+    filesToInspect.forEach((file) => {
+      const syncIssue = this.validateSyncRules(file);
+      if (syncIssue) {
+        rejectedIssues.push(syncIssue);
+      } else {
+        asyncCandidates.push(file);
+      }
+    });
+
+    const finish = () => {
+      if (rejectedIssues.length > 0) {
+        this.showIssuesModal(rejectedIssues);
+      }
+      input.value = "";
+    };
+
+    if (asyncCandidates.length === 0) {
+      finish();
+      return;
+    }
+
+    Promise.all(
+      asyncCandidates.map((file) => this.validateDimensions(file))
+    ).then((results) => {
+      results.forEach((result) => {
+        if (result.issue) {
+          rejectedIssues.push(result.issue);
+        } else {
+          this.attachFileToForm(result.file);
+        }
+      });
+      finish();
+    });
+  }
+
+  private validateSyncRules(file: File): GalleryIssue | null {
+    if (!ALLOWED_MIME_TYPES.includes(file.type)) {
+      return { fileName: file.name, code: "INVALID_FORMAT" };
+    }
+    const sizeMb = file.size / 1024 / 1024;
+    if (sizeMb > this.limits.maxSizeMb) {
+      return { fileName: file.name, code: "TOO_LARGE" };
+    }
+    return null;
+  }
+
+  private validateDimensions(
+    file: File
+  ): Promise<{ file: File; issue: GalleryIssue | null; dataUrl?: string }> {
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.onload = (e: any) => {
+        const dataUrl: string = e.target.result;
+        const image = new Image();
+        image.onload = () => {
+          const { width, height } = image;
+          if (width < height) {
+            resolve({
+              file,
+              issue: { fileName: file.name, code: "NOT_LANDSCAPE" },
+            });
+            return;
+          }
+          if (width < this.limits.minWidthPx) {
+            resolve({
+              file,
+              issue: { fileName: file.name, code: "WIDTH_TOO_SMALL" },
+            });
+            return;
+          }
+          resolve({ file, issue: null, dataUrl });
+        };
+        image.onerror = () => {
+          resolve({
+            file,
+            issue: { fileName: file.name, code: "INVALID_FORMAT" },
+          });
+        };
+        image.src = dataUrl;
+      };
+      reader.onerror = () => {
+        resolve({
+          file,
+          issue: { fileName: file.name, code: "INVALID_FORMAT" },
+        });
+      };
+      reader.readAsDataURL(file);
+    });
+  }
+
+  private attachFileToForm(file: File): void {
+    const reader = new FileReader();
+    reader.onload = (e: any) => {
+      this.addGallery();
+      this.galleries.at(this.galleries.length - 1).patchValue({
+        imageUrl: e.target.result,
+        description: file.name,
+        orderIndex: this.galleries.length,
+        file: file,
+      });
+      this.galleries.markAsDirty();
+    };
+    reader.readAsDataURL(file);
+  }
+
+  private showIssuesModal(issues: GalleryIssue[]): void {
+    const items = issues
+      .map((issue) => {
+        const codeLabel = this.translate.instant(
+          `tour-gallery.issueCodes.${issue.code}`
+        );
+        return `<li><strong>${this.escapeHtml(issue.fileName)}</strong> — ${this.escapeHtml(codeLabel)}</li>`;
+      })
+      .join("");
+
+    Swal.fire({
+      icon: "warning",
+      title: this.translate.instant("tour-gallery.errors.validationTitle"),
+      html: `<ul style="text-align:left; padding-left: 1.2rem;">${items}</ul>`,
+      confirmButtonText: "OK",
+    });
+  }
+
+  private handleBackendError(err: HttpErrorResponse): void {
+    const body = err.error;
+    if (body && Array.isArray(body.issues) && body.issues.length > 0) {
+      const issues: GalleryIssue[] = body.issues.map((raw: any) => ({
+        fileName: raw?.fileName || "",
+        code: raw?.code || "INVALID_FORMAT",
+        message: raw?.message,
+      }));
+      this.showIssuesModal(issues);
+      return;
+    }
+
+    this.errorMessage = this.translate.instant("tour-gallery.errors.generic");
+    Swal.fire({
+      icon: "error",
+      title: this.translate.instant("tour-gallery.errors.genericTitle"),
+      text: this.errorMessage,
+      confirmButtonText: "OK",
+    });
+  }
+
+  private escapeHtml(value: string): string {
+    if (!value) return "";
+    return value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
   }
 
   onDeleteImage(index: number): void {

--- a/src/app/pages/providers/tours/tour-gallery/tour-gallery.module.ts
+++ b/src/app/pages/providers/tours/tour-gallery/tour-gallery.module.ts
@@ -1,5 +1,7 @@
 import { NgModule } from "@angular/core";
 import { CommonModule } from "@angular/common";
+import { ReactiveFormsModule } from "@angular/forms";
+import { TranslateModule } from "@ngx-translate/core";
 
 import { TourGalleryRoutingModule } from "./tour-gallery-routing.module";
 import { SharedModule } from "../../../../shared/shared-module";
@@ -7,6 +9,12 @@ import { TourGalleryComponent } from "./tour-gallery.component";
 
 @NgModule({
   declarations: [TourGalleryComponent],
-  imports: [CommonModule, TourGalleryRoutingModule, SharedModule],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    TranslateModule,
+    TourGalleryRoutingModule,
+    SharedModule,
+  ],
 })
 export class TourGalleryModule {}


### PR DESCRIPTION
Aplica RN-013 en el uploader del PROVIDER antes de mandar al backend, evitando el round-trip cuando la imagen no cumple. El backend (BE-10) sigue validando como defensa en profundidad.

Validaciones pre-upload:
- Formato: JPEG, PNG o WebP
- Tamaño ≤ GALLERY_MAX_SIZE_MB
- Orientación landscape (ancho ≥ alto)
- Ancho ≥ GALLERY_MIN_WIDTH_PX
- Cuenta total (existentes + nuevas) ≤ GALLERY_MAX_IMAGES_PER_TOUR

Umbrales leídos de app_config vía AppConfigService al iniciar el componente, con fallback a los defaults (5 MB / 800 px / 7 imgs) si el GET falla. Coherente con el panel FE-04: si ADMIN sube un umbral, aplica inmediatamente sin re-deploy.

Errores acumulados por archivo y mostrados en un Swal con lista traducida. Si el backend devuelve 400 con issues[] (bypass del cliente o cambio server-side), también se despliegan en el mismo formato.

i18n completa en es/en/pt (tour-gallery.*).