### PR TITLE
feat(auth): FE-01 auto-refresh transparente en interceptor con mutex

### DIFF
--- a/src/app/auth/login-tourist/login-tourist.component.ts
+++ b/src/app/auth/login-tourist/login-tourist.component.ts
@@ -84,7 +84,7 @@ export class LoginTouristComponent implements OnInit, OnDestroy {
           this.loading = false;
 
           if (response && response.token) {
-            this.authService.setToken(response.token);
+            this.authService.setTokensFromResponse(response);
             this.authService.setUser({
               fullName: response.fullName,
               email: response.email,
@@ -137,7 +137,7 @@ export class LoginTouristComponent implements OnInit, OnDestroy {
       await this.authService.authenticateSocial(userData).subscribe({
         next: (response) => {
           console.log('Respuesta de Google:', response)
-          this.authService.setToken(response.token);
+          this.authService.setTokensFromResponse(response);
           this.authService.setUser({
             fullName: response.fullName,
             email: response.email,
@@ -181,7 +181,7 @@ export class LoginTouristComponent implements OnInit, OnDestroy {
         next: (response) => {
           // Navegar a la página principal
           console.log('Respuesta de Facebook:', response)
-          this.authService.setToken(response.token);
+          this.authService.setTokensFromResponse(response);
           this.authService.setUser({
             fullName: response.fullName,
             email: response.email,

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -6,40 +6,87 @@ import {
   HttpInterceptor,
   HttpErrorResponse
 } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { BehaviorSubject, Observable, throwError } from 'rxjs';
+import { catchError, filter, switchMap, take } from 'rxjs/operators';
 import { Router } from '@angular/router';
-import { AuthService } from '../services/auth.service';
+import { AuthService, RefreshResponseDto } from '../services/auth.service';
+
+const AUTH_ENDPOINTS_TO_SKIP = ['/auth/refresh', '/auth/logout', '/auth/authenticate', '/auth/register', '/auth/social-auth', '/auth/google-auth', '/auth/facebook-auth', '/auth/forgot-password', '/auth/reset-password'];
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
+  private isRefreshing = false;
+  private refreshTokenSubject: BehaviorSubject<string | null> =
+    new BehaviorSubject<string | null>(null);
+
   constructor(
     private authService: AuthService,
     private router: Router
   ) {}
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-    // Obtener el token del localStorage
-    const token = this.authService.getToken();
+    const token = this.authService.getAccessToken();
+    const authRequest = token ? this.addToken(request, token) : request;
 
-    // Si existe un token, lo agregamos al header de la petición
-    if (token) {
-      request = request.clone({
-        setHeaders: {
-          Authorization: `Bearer ${token}`
-        }
-      });
-    }
-
-    return next.handle(request).pipe(
+    return next.handle(authRequest).pipe(
       catchError((error: HttpErrorResponse) => {
-        if (error.status === 401) {
-          // Si el token no es válido o ha expirado
-          this.authService.removeToken();
-          this.router.navigate(['/login']);
+        if (error.status !== 401 || this.isAuthEndpoint(request)) {
+          return throwError(() => error);
         }
+        if (this.authService.getRefreshToken()) {
+          return this.handle401(request, next);
+        }
+        this.forceLogout();
         return throwError(() => error);
       })
     );
   }
-} 
+
+  private isAuthEndpoint(request: HttpRequest<unknown>): boolean {
+    return AUTH_ENDPOINTS_TO_SKIP.some((endpoint) => request.url.includes(endpoint));
+  }
+
+  private addToken(request: HttpRequest<unknown>, token: string): HttpRequest<unknown> {
+    return request.clone({
+      setHeaders: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  }
+
+  private handle401(
+    request: HttpRequest<unknown>,
+    next: HttpHandler
+  ): Observable<HttpEvent<unknown>> {
+    if (this.isRefreshing) {
+      return this.refreshTokenSubject.pipe(
+        filter((token) => token !== null),
+        take(1),
+        switchMap((token) => next.handle(this.addToken(request, token as string)))
+      );
+    }
+
+    this.isRefreshing = true;
+    this.refreshTokenSubject.next(null);
+
+    return this.authService.refresh().pipe(
+      switchMap((response: RefreshResponseDto) => {
+        this.isRefreshing = false;
+        this.authService.setTokens(response.accessToken, response.refreshToken);
+        this.refreshTokenSubject.next(response.accessToken);
+        return next.handle(this.addToken(request, response.accessToken));
+      }),
+      catchError((refreshError) => {
+        this.isRefreshing = false;
+        this.refreshTokenSubject.next(null);
+        this.forceLogout();
+        return throwError(() => refreshError);
+      })
+    );
+  }
+
+  private forceLogout(): void {
+    this.authService.removeTokens();
+    this.router.navigate(['/login']);
+  }
+}

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,14 +1,14 @@
 import { Injectable } from '@angular/core';
-import { 
-  GoogleAuthProvider, 
+import {
+  GoogleAuthProvider,
   FacebookAuthProvider,
   UserCredential,
-  signOut, 
+  signOut,
   User,
   onAuthStateChanged,
   signInWithPopup
 } from 'firebase/auth';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, Observable, catchError, of } from 'rxjs';
 import { auth } from '../../app.module';
 import { environment } from '../../../environments/environment';
 import { HttpClient } from '@angular/common/http';
@@ -22,6 +22,15 @@ import { RoleDto } from '../../shared/dto/role.dto';
 import { Roles } from '../../shared/enums/roles.enum';
 import { RequestsProvidersStatus } from '../../shared/enums/requests-providers-status.enum';
 
+export interface RefreshResponseDto {
+  accessToken: string;
+  refreshToken: string;
+}
+
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+const LEGACY_TOKEN_KEY = 'token';
+
 @Injectable({
   providedIn: 'root'
 })
@@ -31,31 +40,67 @@ export class AuthService {
   private baseUrl = environment.apiUrl + "/auth";
 
   constructor(private http: HttpClient) {
-    // Monitorear los cambios en el estado de autenticación
     onAuthStateChanged(auth, (user) => {
       this.currentUserSubject.next(user);
     });
   }
 
-  // Check if the user is authenticated
   isAuthenticated(): boolean {
-    return !!localStorage.getItem("token");
+    return !!this.getAccessToken();
   }
 
-  // Get the authentication token
   getToken(): string | null {
-    return localStorage.getItem("token");
+    return this.getAccessToken();
   }
 
-  // Set the authentication token
+  getAccessToken(): string | null {
+    return (
+      localStorage.getItem(ACCESS_TOKEN_KEY) ||
+      localStorage.getItem(LEGACY_TOKEN_KEY)
+    );
+  }
+
+  getRefreshToken(): string | null {
+    return localStorage.getItem(REFRESH_TOKEN_KEY);
+  }
+
   setToken(token: string): void {
-    localStorage.setItem("token", token);
+    this.setTokens(token, null);
+  }
+
+  setTokens(accessToken: string, refreshToken: string | null): void {
+    if (accessToken) {
+      localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+      localStorage.setItem(LEGACY_TOKEN_KEY, accessToken);
+    }
+    if (refreshToken) {
+      localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+    } else {
+      localStorage.removeItem(REFRESH_TOKEN_KEY);
+    }
     sessionStorage.removeItem("providerPanelView");
   }
 
-  // Remove the authentication token
+  setTokensFromResponse(response: {
+    token?: string;
+    accessToken?: string;
+    refreshToken?: string;
+  }): void {
+    const accessToken = response.accessToken || response.token || '';
+    const refreshToken = response.refreshToken || null;
+    if (accessToken) {
+      this.setTokens(accessToken, refreshToken);
+    }
+  }
+
   removeToken(): void {
-    localStorage.removeItem("token");
+    this.removeTokens();
+  }
+
+  removeTokens(): void {
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+    localStorage.removeItem(LEGACY_TOKEN_KEY);
   }
 
   setUser(user: any): void {
@@ -100,10 +145,15 @@ export class AuthService {
     );
   }
 
-  // Iniciar sesión con Google
+  refresh(): Observable<RefreshResponseDto> {
+    const refreshToken = this.getRefreshToken();
+    return this.http.post<RefreshResponseDto>(`${this.baseUrl}/refresh`, {
+      refreshToken,
+    });
+  }
+
   async loginWithGoogle(): Promise<UserCredential> {
     const provider = new GoogleAuthProvider();
-    // Añadir scopes para acceder a más información del usuario
     provider.addScope('profile');
     provider.addScope('email');
     return signInWithPopup(auth, provider);
@@ -118,10 +168,8 @@ export class AuthService {
       data
     );
   }
-  // Iniciar sesión con Facebook
   async loginWithFacebook(): Promise<UserCredential> {
     const provider = new FacebookAuthProvider();
-    // Añadir permisos para acceder a más información del usuario
     provider.addScope('email');
     provider.addScope('public_profile');
     return signInWithPopup(auth, provider);
@@ -137,12 +185,10 @@ export class AuthService {
     );
   }
 
-  // Obtener datos del usuario actual
   getCurrentUser(): User | null {
     return auth.currentUser;
   }
 
-  // Obtener token del usuario
   async getUserToken(): Promise<string | null> {
     const user = auth.currentUser;
     if (user) {
@@ -151,12 +197,10 @@ export class AuthService {
     return null;
   }
 
-  // Cerrar sesión
   async logoutSocial(): Promise<void> {
     return signOut(auth);
   }
 
-  // Verificar si el usuario está autenticado
   isAuthenticatedSocial(): boolean {
     return !!auth.currentUser;
   }
@@ -170,13 +214,20 @@ export class AuthService {
   }
 
   logout(): void {
-    // 1. Limpiar variables de usuario y seguridad
-    localStorage.removeItem("token");
+    const refreshToken = this.getRefreshToken();
+
+    if (refreshToken) {
+      this.http
+        .post(`${this.baseUrl}/logout`, { refreshToken })
+        .pipe(catchError(() => of(null)))
+        .subscribe();
+    }
+
+    this.removeTokens();
     localStorage.removeItem("user");
     localStorage.removeItem("requestProviderStatus");
     localStorage.removeItem("idProvider");
-    
-    // 2. Limpiar estados de navegación de la sesión
+
     sessionStorage.removeItem("providerPanelView");
     sessionStorage.removeItem("menuValue");
   }
@@ -184,7 +235,7 @@ export class AuthService {
   isAdmin(): boolean {
     const user = this.getUser();
     if (!user) return false;
-    
+
     const roleList: RoleDto[] = user.roleList || user.roles || [];
     return roleList.some((r: RoleDto) => r.id === Roles.ADMIN);
   }
@@ -192,7 +243,7 @@ export class AuthService {
   isProvider(): boolean {
     const user = this.getUser();
     if (!user) return false;
-    
+
     const roleList: RoleDto[] = user.roleList || user.roles || [];
     return roleList.some((r: RoleDto) => r.id === Roles.PROVIDER);
   }
@@ -200,7 +251,7 @@ export class AuthService {
   isProviderOperator(): boolean {
     const user = this.getUser();
     if (!user) return false;
-    
+
     const roleList: RoleDto[] = user.roleList || user.roles || [];
     return roleList.some((r: RoleDto) => r.id === Roles.PROVIDER_OPERATOR);
   }
@@ -208,10 +259,10 @@ export class AuthService {
   isUser(): boolean {
     const user = this.getUser();
     if (!user) return false;
-    
+
     const roleList: RoleDto[] = user.roleList || user.roles || [];
     return roleList.some((r: RoleDto) => r.id === Roles.USER);
-  } 
+  }
 
   setRequestProviderStatus(status: RequestsProvidersStatus): void {
     localStorage.setItem("requestProviderStatus", status);
@@ -221,16 +272,14 @@ export class AuthService {
     const status = localStorage.getItem("requestProviderStatus");
     return status as RequestsProvidersStatus || null;
   }
-  // set id provider
   setIdProvider(id: number): void {
     localStorage.setItem("idProvider", id.toString());
   }
-  // get id provider
   getIdProvider(): number | null {
     const id = localStorage.getItem("idProvider");
     return id ? parseInt(id) : null;
   }
-  
+
   /**
    * Get user's display name (first name + first surname)
    * Examples:
@@ -245,28 +294,23 @@ export class AuthService {
     }
 
     const nameParts = user.fullName.trim().split(/\s+/);
-    
+
     if (nameParts.length === 0) {
       return 'Usuario';
     }
-    
+
     if (nameParts.length === 1) {
-      // Solo un nombre
       return nameParts[0];
     }
-    
+
     if (nameParts.length === 2) {
-      // Un nombre y un apellido
       return `${nameParts[0]} ${nameParts[1]}`;
     }
-    
-    // Dos o más nombres y apellidos
-    // Tomar el primer nombre (índice 0) y el primer apellido
-    // Asumiendo que los apellidos empiezan después de la mitad
+
     const firstName = nameParts[0];
     const middleIndex = Math.floor(nameParts.length / 2);
     const firstSurname = nameParts[middleIndex];
-    
+
     return `${firstName} ${firstSurname}`;
   }
-} 
+}

--- a/src/app/shared/dto/login-response.dto.ts
+++ b/src/app/shared/dto/login-response.dto.ts
@@ -5,16 +5,22 @@ export class LoginResponseDto {
   email: string;
   roleList: RoleDto[];
   token: string;
+  accessToken?: string;
+  refreshToken?: string;
 
   constructor(
     firstName: string,
     email: string,
     roleList: RoleDto[],
-    password: string
+    password: string,
+    accessToken?: string,
+    refreshToken?: string
   ) {
     this.fullName = firstName;
     this.email = email;
     this.roleList = roleList;
     this.token = password;
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
   }
 }

--- a/src/app/shared/dto/register-response.dto.ts
+++ b/src/app/shared/dto/register-response.dto.ts
@@ -5,16 +5,22 @@ export class RegisterResponseDto {
   email: string;
   roles: RoleDto[];
   token: string;
+  accessToken?: string;
+  refreshToken?: string;
 
   constructor(
     firstName: string,
     email: string,
     roles: RoleDto[],
-    token: string
+    token: string,
+    accessToken?: string,
+    refreshToken?: string
   ) {
     this.fullName = firstName;
     this.email = email;
     this.roles = roles;
     this.token = token;
+    this.accessToken = accessToken;
+    this.refreshToken = refreshToken;
   }
 }

--- a/src/app/shared/dto/social-responose.dto.ts
+++ b/src/app/shared/dto/social-responose.dto.ts
@@ -7,8 +7,10 @@ export class SocialResponseDto extends LoginResponseDto {
     firstName: string,
     email: string,
     roles: RoleDto[],
-    token: string
+    token: string,
+    accessToken?: string,
+    refreshToken?: string
   ) {
-    super(firstName, email, roles, token);
+    super(firstName, email, roles, token, accessToken, refreshToken);
   }
 }


### PR DESCRIPTION
Cierra el bucle FE↔BE con BE-12/13/14/15 (refresh tokens del backend, ya en producción). Guarda accessToken + refreshToken en localStorage (opción B del backlog — HttpOnly cookie queda como FE-01b futuro). Ver decisión en doc 00 del 2026-07-10.

- DTOs (login/register/social) leen los nuevos campos accessToken y refreshToken como opcionales — sin romper consumidores existentes.
- AuthService:
  - setTokensFromResponse(response): extrae accessToken (fallback a token legacy) y refreshToken del payload.
  - setTokens/getAccessToken/getRefreshToken separados; setToken(token) sigue funcionando por compat.
  - refresh(): POST /auth/refresh con {refreshToken}.
  - logout(): POST /auth/logout server-side (best-effort con catchError) + limpia local (comportamiento previo preservado).
- AuthInterceptor:
  - Adjunta Bearer con el accessToken.
  - En 401 no-auth: si hay refreshToken → intenta refresh y reintenta el request original con el nuevo access. Si no hay refreshToken (sesión legacy) → forceLogout + propaga error (comportamiento previo).
  - Mutex con BehaviorSubject para que múltiples 401 concurrentes disparen un solo refresh; los demás esperan y reintentan con el nuevo token.
  - Skip explícito de endpoints /auth/** (login/register/refresh/logout/ forgot/reset/social/google/facebook) para evitar loops de refresh.
- login-tourist.component: pasa a setTokensFromResponse en los 3 flujos (email/password, Google, Facebook).

Backwards compat: usuarios con sesión activa (localStorage.token existente, sin accessToken/refreshToken) siguen operando — al expirar el access, como no hay refreshToken, cae en forceLogout como antes.