### PR TITLE
fix(env): actualiza apiUrl del frontend a Cloud Run HTTPS

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,8 +4,8 @@
 
 export const environment = {
   production: false,
-  apiUrl: "http://34.160.22.16/api/v1",
-  apiUrlBack: "http://34.160.22.16/api/v1",
+  apiUrl: "https://tourya-dev-api-640622322458.us-east1.run.app/api/v1",
+  apiUrlBack: "https://tourya-dev-api-640622322458.us-east1.run.app/api/v1",
   firebaseConfig: {
     apiKey: "AIzaSyCJyNkzo4e80-G0eBCUrIBDt6bbJ8Osp_g",
     authDomain: "tourya-169d6.firebaseapp.com",


### PR DESCRIPTION
Corrige el Mixed Content que aparecio al migrar el frontend a Cloud Run el 2026-07-09: environment.ts apuntaba a http://34.160.22.16/api/v1 (IP AWS legacy sobre HTTP). Como el frontend Cloud Run sirve por HTTPS obligatorio, el navegador bloqueaba TODAS las llamadas HTTP salientes (auth, catalogo, carrito, reservas, todo). Antes no se manifestaba porque el frontend estaba en EC2 (HTTP -> HTTP, sin Mixed Content).

Apunta a https://tourya-dev-api-640622322458.us-east1.run.app/api/v1 (mismo Cloud Run donde ya corre el backend con la migracion SMTP a Tourya Workspace aplicada).

CORS del backend ya permite este origen (BeansConfig.java linea 55).

Nota: environment.prod.ts y fileReplacements no estan configurados en angular.json, por lo que el build usa siempre environment.ts. Registrar la deuda para cuando se cree el proyecto de prod real (tourya-project-493820).