### PR TITLE
fix(env): revertir apiUrl a URL relativa /api/v1 (accedido vía LB)

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,8 +4,8 @@
 
 export const environment = {
   production: false,
-  apiUrl: "https://tourya-dev-api-640622322458.us-east1.run.app/api/v1",
-  apiUrlBack: "https://tourya-dev-api-640622322458.us-east1.run.app/api/v1",
+  apiUrl: "/api/v1",
+  apiUrlBack: "/api/v1",
   firebaseConfig: {
     apiKey: "AIzaSyCJyNkzo4e80-G0eBCUrIBDt6bbJ8Osp_g",
     authDomain: "tourya-169d6.firebaseapp.com",


### PR DESCRIPTION
Revierte mi commit anterior (3754989). La arquitectura correcta es:

  Load Balancer HTTP (34.160.22.16 o tourya.co)
    ├── /*      → Cloud Run frontend (tourya-dev-front)
    └── /api/*  → Cloud Run backend (tourya-dev-api)

Con URL relativa el frontend llama al backend por el MISMO origen que sirvió la pagina (el LB), sin cruzar dominios → sin CORS.

Mi commit anterior habia puesto la URL absoluta al Cloud Run HTTPS del backend para resolver un supuesto Mixed Content. Pero ese Mixed Content solo aparecia al probar el flujo desde 'https://tourya-dev-front-...run.app' (Cloud Run directo del front, HTTPS), que NO es la forma correcta de acceder: el flujo valido es 'http://34.160.22.16' o 'http://tourya.co', que pasa por el LB y lo hace todo same-origin. Al usar URL absoluta se rompio el same-origin y CORS empezo a bloquear porque 'http://34.160.22.16' no esta (ni estuvo nunca) en la lista de allowedOrigins del backend.

Se acepta como deuda:
- No hay forwarding rule HTTPS en el LB dev (solo :80). Cuando se agregue, el flujo pasara a https:// y esta URL relativa lo sigue soportando sin cambios.
- Acceso directo por Cloud Run URL del front no funciona porque Cloud Run no hace path routing a otro Cloud Run.