### PR TITLE
feat(admin): FE-05 input % Tourya en modal de aprobación de tour

### DIFF
--- a/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.html
+++ b/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.html
@@ -330,7 +330,7 @@
 
 <!-- Modal de Confirmación para Aceptar -->
 <div class="modal fade" [class.show]="showAcceptModal" [style.display]="showAcceptModal ? 'block' : 'none'" tabindex="-1" role="dialog">
-  <div class="modal-dialog modal-sm" role="document">
+  <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Confirmar Aceptación</h5>
@@ -338,14 +338,52 @@
       </div>
       <div class="modal-body">
         <p>¿Estás seguro de que deseas aceptar este tour?</p>
+
+        <div class="mb-3">
+          <label for="porcentajeTouryaInput" class="form-label fw-semibold">
+            Porcentaje Tourya (%)
+          </label>
+          <div class="input-group">
+            <input
+              id="porcentajeTouryaInput"
+              type="number"
+              class="form-control"
+              min="0"
+              max="100"
+              step="0.01"
+              [(ngModel)]="porcentajeTouryaInput"
+              [disabled]="savingPorcentajeTourya"
+              aria-describedby="porcentajeTouryaHelp"
+            />
+            <span class="input-group-text">%</span>
+          </div>
+          <div id="porcentajeTouryaHelp" class="form-text small">
+            Comisión que se descuenta al proveedor por cada reserva. Se hereda a los slots nuevos.
+            Rango permitido: 0–100.
+          </div>
+        </div>
+
         <div class="alert alert-success mb-0">
           <i class="isax isax-info-circle me-2"></i>
           <small>El tour pasará a estado "Aceptado" y estará disponible para los usuarios.</small>
         </div>
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-success me-2" (click)="acceptTour()">Sí, Aceptar</button>
-        <button type="button" class="btn btn-secondary" (click)="closeAcceptModal()">Cancelar</button>
+        <button
+          type="button"
+          class="btn btn-success me-2"
+          (click)="acceptTour()"
+          [disabled]="savingPorcentajeTourya || !isPorcentajeTouryaValid()"
+        >
+          <span *ngIf="!savingPorcentajeTourya">Sí, Aceptar</span>
+          <span *ngIf="savingPorcentajeTourya">Guardando…</span>
+        </button>
+        <button
+          type="button"
+          class="btn btn-secondary"
+          (click)="closeAcceptModal()"
+          [disabled]="savingPorcentajeTourya"
+        >Cancelar</button>
       </div>
     </div>
   </div>

--- a/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.ts
+++ b/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.ts
@@ -22,6 +22,10 @@ export class TourAdminDetailComponent implements OnInit, AfterViewChecked {
   showAcceptModal: boolean = false;
   showCancelModal: boolean = false;
   showReturnModal: boolean = false;
+
+  porcentajeTouryaInput: number = 15;
+  savingPorcentajeTourya: boolean = false;
+  private readonly DEFAULT_PORCENTAJE_TOURYA_PERCENT = 15;
   categories: TourCategoryDto[] = [];
   providerDetail: ProviderDto | null = null;
   locationsPublic: LocationsPublicDto[] = [];
@@ -217,11 +221,29 @@ export class TourAdminDetailComponent implements OnInit, AfterViewChecked {
   }
 
   openAcceptModal(): void {
+    const current = this.tour?.porcentajeTourya;
+    if (typeof current === 'number' && Number.isFinite(current)) {
+      this.porcentajeTouryaInput = this.round2(current * 100);
+    } else {
+      this.porcentajeTouryaInput = this.DEFAULT_PORCENTAJE_TOURYA_PERCENT;
+    }
     this.showAcceptModal = true;
   }
 
   closeAcceptModal(): void {
+    if (this.savingPorcentajeTourya) {
+      return;
+    }
     this.showAcceptModal = false;
+  }
+
+  isPorcentajeTouryaValid(): boolean {
+    const v = this.porcentajeTouryaInput;
+    return typeof v === 'number' && Number.isFinite(v) && v >= 0 && v <= 100;
+  }
+
+  private round2(value: number): number {
+    return Math.round(value * 100) / 100;
   }
 
   openCancelModal(): void {
@@ -241,18 +263,50 @@ export class TourAdminDetailComponent implements OnInit, AfterViewChecked {
   }
 
   acceptTour(): void {
-    if (this.tour) {
-      this.tourAdminService.acceptTour(this.tour.id).subscribe({
+    if (!this.tour || !this.isPorcentajeTouryaValid()) {
+      return;
+    }
+    const tourId = this.tour.id;
+    const newDecimal = this.round2(this.porcentajeTouryaInput) / 100;
+    const currentDecimal =
+      typeof this.tour.porcentajeTourya === 'number' && Number.isFinite(this.tour.porcentajeTourya)
+        ? this.round2(this.tour.porcentajeTourya * 100) / 100
+        : null;
+
+    const doAccept = () => {
+      this.tourAdminService.acceptTour(tourId).subscribe({
         next: () => {
+          this.savingPorcentajeTourya = false;
           this.openSnackBar('Tour aceptado exitosamente');
-          this.closeAcceptModal();
+          this.showAcceptModal = false;
           this.router.navigate(['/admin/dashboard']);
         },
         error: (error) => {
+          this.savingPorcentajeTourya = false;
           console.error('Error al aceptar el tour:', error);
           this.openSnackBar('Error al aceptar el tour');
         }
       });
+    };
+
+    if (currentDecimal === null || Math.abs(currentDecimal - newDecimal) > 0.00001) {
+      this.savingPorcentajeTourya = true;
+      this.tourAdminService.updatePorcentajeTourya(tourId, newDecimal).subscribe({
+        next: () => {
+          if (this.tour) {
+            this.tour.porcentajeTourya = newDecimal;
+          }
+          doAccept();
+        },
+        error: (error) => {
+          this.savingPorcentajeTourya = false;
+          console.error('Error al actualizar el porcentaje Tourya:', error);
+          this.openSnackBar('Error al actualizar el porcentaje Tourya');
+        }
+      });
+    } else {
+      this.savingPorcentajeTourya = true;
+      doAccept();
     }
   }
 

--- a/src/app/shared/dto/tour-admin.dto.ts
+++ b/src/app/shared/dto/tour-admin.dto.ts
@@ -8,6 +8,7 @@ export interface TourAdminDto {
   maxPeople: number;
   highlight: number;
   price: number | null;
+  porcentajeTourya?: number | null;
   minAge: number;
   rating: number | null;
   status: TourStatus;

--- a/src/app/shared/services/tour-admin.service.ts
+++ b/src/app/shared/services/tour-admin.service.ts
@@ -76,4 +76,16 @@ export class TourAdminService {
   returnedTour(tourId: number): Observable<void> {
     return this.http.put<void>(`${this.baseUrl}/admin/returnedTourById/${tourId}`, {});
   }
+
+  /**
+   * Actualiza el porcentaje Tourya del tour. Solo ADMIN/BACKOFFICE.
+   * El valor debe ser un decimal entre 0.0 y 1.0 (ej. 0.15 = 15%).
+   * Retorna el TourFullDataResponse del backend con el tour actualizado.
+   */
+  updatePorcentajeTourya(tourId: number, porcentajeTourya: number): Observable<unknown> {
+    return this.http.patch<unknown>(
+      `${this.baseUrl}/admin/${tourId}/porcentajeTourya`,
+      { porcentajeTourya }
+    );
+  }
 }


### PR DESCRIPTION
Cierra el bucle RN-015 con el backend BE-01/02 (default heredable) y el PR tourya-api #169 (endpoint PATCH). Al aprobar un tour el ADMIN puede ajustar el porcentaje Tourya en el mismo modal — el input viene pre-poblado con el valor actual del tour (o 15% como default si no está seteado).

Cambios:
- TourAdminDto: campo opcional porcentajeTourya (number decimal 0-1).
- TourAdminService.updatePorcentajeTourya(tourId, decimal): llama al nuevo PATCH /tours/admin/{tourId}/porcentajeTourya con body { porcentajeTourya }.
- tour-admin-detail.component:
  - Input numérico % (0-100 con step 0.01) en el modal de aprobación.
  - Pre-población desde tour.porcentajeTourya * 100 al abrir el modal.
  - Al aceptar: si el valor cambió respecto al del tour, se llama primero al PATCH; luego se dispara el PUT accept. Si no cambió, solo accept.
  - Botón deshabilitado durante el PATCH y con label "Guardando…".
  - Validación cliente: rango 0-100 (además del DecimalMax(1.0) del backend).

Notas:
- Conversión bidireccional: la UI muestra "15" (%), el backend guarda 0.15 (decimal). Se redondea a 2 decimales para evitar drift.
- No se toca acceptTour del backend — mantiene contract original de PUT sin body. La UI solo llama al PATCH cuando efectivamente hay cambio.