### PR TITLE
i18n: FE-11 traduce pantalla /providers/requestproviders (es/en/pt)

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1832,5 +1832,102 @@
       "generic": "An error occurred, please try again",
       "genericTitle": "Could not save the gallery"
     }
+  },
+  "request-provider": {
+    "breadcrumb": "Provider Request",
+    "sidebar": {
+      "title": "Provider Request",
+      "basicInfo": "Basic information"
+    },
+    "loading": {
+      "data": "Loading data...",
+      "info": "Loading provider information..."
+    },
+    "sections": {
+      "providerDetails": "Provider details",
+      "documents": "Documents"
+    },
+    "fields": {
+      "name": "Name",
+      "namePlaceholder": "Enter your full name",
+      "documentNumber": "Document number",
+      "documentNumberPlaceholder": "Enter your document number",
+      "documentType": "Document type",
+      "selectDocumentType": "Select document type",
+      "serviceType": "Service type",
+      "selectServiceType": "Select service type",
+      "rnt": "National Tourism Registry (RNT)",
+      "rntPlaceholder": "Enter your RNT",
+      "country": "Country",
+      "department": "State/Province",
+      "city": "City",
+      "selectPlaceholder": "Select",
+      "phone": "Phone",
+      "phonePlaceholder": "Enter your phone number",
+      "address": "Address",
+      "addressPlaceholder": "Enter your full address"
+    },
+    "validation": {
+      "nameRequired": "Name is required",
+      "nameMinLength": "Name must be at least 3 characters long",
+      "documentNumberRequired": "Document number is required",
+      "documentNumberMinLength": "Document number must be at least 6 characters long",
+      "documentTypeRequired": "Document type is required",
+      "serviceTypeRequired": "Service type is required",
+      "rntRequired": "RNT is required",
+      "countryRequired": "Country is required",
+      "phoneRequired": "Phone is required",
+      "phoneMinLength": "Phone must be at least 10 digits long",
+      "addressRequired": "Address is required",
+      "addressMinLength": "Address must be at least 10 characters long"
+    },
+    "buttons": {
+      "submit": "Submit request",
+      "resubmit": "Resubmit request",
+      "sendToServer": "Send documents to server",
+      "viewFile": "View file",
+      "changeDocument": "Change {{name}}",
+      "uploadDocument": "Upload {{name}}",
+      "remove": "Remove"
+    },
+    "status": {
+      "declinedReason": "Reason for rejection:",
+      "incompleteReason": "Reason for information request:",
+      "submittedBadge": "Status: Submitted",
+      "submittedMessage": "Your request has been submitted successfully."
+    },
+    "documents": {
+      "requiredTitle": "Required documents",
+      "workflow": {
+        "title": "Workflow:",
+        "step1": "Upload documents using the buttons below",
+        "step2": "Documents are temporarily saved in your browser",
+        "step3": "Press \"Send documents to server\" to upload them"
+      },
+      "badges": {
+        "mandatory": "Mandatory",
+        "optional": "Optional",
+        "new": "New",
+        "existing": "Existing"
+      },
+      "acceptedFormats": "PDF, JPG, PNG, DOC (Max 10MB)",
+      "existingFile": "Existing file",
+      "summary": {
+        "totalAvailable": "Total available",
+        "withFiles": "With files",
+        "mandatoryPending": "Mandatory pending",
+        "readyToSend": "New to send",
+        "markedForDelete": "{{count}} file(s) marked for deletion",
+        "pressToSend": ". Press this button to send them to the server"
+      }
+    },
+    "cancelled": {
+      "title": "Your Request Has Been Cancelled",
+      "description": "Unfortunately your provider request has been cancelled.",
+      "reason": "Reason:",
+      "reasonUnspecified": "Not specified",
+      "logoutInstruction": "Please log out.",
+      "logoutButton": "Log out"
+    }
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1833,5 +1833,102 @@
       "generic": "Ha ocurrido un error, por favor intente de nuevo",
       "genericTitle": "No se pudo guardar la galería"
     }
+  },
+  "request-provider": {
+    "breadcrumb": "Solicitud de proveedor",
+    "sidebar": {
+      "title": "Solicitud de proveedor",
+      "basicInfo": "Información básica"
+    },
+    "loading": {
+      "data": "Cargando datos...",
+      "info": "Cargando información del proveedor..."
+    },
+    "sections": {
+      "providerDetails": "Datos del proveedor",
+      "documents": "Documentos"
+    },
+    "fields": {
+      "name": "Nombre",
+      "namePlaceholder": "Ingresa tu nombre completo",
+      "documentNumber": "Número de documento",
+      "documentNumberPlaceholder": "Ingresa tu número de documento",
+      "documentType": "Tipo de documento",
+      "selectDocumentType": "Selecciona el tipo de documento",
+      "serviceType": "Tipo de servicio",
+      "selectServiceType": "Selecciona el tipo de servicio",
+      "rnt": "Registro Nacional de Turismo (RNT)",
+      "rntPlaceholder": "Ingresa tu RNT",
+      "country": "País",
+      "department": "Departamento",
+      "city": "Ciudad",
+      "selectPlaceholder": "Seleccionar",
+      "phone": "Teléfono",
+      "phonePlaceholder": "Ingresa tu número de teléfono",
+      "address": "Dirección",
+      "addressPlaceholder": "Ingresa tu dirección completa"
+    },
+    "validation": {
+      "nameRequired": "El nombre es obligatorio",
+      "nameMinLength": "El nombre debe tener al menos 3 caracteres",
+      "documentNumberRequired": "El número de documento es obligatorio",
+      "documentNumberMinLength": "El número de documento debe tener al menos 6 caracteres",
+      "documentTypeRequired": "El tipo de documento es obligatorio",
+      "serviceTypeRequired": "El tipo de servicio es obligatorio",
+      "rntRequired": "El RNT es obligatorio",
+      "countryRequired": "El país es obligatorio",
+      "phoneRequired": "El teléfono es obligatorio",
+      "phoneMinLength": "El teléfono debe tener al menos 10 dígitos",
+      "addressRequired": "La dirección es obligatoria",
+      "addressMinLength": "La dirección debe tener al menos 10 caracteres"
+    },
+    "buttons": {
+      "submit": "Enviar solicitud",
+      "resubmit": "Reenviar solicitud",
+      "sendToServer": "Enviar documentos al servidor",
+      "viewFile": "Ver archivo",
+      "changeDocument": "Cambiar {{name}}",
+      "uploadDocument": "Cargar {{name}}",
+      "remove": "Eliminar"
+    },
+    "status": {
+      "declinedReason": "Motivo del rechazo:",
+      "incompleteReason": "Motivo de solicitud de información:",
+      "submittedBadge": "Estado: Enviada",
+      "submittedMessage": "Tu solicitud ha sido enviada correctamente."
+    },
+    "documents": {
+      "requiredTitle": "Documentos requeridos",
+      "workflow": {
+        "title": "Flujo de trabajo:",
+        "step1": "Carga los documentos usando los botones de abajo",
+        "step2": "Los documentos se guardan temporalmente en tu navegador",
+        "step3": "Presiona \"Enviar documentos al servidor\" para enviarlos"
+      },
+      "badges": {
+        "mandatory": "Obligatorio",
+        "optional": "Opcional",
+        "new": "Nuevo",
+        "existing": "Existente"
+      },
+      "acceptedFormats": "PDF, JPG, PNG, DOC (Máx 10MB)",
+      "existingFile": "Archivo existente",
+      "summary": {
+        "totalAvailable": "Total disponibles",
+        "withFiles": "Con archivos",
+        "mandatoryPending": "Obligatorios pendientes",
+        "readyToSend": "Nuevos para enviar",
+        "markedForDelete": "{{count}} archivo(s) marcado(s) para eliminar",
+        "pressToSend": ". Presiona este botón para enviarlos al servidor"
+      }
+    },
+    "cancelled": {
+      "title": "Tu Solicitud ha sido Cancelada",
+      "description": "Lamentablemente tu solicitud de proveedor ha sido cancelada.",
+      "reason": "Motivo:",
+      "reasonUnspecified": "No especificado",
+      "logoutInstruction": "Por favor, cierra sesión.",
+      "logoutButton": "Cerrar sesión"
+    }
   }
 }

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1833,5 +1833,102 @@
       "generic": "Ocorreu um erro, tente novamente",
       "genericTitle": "Não foi possível salvar a galeria"
     }
+  },
+  "request-provider": {
+    "breadcrumb": "Solicitação de fornecedor",
+    "sidebar": {
+      "title": "Solicitação de fornecedor",
+      "basicInfo": "Informações básicas"
+    },
+    "loading": {
+      "data": "Carregando dados...",
+      "info": "Carregando informações do fornecedor..."
+    },
+    "sections": {
+      "providerDetails": "Dados do fornecedor",
+      "documents": "Documentos"
+    },
+    "fields": {
+      "name": "Nome",
+      "namePlaceholder": "Insira seu nome completo",
+      "documentNumber": "Número do documento",
+      "documentNumberPlaceholder": "Insira o número do seu documento",
+      "documentType": "Tipo de documento",
+      "selectDocumentType": "Selecione o tipo de documento",
+      "serviceType": "Tipo de serviço",
+      "selectServiceType": "Selecione o tipo de serviço",
+      "rnt": "Registro Nacional de Turismo (RNT)",
+      "rntPlaceholder": "Insira seu RNT",
+      "country": "País",
+      "department": "Estado/Departamento",
+      "city": "Cidade",
+      "selectPlaceholder": "Selecionar",
+      "phone": "Telefone",
+      "phonePlaceholder": "Insira seu número de telefone",
+      "address": "Endereço",
+      "addressPlaceholder": "Insira seu endereço completo"
+    },
+    "validation": {
+      "nameRequired": "O nome é obrigatório",
+      "nameMinLength": "O nome deve ter pelo menos 3 caracteres",
+      "documentNumberRequired": "O número do documento é obrigatório",
+      "documentNumberMinLength": "O número do documento deve ter pelo menos 6 caracteres",
+      "documentTypeRequired": "O tipo de documento é obrigatório",
+      "serviceTypeRequired": "O tipo de serviço é obrigatório",
+      "rntRequired": "O RNT é obrigatório",
+      "countryRequired": "O país é obrigatório",
+      "phoneRequired": "O telefone é obrigatório",
+      "phoneMinLength": "O telefone deve ter pelo menos 10 dígitos",
+      "addressRequired": "O endereço é obrigatório",
+      "addressMinLength": "O endereço deve ter pelo menos 10 caracteres"
+    },
+    "buttons": {
+      "submit": "Enviar solicitação",
+      "resubmit": "Reenviar solicitação",
+      "sendToServer": "Enviar documentos ao servidor",
+      "viewFile": "Ver arquivo",
+      "changeDocument": "Alterar {{name}}",
+      "uploadDocument": "Carregar {{name}}",
+      "remove": "Remover"
+    },
+    "status": {
+      "declinedReason": "Motivo da rejeição:",
+      "incompleteReason": "Motivo da solicitação de informação:",
+      "submittedBadge": "Status: Enviada",
+      "submittedMessage": "Sua solicitação foi enviada com sucesso."
+    },
+    "documents": {
+      "requiredTitle": "Documentos obrigatórios",
+      "workflow": {
+        "title": "Fluxo de trabalho:",
+        "step1": "Carregue os documentos usando os botões abaixo",
+        "step2": "Os documentos são salvos temporariamente no navegador",
+        "step3": "Pressione \"Enviar documentos ao servidor\" para enviá-los"
+      },
+      "badges": {
+        "mandatory": "Obrigatório",
+        "optional": "Opcional",
+        "new": "Novo",
+        "existing": "Existente"
+      },
+      "acceptedFormats": "PDF, JPG, PNG, DOC (Máx 10MB)",
+      "existingFile": "Arquivo existente",
+      "summary": {
+        "totalAvailable": "Total disponíveis",
+        "withFiles": "Com arquivos",
+        "mandatoryPending": "Obrigatórios pendentes",
+        "readyToSend": "Novos para enviar",
+        "markedForDelete": "{{count}} arquivo(s) marcado(s) para exclusão",
+        "pressToSend": ". Pressione este botão para enviá-los ao servidor"
+      }
+    },
+    "cancelled": {
+      "title": "Sua Solicitação Foi Cancelada",
+      "description": "Infelizmente sua solicitação de fornecedor foi cancelada.",
+      "reason": "Motivo:",
+      "reasonUnspecified": "Não especificado",
+      "logoutInstruction": "Por favor, encerre a sessão.",
+      "logoutButton": "Encerrar sessão"
+    }
   }
 }

--- a/src/app/pages/providers/requestproviders/requestprovider.component.html
+++ b/src/app/pages/providers/requestproviders/requestprovider.component.html
@@ -3,12 +3,12 @@
     <div class="container">
         <div class="row">
             <div class="col-md-12 col-12">
-                <h2 class="breadcrumb-title mb-2">Request Provider</h2>
+                <h2 class="breadcrumb-title mb-2">{{ 'request-provider.breadcrumb' | translate }}</h2>
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb justify-content-center mb-0">
                         <li class="breadcrumb-item"><a [routerLink]="routes.baseUrl"><i class="isax isax-home5"></i></a>
                         </li>
-                        <li class="breadcrumb-item active" aria-current="page">Request Provider</li>
+                        <li class="breadcrumb-item active" aria-current="page">{{ 'request-provider.breadcrumb' | translate }}</li>
                     </ol>
                 </nav>
             </div>
@@ -23,9 +23,9 @@
         <!-- Center Loading Spinner -->
         <div *ngIf="isLoadingData" class="d-flex flex-column align-items-center justify-content-center py-5 my-5">
             <div class="spinner-border text-primary" role="status" style="width: 4rem; height: 4rem;">
-                <span class="visually-hidden">Cargando datos...</span>
+                <span class="visually-hidden">{{ 'request-provider.loading.data' | translate }}</span>
             </div>
-            <h4 class="mt-4 text-muted">Cargando información del proveedor...</h4>
+            <h4 class="mt-4 text-muted">{{ 'request-provider.loading.info' | translate }}</h4>
         </div>
 
         <div class="row" *ngIf="!isLoadingData && dataRequestProvider?.status !== 'Cancelled'">
@@ -35,13 +35,13 @@
                 <div class="card border-0 mb-4 mb-lg-0 theiaStickySidebar">
                     <div class="card-body">
                         <div>
-                            <h5 class="mb-3">Request Provider</h5>
+                            <h5 class="mb-3">{{ 'request-provider.sidebar.title' | translate }}</h5>
                             <ul class="add-tab-list">
                                 <li *ngFor="let tab of tabs">
                                     <a href="javascript:void(0);" [class.active]="activeTab === tab.id"
-                                        (click)="scrollTo(tab.id)" 
+                                        (click)="scrollTo(tab.id)"
                                         *ngIf="tab.id !== 'gallery' || shouldShowGalleryPanel()">
-                                        {{ tab.label }}
+                                        {{ tab.label | translate }}
                                     </a>
                                 </li>
                             </ul>
@@ -57,7 +57,7 @@
                     <div class="card shadow-none" id="basic_info">
                         <div class="card-header">
                             <div class="d-flex align-items-center justify-content-between">
-                                <h5 class="fs-18">Provider Details</h5>
+                                <h5 class="fs-18">{{ 'request-provider.sections.providerDetails' | translate }}</h5>
                             </div>
                         </div>
                         <div class="card-body pb-1">
@@ -65,16 +65,16 @@
                                 <!-- Name -->
                                 <div class="col-md-6">
                                     <div class="mb-3">
-                                        <label class="form-label">Name</label>
+                                        <label class="form-label">{{ 'request-provider.fields.name' | translate }}</label>
                                         <input type="text" class="form-control" formControlName="name"
-                                            placeholder="Enter your full name">
+                                            [placeholder]="'request-provider.fields.namePlaceholder' | translate">
                                         <div *ngIf="requestProviderForm.controls['name'].invalid && (requestProviderForm.controls['name'].dirty || requestProviderForm.controls['name'].touched)"
                                             class="text-danger">
                                             <div *ngIf="requestProviderForm.controls['name'].errors?.['required']">
-                                                Name is required
+                                                {{ 'request-provider.validation.nameRequired' | translate }}
                                             </div>
                                             <div *ngIf="requestProviderForm.controls['name'].errors?.['minlength']">
-                                                Name must be at least 3 characters long
+                                                {{ 'request-provider.validation.nameMinLength' | translate }}
                                             </div>
                                         </div>
                                     </div>
@@ -83,16 +83,16 @@
                                 <!-- Document Number -->
                                 <div class="col-md-6">
                                     <div class="mb-3">
-                                        <label class="form-label">Document Number</label>
+                                        <label class="form-label">{{ 'request-provider.fields.documentNumber' | translate }}</label>
                                         <input type="text" class="form-control" formControlName="documentNumber"
-                                            placeholder="Enter your document number">
+                                            [placeholder]="'request-provider.fields.documentNumberPlaceholder' | translate">
                                         <div *ngIf="requestProviderForm.controls['documentNumber'].invalid && (requestProviderForm.controls['documentNumber'].dirty || requestProviderForm.controls['documentNumber'].touched)"
                                             class="text-danger">
                                             <div *ngIf="requestProviderForm.controls['documentNumber'].errors?.['required']">
-                                                Document number is required
+                                                {{ 'request-provider.validation.documentNumberRequired' | translate }}
                                             </div>
                                             <div *ngIf="requestProviderForm.controls['documentNumber'].errors?.['minlength']">
-                                                Document number must be at least 6 characters long
+                                                {{ 'request-provider.validation.documentNumberMinLength' | translate }}
                                             </div>
                                         </div>
                                     </div>
@@ -101,9 +101,9 @@
                                 <!-- Document Type -->
                                 <div class="col-md-6">
                                     <div class="mb-3">
-                                        <label class="form-label">Document Type</label>
+                                        <label class="form-label">{{ 'request-provider.fields.documentType' | translate }}</label>
                                         <select class="form-control" formControlName="documentType">
-                                            <option value="">Select document type</option>
+                                            <option value="">{{ 'request-provider.fields.selectDocumentType' | translate }}</option>
                                             <option *ngFor="let documentType of documentTypes" [value]="documentType.id">
                                                 {{ documentType.description }}
                                             </option>
@@ -111,7 +111,7 @@
                                         <div *ngIf="requestProviderForm.controls['documentType'].invalid && (requestProviderForm.controls['documentType'].dirty || requestProviderForm.controls['documentType'].touched)"
                                             class="text-danger">
                                             <div *ngIf="requestProviderForm.controls['documentType'].errors?.['required']">
-                                                Document type is required
+                                                {{ 'request-provider.validation.documentTypeRequired' | translate }}
                                             </div>
                                         </div>
                                     </div>
@@ -120,9 +120,9 @@
                                 <!-- Service Type -->
                                 <div class="col-md-6">
                                     <div class="mb-3">
-                                        <label class="form-label">Service Type</label>
+                                        <label class="form-label">{{ 'request-provider.fields.serviceType' | translate }}</label>
                                         <select class="form-control" formControlName="serviceType">
-                                            <option value="">Select service type</option>
+                                            <option value="">{{ 'request-provider.fields.selectServiceType' | translate }}</option>
                                             <option *ngFor="let serviceType of serviceTypes" [value]="serviceType" [disabled]="serviceType !== 'Tour'">
                                                 {{ serviceType }}
                                             </option>
@@ -130,7 +130,7 @@
                                         <div *ngIf="requestProviderForm.controls['serviceType'].invalid && (requestProviderForm.controls['serviceType'].dirty || requestProviderForm.controls['serviceType'].touched)"
                                             class="text-danger">
                                             <div *ngIf="requestProviderForm.controls['serviceType'].errors?.['required']">
-                                                Service type is required
+                                                {{ 'request-provider.validation.serviceTypeRequired' | translate }}
                                             </div>
                                         </div>
                                     </div>
@@ -139,13 +139,13 @@
                                 <!-- RNT -->
                                 <div class="col-md-6">
                                     <div class="mb-3">
-                                        <label class="form-label">Registro Nacional de Turismo (RNT)</label>
+                                        <label class="form-label">{{ 'request-provider.fields.rnt' | translate }}</label>
                                         <input type="text" class="form-control" formControlName="rnt"
-                                            placeholder="Ingresa tu RNT">
+                                            [placeholder]="'request-provider.fields.rntPlaceholder' | translate">
                                         <div *ngIf="requestProviderForm.controls['rnt'].invalid && (requestProviderForm.controls['rnt'].dirty || requestProviderForm.controls['rnt'].touched)"
                                             class="text-danger">
                                             <div *ngIf="requestProviderForm.controls['rnt'].errors?.['required']">
-                                                RNT is required
+                                                {{ 'request-provider.validation.rntRequired' | translate }}
                                             </div>
                                         </div>
                                     </div>
@@ -154,8 +154,8 @@
                                 <!-- Country -->
                                 <div class="col-md-6">
                                     <div class="mb-3">
-                                        <label class="form-label">Country</label>
-                                        <mat-select class="custom-mat-select select" placeholder="Select"
+                                        <label class="form-label">{{ 'request-provider.fields.country' | translate }}</label>
+                                        <mat-select class="custom-mat-select select" [placeholder]="'request-provider.fields.selectPlaceholder' | translate"
                                             formControlName="country"
                                             (valueChange)="onCountryChange($event)">
                                             <mat-option *ngFor="let country of countries"
@@ -165,7 +165,7 @@
                                         <div *ngIf="requestProviderForm.controls['country'].invalid && (requestProviderForm.controls['country'].dirty || requestProviderForm.controls['country'].touched)"
                                             class="text-danger">
                                             <div *ngIf="requestProviderForm.controls['country'].errors?.['required']">
-                                                Country is required
+                                                {{ 'request-provider.validation.countryRequired' | translate }}
                                             </div>
                                         </div>
                                     </div>
@@ -173,38 +173,25 @@
 
                                 <div class="col-xl-3 col-md-6">
                                     <div class="mb-3">
-                                        <label class="form-label">Department</label>
-                                        <mat-select class="custom-mat-select select" placeholder="Select"
+                                        <label class="form-label">{{ 'request-provider.fields.department' | translate }}</label>
+                                        <mat-select class="custom-mat-select select" [placeholder]="'request-provider.fields.selectPlaceholder' | translate"
                                             formControlName="department"
                                             (valueChange)="onDepartmentChange($event)">
                                             <mat-option *ngFor="let department of departments"
                                                 [value]="department.id">{{department.name}}</mat-option>
                                         </mat-select>
-
-                                        <!-- <div *ngIf="location.get('department')?.invalid && (location.get('department')?.dirty || location.get('department')?.touched)"
-                                            class="text-danger">
-                                            <div *ngIf="location.get('department')?.errors?.['required']">
-                                                Department is required
-                                            </div>
-                                        </div> -->
                                     </div>
                                 </div>
 
                                 <div class="col-xl-3 col-md-6">
                                     <div class="mb-3">
                                         <div class="mb-3">
-                                            <label class="form-label">City</label>
-                                            <mat-select class="custom-mat-select select" placeholder="Select"
+                                            <label class="form-label">{{ 'request-provider.fields.city' | translate }}</label>
+                                            <mat-select class="custom-mat-select select" [placeholder]="'request-provider.fields.selectPlaceholder' | translate"
                                                 formControlName="city">
                                                 <mat-option *ngFor="let city of cities"
                                                     [value]="city.id">{{city.name}}</mat-option>
                                             </mat-select>
-                                            <!-- <div *ngIf="location.get('city')?.invalid && (location.get('city')?.dirty || location.get('city')?.touched)"
-                                                class="text-danger">
-                                                <div *ngIf="location.get('city')?.errors?.['required']">
-                                                    City is required
-                                                </div>
-                                            </div> -->
                                         </div>
                                     </div>
                                 </div>
@@ -212,16 +199,16 @@
                                 <!-- Phone -->
                                 <div class="col-md-6">
                                     <div class="mb-3">
-                                        <label class="form-label">Phone</label>
+                                        <label class="form-label">{{ 'request-provider.fields.phone' | translate }}</label>
                                         <input type="text" class="form-control" formControlName="phone"
-                                            placeholder="Enter your phone number">
+                                            [placeholder]="'request-provider.fields.phonePlaceholder' | translate">
                                         <div *ngIf="requestProviderForm.controls['phone'].invalid && (requestProviderForm.controls['phone'].dirty || requestProviderForm.controls['phone'].touched)"
                                             class="text-danger">
                                             <div *ngIf="requestProviderForm.controls['phone'].errors?.['required']">
-                                                Phone is required
+                                                {{ 'request-provider.validation.phoneRequired' | translate }}
                                             </div>
                                             <div *ngIf="requestProviderForm.controls['phone'].errors?.['minlength']">
-                                                Phone must be at least 10 digits long
+                                                {{ 'request-provider.validation.phoneMinLength' | translate }}
                                             </div>
                                         </div>
                                     </div>
@@ -230,16 +217,16 @@
                                 <!-- Address -->
                                 <div class="col-md-12">
                                     <div class="mb-3">
-                                        <label class="form-label">Address</label>
+                                        <label class="form-label">{{ 'request-provider.fields.address' | translate }}</label>
                                         <textarea class="form-control" rows="3" formControlName="address"
-                                            placeholder="Enter your complete address"></textarea>
+                                            [placeholder]="'request-provider.fields.addressPlaceholder' | translate"></textarea>
                                         <div *ngIf="requestProviderForm.controls['address'].invalid && (requestProviderForm.controls['address'].dirty || requestProviderForm.controls['address'].touched)"
                                             class="text-danger">
                                             <div *ngIf="requestProviderForm.controls['address'].errors?.['required']">
-                                                Address is required
+                                                {{ 'request-provider.validation.addressRequired' | translate }}
                                             </div>
                                             <div *ngIf="requestProviderForm.controls['address'].errors?.['minlength']">
-                                                Address must be at least 10 characters long
+                                                {{ 'request-provider.validation.addressMinLength' | translate }}
                                             </div>
                                         </div>
                                     </div>
@@ -252,13 +239,13 @@
                     <div *ngIf="dataRequestProvider.status === 'Declined' && dataRequestProvider.declinedReason" class="mt-3">
                         <div class="alert alert-danger d-flex align-items-center" role="alert">
                             <i class="isax isax-close-circle me-2"></i>
-                            <span class="fw-bold">Motivo del rechazo:</span>&nbsp;{{ dataRequestProvider.declinedReason }}
+                            <span class="fw-bold">{{ 'request-provider.status.declinedReason' | translate }}</span>&nbsp;{{ dataRequestProvider.declinedReason }}
                         </div>
                     </div>
                     <div *ngIf="dataRequestProvider.status === 'Incomplete Information' && dataRequestProvider.incompleteReason" class="mt-3">
                         <div class="alert alert-warning d-flex align-items-center" role="alert">
                             <i class="isax isax-info-circle me-2"></i>
-                            <span class="fw-bold">Motivo de solicitud de información:</span>&nbsp;{{ dataRequestProvider.incompleteReason }}
+                            <span class="fw-bold">{{ 'request-provider.status.incompleteReason' | translate }}</span>&nbsp;{{ dataRequestProvider.incompleteReason }}
                         </div>
                     </div>
 
@@ -269,26 +256,26 @@
                             <button type="submit" class="btn btn-primary"
                                 [disabled]="loading || (requestProviderForm.touched && requestProviderForm.invalid)"
                                 *ngIf="!isExistingData || dataRequestProvider.status === 'Incomplete Information'">
-                                <span>{{ !isExistingData ? 'Submit Request' : 'Resubmit Request' }}</span>
+                                <span>{{ (!isExistingData ? 'request-provider.buttons.submit' : 'request-provider.buttons.resubmit') | translate }}</span>
                                 <div *ngIf="loading" class="spinner-border spinner-border-sm ms-2">
                                 </div>
                             </button>
-                            
+
                             <!-- Botón Submitted (cuando el status es Created) -->
                             <button type="button" class="btn btn-success"
                                 (click)="changeToSubmitted()"
                                 [disabled]="loading || !canChangeToSubmitted"
                                 *ngIf="isExistingData && canChangeToSubmitted">
-                                <span>Submit Request</span>
+                                <span>{{ 'request-provider.buttons.submit' | translate }}</span>
                                 <div *ngIf="loading" class="spinner-border spinner-border-sm ms-2">
                                 </div>
                             </button>
-                            
+
                             <!-- Mensaje cuando ya está Submitted -->
-                            <div *ngIf="isExistingData && !canChangeToSubmitted && dataRequestProvider.status === 'Submitted'" 
+                            <div *ngIf="isExistingData && !canChangeToSubmitted && dataRequestProvider.status === 'Submitted'"
                                  class="alert alert-success mb-0">
                                 <i class="isax isax-tick-circle me-2"></i>
-                                <strong>Status: Submitted</strong> - Tu solicitud ha sido enviada correctamente.
+                                <strong>{{ 'request-provider.status.submittedBadge' | translate }}</strong> - {{ 'request-provider.status.submittedMessage' | translate }}
                             </div>
                         </div>
                     </div>
@@ -311,20 +298,20 @@
                     <!-- Panel de carga de archivos solo si isExistingData es true y status es Pre-Approved -->
                     <div class="card shadow-none" id="gallery" *ngIf="shouldShowGalleryPanel()">
                         <div class="card-header">
-                            <h5 class="fs-18">Documents</h5>
+                            <h5 class="fs-18">{{ 'request-provider.sections.documents' | translate }}</h5>
                         </div>
                         <div class="card-body">
                             <!-- 3 Botones de carga de archivos según estructura JSON -->
                             <div class="row">
                                 <div class="col-12">
-                                    <h6 class="mb-4">Required Documents</h6>
+                                    <h6 class="mb-4">{{ 'request-provider.documents.requiredTitle' | translate }}</h6>
                                     <!-- Información del flujo de trabajo -->
                                     <div class="alert alert-info mb-3">
-                                        <h6><i class="isax isax-info-circle me-2"></i>Flujo de trabajo:</h6>
+                                        <h6><i class="isax isax-info-circle me-2"></i>{{ 'request-provider.documents.workflow.title' | translate }}</h6>
                                         <ol class="mb-0">
-                                            <li>Carga los documentos usando los botones de abajo</li>
-                                            <li>Los documentos se guardan temporalmente en tu navegador</li>
-                                            <li>Presiona "Guardar todos los documentos" para enviarlos al servidor</li>
+                                            <li>{{ 'request-provider.documents.workflow.step1' | translate }}</li>
+                                            <li>{{ 'request-provider.documents.workflow.step2' | translate }}</li>
+                                            <li>{{ 'request-provider.documents.workflow.step3' | translate }}</li>
                                         </ol>
                                     </div>
                                     <!-- Grid de botones de carga dinámicos -->
@@ -336,20 +323,20 @@
                                                  [class.border-danger]="!hasFile(docType.id) && docType.mandatory"
                                                  [class.border-secondary]="!hasFile(docType.id) && !docType.mandatory"
                                                  [class.bg-light]="hasFile(docType.id)">
-                                                
+
                                                 <!-- Badge de estado -->
                                                 <div class="position-absolute top-0 end-0 p-2">
                                                     <span *ngIf="!hasFile(docType.id) && docType.mandatory" class="badge bg-danger">
-                                                        <i class="isax isax-danger me-1"></i>Obligatorio
+                                                        <i class="isax isax-danger me-1"></i>{{ 'request-provider.documents.badges.mandatory' | translate }}
                                                     </span>
                                                     <span *ngIf="!hasFile(docType.id) && !docType.mandatory" class="badge bg-secondary">
-                                                        <i class="isax isax-info-circle me-1"></i>Opcional
+                                                        <i class="isax isax-info-circle me-1"></i>{{ 'request-provider.documents.badges.optional' | translate }}
                                                     </span>
                                                     <span *ngIf="hasNewFile(docType.id)" class="badge bg-success">
-                                                        <i class="isax isax-tick-circle me-1"></i>Nuevo
+                                                        <i class="isax isax-tick-circle me-1"></i>{{ 'request-provider.documents.badges.new' | translate }}
                                                     </span>
                                                     <span *ngIf="hasExistingFile(docType.id) && !hasNewFile(docType.id)" class="badge bg-primary">
-                                                        <i class="isax isax-document me-1"></i>Existente
+                                                        <i class="isax isax-document me-1"></i>{{ 'request-provider.documents.badges.existing' | translate }}
                                                     </span>
                                                 </div>
 
@@ -357,11 +344,11 @@
                                                     <!-- Sin archivo cargado -->
                                                     <div *ngIf="!hasFile(docType.id)">
                                                         <div class="mb-3">
-                                                            <i class="isax isax-document-text display-4" 
+                                                            <i class="isax isax-document-text display-4"
                                                                [class.text-danger]="docType.mandatory"
                                                                [class.text-secondary]="!docType.mandatory"></i>
                                                         </div>
-                                                        <h5 class="card-title mb-2" 
+                                                        <h5 class="card-title mb-2"
                                                             [class.text-danger]="docType.mandatory"
                                                             [class.text-secondary]="!docType.mandatory">
                                                             {{ docType.name }}
@@ -369,17 +356,17 @@
                                                         <p class="card-text text-muted mb-3">
                                                             {{ docType.description }}
                                                         </p>
-                                                        <button 
-                                                            type="button" 
+                                                        <button
+                                                            type="button"
                                                             class="btn w-100 mb-2"
                                                             [class.btn-danger]="docType.mandatory"
                                                             [class.btn-secondary]="!docType.mandatory"
                                                             (click)="triggerFileInput(docType.id)"
                                                             [disabled]="dataRequestProvider.status !== 'Incomplete Information' && dataRequestProvider.status !== 'Pre-Approved' && dataRequestProvider.status !== 'Submitted'">
                                                             <i class="isax isax-document-upload me-2"></i>
-                                                            Cargar {{ docType.name }}
+                                                            {{ 'request-provider.buttons.uploadDocument' | translate: { name: docType.name } }}
                                                         </button>
-                                                        <small class="text-muted">PDF, JPG, PNG, DOC (Max 10MB)</small>
+                                                        <small class="text-muted">{{ 'request-provider.documents.acceptedFormats' | translate }}</small>
                                                     </div>
 
                                                     <!-- Con archivo cargado (nuevo o existente) -->
@@ -400,62 +387,62 @@
                                                                 {{ getFileSizeInMB(docType.id) }} MB
                                                             </small>
                                                             <small class="text-muted" *ngIf="hasExistingFile(docType.id) && !hasNewFile(docType.id)">
-                                                                Archivo existente
+                                                                {{ 'request-provider.documents.existingFile' | translate }}
                                                             </small>
                                                         </div>
-                                                        
+
                                                         <!-- Botones para archivo existente -->
                                                         <div class="d-grid gap-2" *ngIf="hasExistingFile(docType.id) && !hasNewFile(docType.id)">
-                                                            <button 
-                                                                type="button" 
+                                                            <button
+                                                                type="button"
                                                                 class="btn btn-outline-info"
                                                                 (click)="openFile(docType.id)"
                                                                 [disabled]="false">
                                                                 <i class="isax isax-eye me-1"></i>
-                                                                Ver archivo
+                                                                {{ 'request-provider.buttons.viewFile' | translate }}
                                                             </button>
-                                                            <button 
-                                                                type="button" 
+                                                            <button
+                                                                type="button"
                                                                 class="btn btn-outline-primary"
                                                                 (click)="triggerFileInput(docType.id)"
                                                                 [disabled]="dataRequestProvider.status !== 'Incomplete Information' && dataRequestProvider.status !== 'Pre-Approved'">
                                                                 <i class="isax isax-refresh me-1"></i>
-                                                                Cambiar {{ docType.name }}
+                                                                {{ 'request-provider.buttons.changeDocument' | translate: { name: docType.name } }}
                                                             </button>
-                                                            <button 
-                                                                type="button" 
+                                                            <button
+                                                                type="button"
                                                                 class="btn btn-outline-danger"
                                                                 (click)="removeDocumentFile(docType.id)"
                                                                 [disabled]="dataRequestProvider.status !== 'Incomplete Information' && dataRequestProvider.status !== 'Pre-Approved'">
                                                                 <i class="isax isax-trash me-1"></i>
-                                                                Eliminar
+                                                                {{ 'request-provider.buttons.remove' | translate }}
                                                             </button>
                                                         </div>
-                                                        
+
                                                         <!-- Botones para archivo nuevo -->
                                                         <div class="d-grid gap-2" *ngIf="hasNewFile(docType.id)">
-                                                            <button 
-                                                                type="button" 
+                                                            <button
+                                                                type="button"
                                                                 class="btn btn-outline-primary"
                                                                 (click)="triggerFileInput(docType.id)"
                                                                 [disabled]="dataRequestProvider.status !== 'Incomplete Information' && dataRequestProvider.status !== 'Pre-Approved'">
                                                                 <i class="isax isax-refresh me-1"></i>
-                                                                Cambiar {{ docType.name }}
+                                                                {{ 'request-provider.buttons.changeDocument' | translate: { name: docType.name } }}
                                                             </button>
-                                                            <button 
-                                                                type="button" 
+                                                            <button
+                                                                type="button"
                                                                 class="btn btn-outline-danger"
                                                                 (click)="removeDocumentFile(docType.id)"
                                                                 [disabled]="dataRequestProvider.status !== 'Incomplete Information' && dataRequestProvider.status !== 'Pre-Approved'">
                                                                 <i class="isax isax-trash me-1"></i>
-                                                                Eliminar
+                                                                {{ 'request-provider.buttons.remove' | translate }}
                                                             </button>
                                                         </div>
                                                     </div>
 
                                                     <!-- Input file oculto -->
-                                                    <input 
-                                                        type="file" 
+                                                    <input
+                                                        type="file"
                                                         class="d-none"
                                                         id="document-file-{{ docType.id }}"
                                                         accept=".pdf,.jpg,.jpeg,.png,.doc,.docx"
@@ -474,49 +461,49 @@
                                         <div class="row text-center">
                                             <div class="col-3">
                                                 <div class="h4 mb-1 text-primary">{{ getTotalDocumentTypes() }}</div>
-                                                <small class="text-muted">Total disponibles</small>
+                                                <small class="text-muted">{{ 'request-provider.documents.summary.totalAvailable' | translate }}</small>
                                             </div>
                                             <div class="col-3">
                                                 <div class="h4 mb-1 text-success">{{ getTotalLoadedDocuments() }}</div>
-                                                <small class="text-muted">Con archivos</small>
+                                                <small class="text-muted">{{ 'request-provider.documents.summary.withFiles' | translate }}</small>
                                             </div>
                                             <div class="col-3">
                                                 <div class="h4 mb-1 text-warning">{{ getTotalMandatoryPending() }}</div>
-                                                <small class="text-muted">Obligatorios pendientes</small>
+                                                <small class="text-muted">{{ 'request-provider.documents.summary.mandatoryPending' | translate }}</small>
                                             </div>
                                             <div class="col-3">
                                                 <div class="h4 mb-1 text-info">{{ getTotalReadyToSend() }}</div>
-                                                <small class="text-muted">Nuevos para enviar</small>
+                                                <small class="text-muted">{{ 'request-provider.documents.summary.readyToSend' | translate }}</small>
                                             </div>
                                         </div>
-                                        
+
                                         <!-- Información adicional sobre archivos eliminados -->
                                         <div class="row mt-2" *ngIf="agregarGaleria.deletedGalleries.length > 0">
                                             <div class="col-12 text-center">
                                                 <small class="text-danger">
                                                     <i class="isax isax-trash me-1"></i>
-                                                    {{ agregarGaleria.deletedGalleries.length }} archivo(s) marcado(s) para eliminar
+                                                    {{ 'request-provider.documents.summary.markedForDelete' | translate: { count: agregarGaleria.deletedGalleries.length } }}
                                                 </small>
                                             </div>
                                         </div>
-                                                
+
                                         <!-- Botón para guardar todos los documentos -->
                                         <div class="row mt-3">
                                             <div class="col-12 text-center">
-                                                <button 
+                                                <button
                                                     *ngIf="dataRequestProvider.status === 'Incomplete Information' || dataRequestProvider.status === 'Pre-Approved'"
-                                                    type="button" 
+                                                    type="button"
                                                     class="btn btn-success"
                                                     (click)="saveAllDocumentsToGallery()"
                                                     [disabled]="!canSendDocuments()">
                                                     <i class="isax isax-cloud-add me-2"></i>
-                                                    Enviar documentos al servidor
+                                                    {{ 'request-provider.buttons.sendToServer' | translate }}
                                                 </button>
                                                 <div class="mt-2">
                                                     <small class="text-muted">
                                                         {{ getDocumentStatusMessage() }}
                                                         <ng-container *ngIf="dataRequestProvider.status === 'Incomplete Information' || dataRequestProvider.status === 'Pre-Approved'">
-                                                            . Presiona este botón para enviarlos al servidor
+                                                            {{ 'request-provider.documents.summary.pressToSend' | translate }}
                                                         </ng-container>
                                                     </small>
                                                 </div>
@@ -532,7 +519,7 @@
             <!-- /Request Provider Form -->
 
         </div>
-        
+
         <!-- Cancelled State -->
         <div class="row" *ngIf="!isLoadingData && dataRequestProvider?.status === 'Cancelled'">
             <div class="col-12 text-center py-5 my-5">
@@ -540,14 +527,14 @@
                     <div class="mb-4">
                         <i class="isax isax-close-circle text-danger" style="font-size: 5rem;"></i>
                     </div>
-                    <h3 class="text-danger mb-3">Tu Solicitud ha sido Cancelada</h3>
+                    <h3 class="text-danger mb-3">{{ 'request-provider.cancelled.title' | translate }}</h3>
                     <p class="text-muted mb-4 fs-16">
-                        Lamentablemente tu solicitud de proveedor ha sido cancelada.<br><br>
-                        Motivo: <strong>{{ dataRequestProvider?.declinedReason || 'No especificado' }}</strong><br><br>
-                        Por favor, cierra sesión.
+                        {{ 'request-provider.cancelled.description' | translate }}<br><br>
+                        {{ 'request-provider.cancelled.reason' | translate }} <strong>{{ dataRequestProvider?.declinedReason || ('request-provider.cancelled.reasonUnspecified' | translate) }}</strong><br><br>
+                        {{ 'request-provider.cancelled.logoutInstruction' | translate }}
                     </p>
                     <button class="btn btn-primary btn-lg px-4 py-2" (click)="logout()">
-                        <i class="isax isax-logout me-2"></i> Cerrar sesión
+                        <i class="isax isax-logout me-2"></i> {{ 'request-provider.cancelled.logoutButton' | translate }}
                     </button>
                 </div>
             </div>
@@ -555,6 +542,3 @@
     </div>
 </div>
 <!-- /Page Wrapper -->
-
-
-

--- a/src/app/pages/providers/requestproviders/requestprovider.component.ts
+++ b/src/app/pages/providers/requestproviders/requestprovider.component.ts
@@ -51,9 +51,11 @@ export class RequestproviderComponent implements OnInit {
   requestProviderDocumentTypes: RequestProviderDocumentType[] = [];
   public routes = routes;
 
+  // FE-11: los labels son claves i18n que se resuelven con el pipe translate
+  // en el HTML del sidebar (ngx-translate).
   tabs = [
-    { id: "basic_info", label: "Basic Info" },
-    { id: "gallery", label: "Documents" },
+    { id: "basic_info", label: "request-provider.sidebar.basicInfo" },
+    { id: "gallery", label: "request-provider.sections.documents" },
   ];
 
   activeTab: string = this.tabs[0].id;


### PR DESCRIPTION
Reportado por Luis 2026-07-15: la pantalla de solicitud de proveedor estaba con textos hardcoded en ingles/espanol mezclados.

Cambios:
- Nueva seccion request-provider en public/i18n/{es,en,pt}.json con ~50 claves: breadcrumb, sidebar, loading, sections, fields, placeholders, validation, buttons, status, documents (workflow, badges, summary, formats), cancelled.
- requestprovider.component.html: reemplaza todos los textos hardcoded por pipes translate. Placeholders migrados a [placeholder] attribute binding. Validaciones (nameRequired, minLength, etc.) traducidas. Buttons con parametrizacion via interpolacion translate: uploadDocument y changeDocument reciben {name} del docType.
- requestprovider.component.ts: tabs[].label pasa de strings hardcoded ("Basic Info", "Documents") a claves i18n resueltas en el HTML.

Sin cambios funcionales — solo idioma.
SharedModule ya expone TranslateModule (importado por el modulo). Los JSON validados con JSON.parse.

Cierra deuda FE-11 registrada 2026-07-15.