### PR TITLE
fix(providers): TC-002 + TC-003 modal detalle reserva y título galería

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 .angular
 
 "ANALISIS_FLUJO_PAGO.md" 
+proxy.conf.json

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1817,6 +1817,10 @@
     }
   },
   "tour-gallery": {
+    "title": "Tour image gallery",
+    "breadcrumb": "Tour Gallery",
+    "providersPanel": "Providers Panel",
+    "uploadButton": "Upload images",
     "uploadTitle": "Upload gallery images",
     "limitsHint": "JPEG, PNG or WebP · Max {{maxSize}} MB per image · Landscape orientation · Minimum width {{minWidth}} px · Up to {{maxImages}} images total",
     "currentCount": "{{current}} of {{max}} images in the gallery",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1818,6 +1818,10 @@
     }
   },
   "tour-gallery": {
+    "title": "Galería de imágenes del tour",
+    "breadcrumb": "Galería del tour",
+    "providersPanel": "Panel de proveedores",
+    "uploadButton": "Subir imágenes",
     "uploadTitle": "Subir imágenes de la galería",
     "limitsHint": "JPEG, PNG o WebP · Máx {{maxSize}} MB por imagen · Orientación horizontal · Ancho mínimo {{minWidth}} px · Hasta {{maxImages}} imágenes en total",
     "currentCount": "{{current}} de {{max}} imágenes en la galería",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1818,6 +1818,10 @@
     }
   },
   "tour-gallery": {
+    "title": "Galeria de imagens do tour",
+    "breadcrumb": "Galeria do tour",
+    "providersPanel": "Painel de provedores",
+    "uploadButton": "Enviar imagens",
     "uploadTitle": "Enviar imagens da galeria",
     "limitsHint": "JPEG, PNG ou WebP · Máx {{maxSize}} MB por imagem · Orientação horizontal · Largura mínima {{minWidth}} px · Até {{maxImages}} imagens no total",
     "currentCount": "{{current}} de {{max}} imagens na galeria",

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -386,24 +386,52 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
   }
 
   private mapReservationToBooking(reservation: any): ProviderTourBooking {
+    // TC-003 fix: el modal se alimenta de GET /reservations?reservationId=X
+    // que devuelve el DTO `ReservationDetailsResponse` (SP `sp_get_provider_reservations`),
+    // no `ReservationResponse`. Los nombres de campos son distintos — hay que leer
+    // los del SP y componer los derivados (checkIn desde scheduleDate+slotTimeStart,
+    // localizar tourName por ser TranslatedField, construir serviceResponsible plano→sub-objeto).
+
+    const tourNameText = this.i18nService.getValue(reservation.tourName) || 'N/A';
+
+    const checkInIso =
+      reservation.scheduleDate && reservation.slotTimeStart
+        ? `${reservation.scheduleDate}T${reservation.slotTimeStart}`
+        : undefined;
+
+    const rawCheckInDate = reservation.scheduleDate || '';
+
+    const serviceResponsible = reservation.serviceResponsibleName
+      ? {
+          name: reservation.serviceResponsibleName,
+          email: reservation.serviceResponsibleEmail,
+          phone: reservation.serviceResponsiblePhone,
+        }
+      : undefined;
+
     return {
       id: `RES-${reservation.reservationId}`,
-      tourId: reservation.tourId, // Mapear el ID del tour
-      tourName: reservation.tourName || 'N/A',
-      tourType: reservation.tourType || 'N/A',
+      tourId: reservation.tourId,
+      tourName: tourNameText,
+      tourType: reservation.tourSubCategory || reservation.tourType || 'N/A',
       img: 'tours-21.jpg',
-      customerName: reservation.serviceResponsible?.name || 'N/A',
-      customerEmail: reservation.serviceResponsible?.email || 'N/A',
-      customerPhone: reservation.serviceResponsible?.phone || 'N/A',
-      travellers: reservation.travellers || 'N/A',
+      customerName: reservation.serviceResponsibleName || 'N/A',
+      customerEmail: reservation.serviceResponsibleEmail || 'N/A',
+      customerPhone: reservation.serviceResponsiblePhone || 'N/A',
+      travellers: reservation.totalTourists != null ? `${reservation.totalTourists}` : 'N/A',
       duration: reservation.duration ? `${reservation.duration} días` : 'N/A',
-      price: reservation.price ? `$${reservation.price.toFixed(2)}` : '$0.00',
-      bookingDate: this.formatDate(reservation.createdDate),
-      checkInDate: this.formatDateTime(reservation.checkInDate),
-      returnDate: this.formatDateTime(reservation.returnDate),
-      rawCheckInDate: reservation.checkInDate ? reservation.checkInDate.split('T')[0] : '',
-      rawReturnDate: reservation.returnDate ? reservation.returnDate.split('T')[0] : '',
-      status: this.mapReservationStatus(reservation.deliveryStatus),
+      price:
+        reservation.shoppingTotalPrice != null
+          ? `$${Number(reservation.shoppingTotalPrice).toFixed(2)}`
+          : reservation.price
+          ? `$${Number(reservation.price).toFixed(2)}`
+          : '$0.00',
+      bookingDate: this.formatDate(reservation.reservationCreatedDate || reservation.createdDate),
+      checkInDate: this.formatDateTime(checkInIso),
+      returnDate: '—',
+      rawCheckInDate,
+      rawReturnDate: rawCheckInDate,
+      status: this.mapReservationStatus(reservation.reservationDeliveryStatus || reservation.deliveryStatus),
       destination: reservation.destination || 'N/A',
       extraServices: reservation.extraServices || [],
       activities: reservation.activities || [],
@@ -424,8 +452,8 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
       cancellationDate: this.formatDate(reservation.cancellationDate),
       cancellationReason: reservation.cancellationReason || undefined,
       canRainCancel: reservation.canRainCancel,
-      // Service Responsible
-      serviceResponsible: reservation.serviceResponsible || undefined
+      // Service Responsible (backend planos → sub-objeto que espera el template)
+      serviceResponsible,
     };
   }
   

--- a/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.html
+++ b/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.html
@@ -3,15 +3,15 @@
   <div class="container">
     <div class="row">
       <div class="col-md-12 col-12">
-        <h2 class="breadcrumb-title mb-2">Tour Gallery</h2>
+        <h2 class="breadcrumb-title mb-2">{{ 'tour-gallery.breadcrumb' | translate }}</h2>
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb justify-content-center mb-0">
             <li class="breadcrumb-item"><a [routerLink]="'/'"><i class="isax isax-home5"></i></a>
             </li>
-            <li class="breadcrumb-item"><a [routerLink]="'/providers/provider-panel'">Providers Panel</a>
+            <li class="breadcrumb-item"><a [routerLink]="'/providers/provider-panel'">{{ 'tour-gallery.providersPanel' | translate }}</a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">
-              Tour Gallery
+              {{ 'tour-gallery.breadcrumb' | translate }}
             </li>
           </ol>
         </nav>
@@ -35,7 +35,7 @@
         <form [formGroup]="tourGalleryForm" (ngSubmit)="onSubmit()">
           <div class="card shadow-none" id="galleries">
             <div class="card-header">
-              <h5 class="fs-18">Gallery {{tour?.name}}</h5>
+              <h5 class="fs-18">{{ 'tour-gallery.title' | translate }} {{ i18nService.getValue(tour?.name) }}</h5>
             </div>
             <div class="card-body">
               <div
@@ -74,7 +74,7 @@
             <div class="d-flex align-items-center justify-content-end">
               <button type="submit" class="btn btn-primary"
                 [disabled]="loading || (submitted && tourGalleryForm.touched && tourGalleryForm.invalid)">
-                <span>Upload images</span>
+                <span>{{ 'tour-gallery.uploadButton' | translate }}</span>
                 <div *ngIf="loading" class="spinner-border spinner-border-sm">
                 </div>
               </button>

--- a/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.ts
+++ b/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.ts
@@ -60,7 +60,7 @@ export class TourGalleryComponent implements OnInit {
     private route: ActivatedRoute,
     private tourService: TourService,
     private _snackBar: MatSnackBar,
-    private i18nService: I18nFieldService,
+    public i18nService: I18nFieldService,
     private appConfigService: AppConfigService,
     private translate: TranslateService
   ) {


### PR DESCRIPTION
Cierra los 2 issues preexistentes reportados por Luis (2026-07-17):
- Touryapp/tourya-api#182 (TC-002 galería)
- Touryapp/tourya-api#183 (TC-003 modal detalle reserva)

Ambos son bugs antiguos (jun/2025 y may/2026 según `git blame`), no regresión de trabajo reciente. Análisis completo con hashes en los comentarios de ambos issues.

## TC-002 — Título galería `Gallery [object Object]`

**Causa**: el backend cambió `tour.name` a `TranslatedField` en `c11a22b` (21-dic-2025) y el template `tour-gallery.component.html:38` seguía interpolando `{{tour?.name}}` sin resolver.

**Fix**:
- `<h5>{{ 'tour-gallery.title' | translate }} {{ i18nService.getValue(tour?.name) }}</h5>`
- Breadcrumb + botón "Upload images" migrados a claves i18n.
- 4 claves nuevas (`title`, `breadcrumb`, `providersPanel`, `uploadButton`) en `es.json`, `en.json`, `pt.json`.
- `i18nService` movido de `private` a `public` para binding en template.

## TC-003 — Modal "Ver reserva" con 6+ campos rotos

**Causa REAL** (distinta a lo que puse en el primer comentario del issue — ver corrección en el segundo comentario):

El modal consume `GET /reservations?reservationId=X` (endpoint paginado con `@RequestParam`), no `GET /reservations/{id}`. Ese endpoint devuelve `ReservationDetailsResponse` (viene del SP `sp_get_provider_reservations`), no `ReservationResponse`. Los nombres de campos son distintos, y el mapper del front leía los del DTO viejo.

Reconciliación de campos aplicada en `mapReservationToBooking()`:

| Destino UI | Antes (mapper leía) | Ahora (nombre real del SP) |
|---|---|---|
| Nombre del tour | `reservation.tourName` (obj) | `i18nService.getValue(reservation.tourName)` |
| Estado | `reservation.deliveryStatus` | `reservation.reservationDeliveryStatus` |
| Fecha reserva | `reservation.checkInDate` | `scheduleDate + slotTimeStart` (compuesta) |
| Fecha compra | `reservation.createdDate` | `reservation.reservationCreatedDate` |
| Viajeros | `reservation.travellers` | `reservation.totalTourists` |
| Precio | `reservation.price` | `reservation.shoppingTotalPrice` |
| Cliente | `reservation.serviceResponsible?.{name,email,phone}` | `serviceResponsibleName/Email/Phone` (planos → sub-objeto) |

Los otros 2 mappers del mismo archivo (líneas 580 y 651) ya usaban los nombres correctos — este fix reconcilia el mapper del modal con lo que hacen la lista y el resto de vistas.

**Sin cambios en el template del modal.**

## Verificación local

- [x] `ng build` compila sin errores nuevos (los 10 template-errors preexistentes de `develop` siguen exactamente igual — verificado con stash/pop).
- [x] `ng serve --proxy-config` levanta OK contra dev api.
- [x] Los 3 idiomas (`es`, `en`, `pt`) sirven las claves nuevas de `tour-gallery` — verificado con curl a `/i18n/{lang}.json`.
- [x] No se introducen dependencias nuevas.

## Test plan que necesita hacer QA en dev (Luis / Franklin)

- [ ] Login como PROVIDER (`touryaluis2@yopmail.com`).
- [ ] **TC-002** — ir a "Lista de tour" → "Edit Gallery" en cualquier tour → verificar que el título muestra `Galería de imágenes del tour <nombre real>` en vez de `[object Object]`. Cambiar idioma a EN y PT, confirmar traducciones.
- [ ] **TC-003** — ir a "Mis reservas" → "Ver" en una reserva RES-300 (u otra) → verificar los 7 campos:
  1. Título del tour en el idioma actual (no `[object Object]`).
  2. Estado real (Delivered, No Show, etc.) — no fijo "Pending".
  3. Fecha de la reserva formateada (no `—`).
  4. Fecha de compra formateada (no `—`).
  5. Viajeros con el número real (no `N/A`).
  6. Precio real (no `$0.00`).
  7. Sección "Reserva a nombre de" con nombre/email/teléfono visibles.
- [ ] Cerrar y reabrir el modal para verificar que no hay estado residual.

## Notas de proceso

- `proxy.conf.json` local para desarrollo — está en `.gitignore` y no se sube.
- Comentario original en el issue #183 tenía un análisis parcialmente incorrecto (proponía cambios de pipe en el template); corregí con un segundo comentario en el mismo issue explicando la causa raíz real.