### PR TITLE
feat(providers): BE-22b + BE-22d frontend + i18n tour-list

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1837,6 +1837,31 @@
       "genericTitle": "Could not save the gallery"
     }
   },
+  "tour-list": {
+    "breadcrumbTitle": "Tours",
+    "breadcrumbTours": "Tours",
+    "breadcrumbActive": "Tour list",
+    "resultsFound": "{{total}} tours found",
+    "price": "Price",
+    "actions": {
+      "editTour": "Edit tour",
+      "editGallery": "Edit gallery",
+      "listSchedule": "Schedule",
+      "principalContact": "Primary contact"
+    },
+    "snack": {
+      "tourAdded": "Tour added successfully",
+      "tourEdited": "Tour successfully edited"
+    },
+    "principalModal": {
+      "title": "Primary contact of the tour",
+      "help": "Select the operator who will be the primary contact for this tour. By default, the provider is the primary contact.",
+      "loading": "Loading operators…",
+      "noOperators": "This tour has no operators assigned yet. ",
+      "goToOperators": "Go to My operators",
+      "currentBadge": "Current"
+    }
+  },
   "request-provider": {
     "breadcrumb": "Provider Request",
     "sidebar": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1838,6 +1838,31 @@
       "genericTitle": "No se pudo guardar la galería"
     }
   },
+  "tour-list": {
+    "breadcrumbTitle": "Tours",
+    "breadcrumbTours": "Tours",
+    "breadcrumbActive": "Lista de tours",
+    "resultsFound": "{{total}} tours encontrados",
+    "price": "Precio",
+    "actions": {
+      "editTour": "Editar tour",
+      "editGallery": "Editar galería",
+      "listSchedule": "Programación",
+      "principalContact": "Contacto principal"
+    },
+    "snack": {
+      "tourAdded": "Tour agregado correctamente",
+      "tourEdited": "Tour editado correctamente"
+    },
+    "principalModal": {
+      "title": "Contacto principal del tour",
+      "help": "Marca al operador que será el contacto principal de este tour. Por default, el proveedor es el contacto principal.",
+      "loading": "Cargando operadores…",
+      "noOperators": "Este tour no tiene operadores asignados aún. ",
+      "goToOperators": "Ir a Mis operarios",
+      "currentBadge": "Actual"
+    }
+  },
   "request-provider": {
     "breadcrumb": "Solicitud de proveedor",
     "sidebar": {

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1838,6 +1838,31 @@
       "genericTitle": "Não foi possível salvar a galeria"
     }
   },
+  "tour-list": {
+    "breadcrumbTitle": "Tours",
+    "breadcrumbTours": "Tours",
+    "breadcrumbActive": "Lista de tours",
+    "resultsFound": "{{total}} tours encontrados",
+    "price": "Preço",
+    "actions": {
+      "editTour": "Editar tour",
+      "editGallery": "Editar galeria",
+      "listSchedule": "Agenda",
+      "principalContact": "Contato principal"
+    },
+    "snack": {
+      "tourAdded": "Tour adicionado com sucesso",
+      "tourEdited": "Tour editado com sucesso"
+    },
+    "principalModal": {
+      "title": "Contato principal do tour",
+      "help": "Marque o operador que será o contato principal deste tour. Por padrão, o provedor é o contato principal.",
+      "loading": "Carregando operadores…",
+      "noOperators": "Este tour ainda não tem operadores atribuídos. ",
+      "goToOperators": "Ir para Meus operadores",
+      "currentBadge": "Atual"
+    }
+  },
   "request-provider": {
     "breadcrumb": "Solicitação de fornecedor",
     "sidebar": {

--- a/src/app/pages/providers/provider-users/provider-users.component.html
+++ b/src/app/pages/providers/provider-users/provider-users.component.html
@@ -240,6 +240,20 @@
               </div>
 
               <div class="col-md-6">
+                <label class="form-label">Teléfono <small class="text-muted">(opcional)</small></label>
+                <input
+                  type="tel"
+                  formControlName="phone"
+                  class="form-control"
+                  placeholder="+57 300 123 4567"
+                  maxlength="20"
+                >
+                <small class="text-muted d-block mt-1">
+                  <i class="isax isax-info-circle me-1"></i>Se usa como contacto principal del tour cuando este operador esté marcado como tal.
+                </small>
+              </div>
+
+              <div class="col-md-6">
                 <label class="form-label">
                   Contraseña temporal <span class="text-danger">*</span>
                   <small class="text-muted ms-1">(mín. 8 caracteres)</small>
@@ -365,6 +379,20 @@
                   [class.is-invalid]="editForm.get('lastname')?.invalid && editForm.get('lastname')?.touched"
                 >
                 <div class="invalid-feedback">El apellido es obligatorio (mínimo 2 caracteres).</div>
+              </div>
+
+              <div class="col-md-6">
+                <label class="form-label">Teléfono <small class="text-muted">(opcional)</small></label>
+                <input
+                  type="tel"
+                  formControlName="phone"
+                  class="form-control"
+                  placeholder="+57 300 123 4567"
+                  maxlength="20"
+                >
+                <small class="text-muted d-block mt-1">
+                  <i class="isax isax-info-circle me-1"></i>Contacto principal del tour cuando este operador esté marcado como tal.
+                </small>
               </div>
 
               <div class="col-md-12">

--- a/src/app/pages/providers/provider-users/provider-users.component.ts
+++ b/src/app/pages/providers/provider-users/provider-users.component.ts
@@ -84,6 +84,8 @@ export class ProviderUsersComponent implements OnInit, OnDestroy {
       firstname: ['', [Validators.required, Validators.minLength(2)]],
       lastname: ['', [Validators.required, Validators.minLength(2)]],
       email: ['', [Validators.required, Validators.email]],
+      // BE-22d: telefono opcional.
+      phone: ['', [Validators.maxLength(20)]],
       temporaryPassword: ['', [Validators.required, Validators.minLength(8)]],
       tourIds: [[], Validators.required],
       principalTourId: [null, Validators.required]
@@ -92,6 +94,8 @@ export class ProviderUsersComponent implements OnInit, OnDestroy {
     this.editForm = this.fb.group({
       firstname: ['', [Validators.required, Validators.minLength(2)]],
       lastname: ['', [Validators.required, Validators.minLength(2)]],
+      // BE-22d: telefono opcional.
+      phone: ['', [Validators.maxLength(20)]],
       tourIds: [[], Validators.required],
       principalTourId: [null, Validators.required]
     });
@@ -194,7 +198,7 @@ export class ProviderUsersComponent implements OnInit, OnDestroy {
   // ── Apertura de modales ───────────────────────────────────────────────────
 
   openCreateModal(): void {
-    this.createForm.reset({ tourIds: [], principalTourId: null });
+    this.createForm.reset({ tourIds: [], principalTourId: null, phone: '' });
     this.errorMessage = '';
     this.activeModal = 'create';
   }
@@ -209,6 +213,7 @@ export class ProviderUsersComponent implements OnInit, OnDestroy {
     this.editForm.patchValue({
       firstname,
       lastname,
+      phone: user.phone ?? '',
       tourIds,
       principalTourId: principal?.tourId ?? null
     });

--- a/src/app/pages/providers/tours/tour-list/tour-list.component.html
+++ b/src/app/pages/providers/tours/tour-list/tour-list.component.html
@@ -3,13 +3,13 @@
     <div class="container">
         <div class="row">
             <div class="col-md-12 col-12">
-                <h2 class="breadcrumb-title mb-2">Tours</h2>
+                <h2 class="breadcrumb-title mb-2">{{ 'tour-list.breadcrumbTitle' | translate }}</h2>
                 <nav aria-label="breadcrumb">
                     <ol class="breadcrumb justify-content-center mb-0">
                         <li class="breadcrumb-item"><a [routerLink]="'/'"><i class="isax isax-home5"></i></a>
                         </li>
-                        <li class="breadcrumb-item"><a [routerLink]="'/providers/tours'">Tours</a></li>
-                        <li class="breadcrumb-item active" aria-current="page">Tour List</li>
+                        <li class="breadcrumb-item"><a [routerLink]="'/providers/tours'">{{ 'tour-list.breadcrumbTours' | translate }}</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">{{ 'tour-list.breadcrumbActive' | translate }}</li>
                     </ol>
                 </nav>
             </div>
@@ -28,7 +28,7 @@
 
             <div class="col-xl-9 col-lg-9">
                 <div class="d-flex align-items-center justify-content-between flex-wrap">
-                    <h6 class="mb-3">{{totalElements}} Tours Found on Your Search</h6>
+                    <h6 class="mb-3">{{ 'tour-list.resultsFound' | translate: { total: totalElements } }}</h6>
                 </div>
 
                 <div class="hotel-list">
@@ -96,21 +96,25 @@
                                         <div class="d-flex align-items-center">
                                             <h6
                                                 class="d-flex align-items-center text-gray-6 fs-14 fw-normal border-end pe-2 me-2">
-                                                Price
+                                                {{ 'tour-list.price' | translate }}
                                                 <span class="ms-1 fs-18 fw-semibold text-primary">
                                                     {{tour?.price}}</span>
 
                                             </h6>
 
-                                            <a class="me-2" [routerLink]="[routes.editTour, tour.id]">Edit tour</a>
+                                            <a class="me-2" [routerLink]="[routes.editTour, tour.id]">{{ 'tour-list.actions.editTour' | translate }}</a>
 
                                             <a class="me-2" [routerLink]="['/providers/tours/galleries', tour.id]">
-                                                Edit Gallery
+                                                {{ 'tour-list.actions.editGallery' | translate }}
                                             </a>
 
                                             <a class="me-2"
                                                 [routerLink]="['/providers/tours/' + tour.id + '/tour-schedule-list']">
-                                                List Schedule
+                                                {{ 'tour-list.actions.listSchedule' | translate }}
+                                            </a>
+
+                                            <a class="me-2" href="javascript:void(0)" (click)="openPrincipalModal(tour)">
+                                                {{ 'tour-list.actions.principalContact' | translate }}
                                             </a>
 
                                         </div>
@@ -157,3 +161,11 @@
     </div>
 </div>
 <!-- /Page Wrapper -->
+
+<!-- BE-22b: modal contacto principal del tour -->
+<app-tour-principal-operator-modal
+  [tourId]="selectedTourIdForPrincipal"
+  [tourName]="selectedTourNameForPrincipal"
+  [showModal]="principalModalOpen"
+  (closeModal)="closePrincipalModal()">
+</app-tour-principal-operator-modal>

--- a/src/app/pages/providers/tours/tour-list/tour-list.component.ts
+++ b/src/app/pages/providers/tours/tour-list/tour-list.component.ts
@@ -6,6 +6,7 @@ import { TourService } from "../tour.service";
 import { Tour } from "../../../../shared/dto/tour-response.dto";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { I18nFieldService } from "../../../../shared/services/i18n-field.service";
+import { TranslateService } from "@ngx-translate/core";
 
 @Component({
   selector: "app-tour-list",
@@ -24,12 +25,18 @@ export class TourListComponent implements OnInit {
   totalElements: number = 0;
   totalPages: number = 0;
 
+  // BE-22b: estado del modal "Contacto principal"
+  principalModalOpen: boolean = false;
+  selectedTourIdForPrincipal: number | null = null;
+  selectedTourNameForPrincipal: string = '';
+
   constructor(
     private router: Router,
     private route: ActivatedRoute,
     private tourService: TourService,
     private _snackBar: MatSnackBar,
-    public i18nService: I18nFieldService
+    public i18nService: I18nFieldService,
+    private translate: TranslateService
   ) {}
 
   ngOnInit(): void {
@@ -38,9 +45,9 @@ export class TourListComponent implements OnInit {
     const edited = !!this.route.snapshot.queryParamMap.get("edited");
 
     if (added) {
-      this.openSnackBar("Tour added successfully");
+      this.openSnackBar(this.translate.instant('tour-list.snack.tourAdded'));
     } else if (edited) {
-      this.openSnackBar("Tour successfully edited");
+      this.openSnackBar(this.translate.instant('tour-list.snack.tourEdited'));
     }
 
     this.router.navigate([], { queryParams: null });
@@ -100,6 +107,21 @@ export class TourListComponent implements OnInit {
 
   toggleClass(index: number) {
     this.isClassAdded[index] = !this.isClassAdded[index];
+  }
+
+  /**
+   * BE-22b: abre el modal para asignar el operador principal del tour.
+   */
+  openPrincipalModal(tour: Tour): void {
+    this.selectedTourIdForPrincipal = tour.id;
+    this.selectedTourNameForPrincipal = this.i18nService.getValue(tour?.name) || '';
+    this.principalModalOpen = true;
+  }
+
+  closePrincipalModal(): void {
+    this.principalModalOpen = false;
+    this.selectedTourIdForPrincipal = null;
+    this.selectedTourNameForPrincipal = '';
   }
 
   selectClass(index: number): void {

--- a/src/app/pages/providers/tours/tour-list/tour-list.module.ts
+++ b/src/app/pages/providers/tours/tour-list/tour-list.module.ts
@@ -3,11 +3,12 @@ import { CommonModule } from "@angular/common";
 
 import { TourListRoutingModule } from "./tour-list-routing.module";
 import { TourListComponent } from "./tour-list.component";
+import { TourPrincipalOperatorModalComponent } from "./tour-principal-operator-modal/tour-principal-operator-modal.component";
 import { MatSliderModule } from "@angular/material/slider";
 import { SharedModule } from "../../../../shared/shared-module";
 
 @NgModule({
-  declarations: [TourListComponent],
+  declarations: [TourListComponent, TourPrincipalOperatorModalComponent],
   imports: [CommonModule, TourListRoutingModule, SharedModule, MatSliderModule],
 })
 export class TourListModule {}

--- a/src/app/pages/providers/tours/tour-list/tour-principal-operator-modal/tour-principal-operator-modal.component.html
+++ b/src/app/pages/providers/tours/tour-list/tour-principal-operator-modal/tour-principal-operator-modal.component.html
@@ -1,0 +1,70 @@
+<div class="modal fade show d-block" tabindex="-1" *ngIf="showModal" style="background: rgba(0,0,0,0.5);">
+  <div class="modal-dialog modal-dialog-centered modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">
+          {{ 'tour-list.principalModal.title' | translate }}
+          <span *ngIf="tourName" class="text-muted fs-14 fw-normal">— {{ tourName }}</span>
+        </h5>
+        <button type="button" class="btn-close" (click)="close()" [disabled]="saving"></button>
+      </div>
+      <div class="modal-body">
+        <p class="text-muted fs-14">
+          {{ 'tour-list.principalModal.help' | translate }}
+        </p>
+
+        <div *ngIf="loading" class="text-center py-3">
+          <div class="spinner-border spinner-border-sm text-primary"></div>
+          <span class="ms-2">{{ 'tour-list.principalModal.loading' | translate }}</span>
+        </div>
+
+        <div *ngIf="!loading && operators.length === 0" class="alert alert-info">
+          {{ 'tour-list.principalModal.noOperators' | translate }}
+          <a routerLink="/providers/users">{{ 'tour-list.principalModal.goToOperators' | translate }}</a>
+        </div>
+
+        <div *ngIf="!loading && operators.length > 0" class="list-group">
+          <label
+            *ngFor="let op of operators"
+            class="list-group-item d-flex align-items-center gap-3"
+            [class.active]="selectedPrincipalId === op.providerUserId"
+            style="cursor: pointer;">
+            <input
+              type="radio"
+              name="principalOperator"
+              class="form-check-input mt-0"
+              [checked]="selectedPrincipalId === op.providerUserId"
+              (change)="select(op.providerUserId)" />
+            <div class="flex-grow-1">
+              <div class="fw-medium">{{ op.fullName }}</div>
+              <div class="text-muted fs-13">
+                {{ op.email }}
+                <span *ngIf="op.phone"> · {{ op.phone }}</span>
+              </div>
+            </div>
+            <span *ngIf="op.providerUserId === originalPrincipalId" class="badge bg-primary">
+              {{ 'tour-list.principalModal.currentBadge' | translate }}
+            </span>
+          </label>
+        </div>
+
+        <div *ngIf="errorMessage" class="alert alert-danger mt-3 mb-0 fs-14">
+          {{ errorMessage }}
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" (click)="close()" [disabled]="saving">
+          {{ 'shared.cancel' | translate }}
+        </button>
+        <button
+          type="button"
+          class="btn btn-primary"
+          (click)="save()"
+          [disabled]="saving || !isDirty() || selectedPrincipalId == null">
+          <span *ngIf="saving" class="spinner-border spinner-border-sm me-2"></span>
+          {{ 'shared.save' | translate }}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/providers/tours/tour-list/tour-principal-operator-modal/tour-principal-operator-modal.component.scss
+++ b/src/app/pages/providers/tours/tour-list/tour-principal-operator-modal/tour-principal-operator-modal.component.scss
@@ -1,0 +1,13 @@
+.list-group-item {
+  transition: background-color 0.15s ease;
+
+  &:hover:not(.active) {
+    background-color: var(--bs-gray-100);
+  }
+
+  &.active {
+    background-color: var(--bs-primary-bg-subtle);
+    color: inherit;
+    border-color: var(--bs-primary);
+  }
+}

--- a/src/app/pages/providers/tours/tour-list/tour-principal-operator-modal/tour-principal-operator-modal.component.ts
+++ b/src/app/pages/providers/tours/tour-list/tour-principal-operator-modal/tour-principal-operator-modal.component.ts
@@ -1,0 +1,99 @@
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { ProviderUsersService } from '../../../../../shared/services/provider-users.service';
+import { ProviderUser } from '../../../../../shared/models/provider-user.model';
+
+/**
+ * BE-22b: modal que se abre desde el card del tour para asignar el operador
+ * principal de ese tour. Lista operadores asignados (GET /provider/users/tour/{id}),
+ * permite marcar uno como principal (PUT /provider/users/{id}/principal-tour).
+ *
+ * Regla (RN-009 reescrita por Luis 2026-07-19): "por default, el PROVIDER es el
+ * contacto principal del tour". Si no hay operadores asignados, el modal muestra
+ * un mensaje explicativo con enlace a /providers/users para asignar operadores
+ * primero.
+ */
+@Component({
+  selector: 'app-tour-principal-operator-modal',
+  standalone: false,
+  templateUrl: './tour-principal-operator-modal.component.html',
+  styleUrls: ['./tour-principal-operator-modal.component.scss']
+})
+export class TourPrincipalOperatorModalComponent implements OnChanges {
+  @Input() tourId: number | null = null;
+  @Input() tourName: string = '';
+  @Input() showModal: boolean = false;
+  @Output() closeModal = new EventEmitter<void>();
+
+  operators: ProviderUser[] = [];
+  selectedPrincipalId: number | null = null;
+  originalPrincipalId: number | null = null;
+  loading: boolean = false;
+  saving: boolean = false;
+  errorMessage: string | null = null;
+
+  constructor(private providerUsersService: ProviderUsersService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['showModal'] && this.showModal && this.tourId != null) {
+      this.load();
+    }
+    if (changes['showModal'] && !this.showModal) {
+      this.reset();
+    }
+  }
+
+  private load(): void {
+    if (this.tourId == null) return;
+    this.loading = true;
+    this.errorMessage = null;
+    this.providerUsersService.listByTour(this.tourId).subscribe({
+      next: (list) => {
+        this.operators = list ?? [];
+        const principal = this.operators.find(op => op.tours?.some(t => t.isPrincipal));
+        this.originalPrincipalId = principal ? principal.providerUserId : null;
+        this.selectedPrincipalId = this.originalPrincipalId;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.loading = false;
+        this.errorMessage = err?.error?.message ?? 'Error cargando operadores';
+      }
+    });
+  }
+
+  select(operatorId: number): void {
+    this.selectedPrincipalId = operatorId;
+  }
+
+  isDirty(): boolean {
+    return this.selectedPrincipalId !== this.originalPrincipalId;
+  }
+
+  save(): void {
+    if (!this.isDirty() || this.selectedPrincipalId == null || this.tourId == null) return;
+    this.saving = true;
+    this.errorMessage = null;
+    this.providerUsersService.changePrincipalTour(this.selectedPrincipalId, this.tourId).subscribe({
+      next: () => {
+        this.saving = false;
+        this.originalPrincipalId = this.selectedPrincipalId;
+        this.close();
+      },
+      error: (err) => {
+        this.saving = false;
+        this.errorMessage = err?.error?.message ?? 'No se pudo guardar el cambio';
+      }
+    });
+  }
+
+  close(): void {
+    this.closeModal.emit();
+  }
+
+  private reset(): void {
+    this.operators = [];
+    this.selectedPrincipalId = null;
+    this.originalPrincipalId = null;
+    this.errorMessage = null;
+  }
+}

--- a/src/app/shared/models/provider-user.model.ts
+++ b/src/app/shared/models/provider-user.model.ts
@@ -9,6 +9,8 @@ export interface ProviderUser {
   userId: number;
   email: string;
   fullName: string;
+  /** BE-22d: telefono del operador. Nullable hasta que lo carguen. */
+  phone?: string | null;
   isPrimary: boolean;
   accountEnabled: boolean;
   mustChangePassword: boolean;
@@ -19,6 +21,8 @@ export interface CreateProviderUserRequest {
   firstname: string;
   lastname: string;
   email: string;
+  /** BE-22d: opcional. */
+  phone?: string | null;
   temporaryPassword: string;
   tourIds: number[];
   principalTourId: number;
@@ -27,6 +31,8 @@ export interface CreateProviderUserRequest {
 export interface UpdateProviderUserRequest {
   firstname: string;
   lastname: string;
+  /** BE-22d: se actualiza si viene. */
+  phone?: string | null;
   tourIds: number[];
   principalTourId: number;
 }

--- a/src/app/shared/services/provider-users.service.ts
+++ b/src/app/shared/services/provider-users.service.ts
@@ -52,4 +52,12 @@ export class ProviderUsersService {
     const params = new HttpParams().set('tourId', tourId.toString());
     return this.http.put<ProviderUser>(`${this.apiUrl}/${providerUserId}/principal-tour`, null, { params });
   }
+
+  /**
+   * BE-22c: GET /provider/users/tour/{tourId} — Lista operadores asignados a un tour
+   * (con flag isPrincipal por operador). Usado por el modal "Contacto principal" del card del tour.
+   */
+  listByTour(tourId: number): Observable<ProviderUser[]> {
+    return this.http.get<ProviderUser[]>(`${this.apiUrl}/tour/${tourId}`);
+  }
 }


### PR DESCRIPTION
Cierra la parte frontend de la respuesta de Luis a P1 (WhatsApp 2026-07-19):
- *"podría ser un botón en el card del tour que despliegue la lista de PROVIDER_OPERATOR y se marca el principal ✅"*
- *"en la creación del PROVIDER_OPERATOR puedes agregarle un campo (teléfono)"*

Backend correspondiente ya mergeado en **tourya-api PR #185**, migración `077_user_phone.sql` ya aplicada a Cloud SQL dev.

## Cambios

### BE-22b — Modal "Contacto principal" desde el card del tour

- Nuevo componente `TourPrincipalOperatorModalComponent` (patrón Bootstrap modal, mismo estilo que `ProviderPaymentDetailsModal` existente).
  - Lista operadores asignados al tour (llama `GET /provider/users/tour/{tourId}` — BE-22c).
  - Radio button por operador con badge "Actual" sobre el principal.
  - Botón "Guardar" deshabilitado hasta que haya cambio real.
  - Al guardar dispara `PUT /provider/users/{providerUserId}/principal-tour?tourId=X`.
- Nuevo link "Contacto principal" en el card del `tour-list`.
- Servicio `ProviderUsersService.listByTour(tourId)` que consume BE-22c.
- Manejo del caso **sin operadores**: mensaje "Este tour no tiene operadores asignados aún" + link a `/providers/users`. Respeta RN-009 reescrita por Luis: *"por default, el PROVIDER es el contacto principal"*.

### BE-22d frontend — Campo `phone` en operador

- `ProviderUser` + `CreateProviderUserRequest` + `UpdateProviderUserRequest` incluyen `phone` opcional.
- `provider-users.component`: nuevo FormControl `phone` en create + edit con input `type="tel"` + `maxlength=20` + helper text explicando que se usa como contacto principal del tour.
- Se prellena en edit desde `user.phone`.

### i18n `tour-list` — migración completa (deuda preexistente resuelta de paso)

Todo lo que estaba hardcoded en el template a i18n:

- Breadcrumb (`Tours`, `Tour List`).
- `{{totalElements}} Tours Found on Your Search` → parametrizado con `total`.
- `Price`, `Edit tour`, `Edit Gallery`, `List Schedule`, `Contacto principal`.
- Snackbar `Tour added successfully` / `Tour successfully edited` — usando `TranslateService.instant()`.
- Modal completo (título, help, loading, noOperators, goToOperators, currentBadge).
- Reusa `shared.cancel` + `shared.save` existentes.
- 3 idiomas (es/en/pt) sincronizados.

## Test plan

- [x] `ng build --configuration development` compila. 0 errores nuevos — los 10 template-errors que quedan son preexistentes en `develop` (mismos componentes: `TourAdminDetail`, `TourGridView`, `TourListView`, `ToursDetail`, `TourDetailsProvider`, `FloatingCart`, `TourSlotSelectionModal`), verificado con el conteo antes/después.
- [ ] Post-merge dev (Luis/Franklin):
  1. Login como PROVIDER → `/providers/tours` → card de un tour → click "Contacto principal".
  2. Modal abre con lista de operadores asignados y muestra badge "Actual" sobre quien sea el principal hoy.
  3. Cambiar la selección → botón "Guardar" se habilita → confirmar → modal cierra → reabrirlo y verificar que persistió.
  4. En `/providers/users` → crear operador nuevo con teléfono → el campo se guarda y aparece en el edit.
  5. Cambiar idioma a EN y PT → todos los labels traducen (breadcrumb, botones del card, modal).

## Backlog

- Cierra **BE-22b**, **BE-22d frontend** en `docs/17-backlog-implementacion.md`.
- Sigue pendiente **BE-22d mobile** (paridad opcional en MAUI para operarios).