### PR TITLE
fix(tour-list): guard null en openPrincipalModal (rompió build prod)

### DIFF
--- a/src/app/pages/providers/tours/tour-list/tour-list.component.ts
+++ b/src/app/pages/providers/tours/tour-list/tour-list.component.ts
@@ -113,6 +113,8 @@ export class TourListComponent implements OnInit {
    * BE-22b: abre el modal para asignar el operador principal del tour.
    */
   openPrincipalModal(tour: Tour): void {
+    // tour.id es `number | undefined` en el DTO; guard para no abrir el modal sin id.
+    if (tour?.id == null) return;
     this.selectedTourIdForPrincipal = tour.id;
     this.selectedTourNameForPrincipal = this.i18nService.getValue(tour?.name) || '';
     this.principalModalOpen = true;


### PR DESCRIPTION
## Contexto

El deploy Dev del 2026-07-20 ([run 29772951127](https://github.com/Touryapp/tourya-front/actions/runs/29772951127)) falló porque en el PR #67 introduje un error de tipos estrictos que solo el build **production** detecta:

\`\`\`
src/app/pages/providers/tours/tour-list/tour-list.component.ts:116:4
✘ [ERROR] TS2322: Type 'number | undefined' is not assignable to type 'number | null'.
    this.selectedTourIdForPrincipal = tour.id;
\`\`\`

`Tour.id` es `number | undefined` en el DTO. `selectedTourIdForPrincipal` está declarado como `number | null`. `ng build --configuration=development` (verifiqué localmente) no lo agarra, `production` sí.

## Fix

Early return si `tour.id == null` — sin id no tiene sentido abrir el modal (el endpoint `GET /provider/users/tour/{id}` sería 404).

## Verificación

\`\`\`
ng build --configuration=production
Output location: dist/template
\`\`\`

Sin errores nuevos.

## Aprendizaje

Correr `ng build --configuration=production` local antes de mergear cambios, no confiar solo en `--configuration=development`. Anotar como lección en memoria.