### PR TITLE
feat(auth): FE-15b — habilitar subset BACKOFFICE_OPERATION (P2 opción C)

### DIFF
--- a/src/app/core/guards/backoffice.guard.ts
+++ b/src/app/core/guards/backoffice.guard.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+/**
+ * FE-15b: guard permisivo que acepta ADMIN o BACKOFFICE_OPERATION.
+ *
+ * <p>Rutas del subset P2 opción C (Luis 2026-07-18): ver reservas, subir pagos,
+ * gestionar reportes DIMAR. Para rutas que deben ser ADMIN puro (dashboard admin,
+ * aprobar tours, editar comisión Tourya, app_config), seguir usando
+ * {@link import('./admin.guard').AdminGuard}.</p>
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class BackofficeGuard implements CanActivate {
+  constructor(
+    private authService: AuthService,
+    private router: Router
+  ) {}
+
+  canActivate(): boolean {
+    if (!this.authService.isAuthenticated()) {
+      this.router.navigate(['/']);
+      return false;
+    }
+
+    if (this.authService.isTouryaBackoffice()) {
+      return true;
+    }
+
+    this.router.navigate(['/']);
+    return false;
+  }
+}

--- a/src/app/core/guards/home-redirect.guard.ts
+++ b/src/app/core/guards/home-redirect.guard.ts
@@ -12,12 +12,24 @@ export class HomeRedirectGuard implements CanActivate {
   ) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    // Si está autenticado y es admin, redirigir al dashboard de admin
-    if (this.authService.isAuthenticated() && this.authService.isAdmin()) {
-      this.router.navigate(['/admin']);
-      return false; // Bloquear la navegación a home para admins
+    if (!this.authService.isAuthenticated()) {
+      return true;
     }
-    
+
+    // Si está autenticado y es admin, redirigir al dashboard de admin
+    if (this.authService.isAdmin()) {
+      this.router.navigate(['/admin']);
+      return false;
+    }
+
+    // FE-15b: BACKOFFICE_OPERATION va directo al panel de reservas (subset P2 —
+    // ver reservas es lo primero que necesitan al entrar). No debe ver el dashboard
+    // admin (que aún incluye acciones exclusivas de ADMIN).
+    if (this.authService.isBackofficeOperation()) {
+      this.router.navigate(['/admin/bookings-management']);
+      return false;
+    }
+
     // Para todos los demás usuarios, permitir acceso normal a home
     return true;
   }

--- a/src/app/pages/admin/admin-routing.module.ts
+++ b/src/app/pages/admin/admin-routing.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { AdminComponent } from './admin.component'; 
+import { AdminComponent } from './admin.component';
+import { AdminGuard } from '../../core/guards/admin.guard';
+import { BackofficeGuard } from '../../core/guards/backoffice.guard';
 
 const routes: Routes = [
   {
@@ -12,16 +14,21 @@ const routes: Routes = [
         redirectTo: 'dashboard',
         pathMatch: 'full'
       },
+      // FE-15b: dashboard y tour-admin (aprobar tours + comisión) siguen siendo ADMIN puro.
       {
         path: 'dashboard',
+        canActivate: [AdminGuard],
         loadChildren: () => import('./dashboard/dashboard.module').then(m => m.DashboardModule)
       },
       {
         path: 'tour-admin',
+        canActivate: [AdminGuard],
         loadChildren: () => import('./tour-admin/tour-admin.module').then(m => m.TourAdminModule)
       },
+      // FE-15b: bookings-management pasa a BackofficeGuard (subset P2 — "ver reservas").
       {
         path: 'bookings-management',
+        canActivate: [BackofficeGuard],
         loadChildren: () => import('../providers/provider-tour-management/provider-tour-management.module').then(m => m.ProviderTourManagementModule)
       }
     ]

--- a/src/app/pages/clients/tours-detail/tours-detail.component.ts
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.ts
@@ -224,7 +224,8 @@ export class ToursDetailComponent implements OnInit, OnDestroy, AfterViewChecked
     // Check if user is admin
   ngOnInit(): void {
     // Check if user is admin
-    this.isBackoffice = this.authService.isAdmin();
+    // FE-15b: ADMIN + BACKOFFICE_OPERATION (subset P2 — moderar reviews cae en "gestionar reportes").
+    this.isBackoffice = this.authService.isTouryaBackoffice();
 
     // Initialize component
     const idParam = this.route.snapshot.paramMap.get('id');

--- a/src/app/pages/providers/provider-panel/provider-panel.component.ts
+++ b/src/app/pages/providers/provider-panel/provider-panel.component.ts
@@ -210,7 +210,8 @@ export class ProviderPanelComponent implements OnInit {
       }
     };
 
-    if (this.authService.isAdmin()) {
+    // FE-15b: BACKOFFICE_OPERATION también puede subir pagos (P2 opción C).
+    if (this.authService.isTouryaBackoffice()) {
       this.payoutOrdersService.getAdminPayoutOrders(undefined, this.fromDate, this.toDate).subscribe(observer);
     } else {
       this.payoutOrdersService.getPayoutOrders(undefined, this.fromDate, this.toDate).subscribe(observer);
@@ -250,7 +251,9 @@ export class ProviderPanelComponent implements OnInit {
 
   goToReservation(reservationId: number): void {
     this.panelStateService.setReservationToOpen(reservationId);
-    if (this.authService.isAdmin()) {
+    // FE-15b: backoffice (ADMIN + BACKOFFICE_OPERATION) va al panel unificado
+    // /admin/bookings-management (P2 — "ver reservas de todos los providers").
+    if (this.authService.isTouryaBackoffice()) {
       this.router.navigate(['/admin/bookings-management']);
     } else {
       this.panelStateService.setView('reservas');

--- a/src/app/pages/providers/provider-payments/provider-payment-details-modal/provider-payment-details-modal.component.ts
+++ b/src/app/pages/providers/provider-payments/provider-payment-details-modal/provider-payment-details-modal.component.ts
@@ -54,7 +54,8 @@ export class ProviderPaymentDetailsModalComponent implements OnChanges {
     this.close();
     this.panelStateService.setReservationToOpen(reservationId);
     
-    if (this.authService.isAdmin()) {
+    // FE-15b: backoffice unificado (ADMIN + BACKOFFICE_OPERATION).
+    if (this.authService.isTouryaBackoffice()) {
       this.router.navigate(['/admin/bookings-management']);
     } else {
       this.panelStateService.setView('reservas');
@@ -74,7 +75,8 @@ export class ProviderPaymentDetailsModalComponent implements OnChanges {
       }
     };
 
-    if (this.authService.isAdmin()) {
+    // FE-15b: backoffice unificado (ADMIN + BACKOFFICE_OPERATION).
+    if (this.authService.isTouryaBackoffice()) {
       this.payoutOrdersService.getAdminPayoutOrderDetails(paymentId).subscribe(observer);
     } else {
       this.payoutOrdersService.getPayoutOrderDetails(paymentId).subscribe(observer);

--- a/src/app/pages/providers/provider-payments/provider-payments.component.html
+++ b/src/app/pages/providers/provider-payments/provider-payments.component.html
@@ -109,7 +109,7 @@
                                 <th mat-sort-header="amountTotal">Monto Total</th>
                                 <th mat-sort-header="status">Estado</th>
                                 <th>Comprobante</th>
-                                @if (authService.isAdmin()) {
+                                @if (authService.isTouryaBackoffice()) {
                                     <th>Acción</th>
                                 }
                             </tr>
@@ -136,7 +136,7 @@
                                             <span class="text-muted fs-12 italic">No disponible</span>
                                         }
                                     </td>
-                                    @if (authService.isAdmin()) {
+                                    @if (authService.isTouryaBackoffice()) {
                                         <td>
                                             @if (payment.status === 'PENDING') {
                                                 <div class="d-flex align-items-center gap-2">

--- a/src/app/pages/providers/provider-payments/provider-payments.component.ts
+++ b/src/app/pages/providers/provider-payments/provider-payments.component.ts
@@ -88,7 +88,8 @@ export class ProviderPaymentsComponent implements OnInit, OnDestroy {
       }
     };
 
-    if (this.authService.isAdmin()) {
+    // FE-15b: backoffice unificado (ADMIN + BACKOFFICE_OPERATION) usa la vista admin.
+    if (this.authService.isTouryaBackoffice()) {
       this.payoutOrdersService.getAdminPayoutOrders(this.selectedStatus, this.fromDate, this.toDate).subscribe(observer);
     } else {
       this.payoutOrdersService.getPayoutOrders(this.selectedStatus, this.fromDate, this.toDate).subscribe(observer);

--- a/src/app/pages/providers/provider-reviews/provider-reviews.component.ts
+++ b/src/app/pages/providers/provider-reviews/provider-reviews.component.ts
@@ -123,13 +123,14 @@ export class ProviderReviewsComponent implements OnInit, OnChanges {
 
   ngOnInit(): void {
     // Detectar roles del usuario con lógica de exclusividad
-    // Prioridad: Admin > Provider > User
+    // Prioridad: Backoffice (ADMIN o BACKOFFICE_OPERATION) > Provider > User
+    // FE-15b: BACKOFFICE_OPERATION también puede consultar reviews (subset P2).
     const isUser = this.authService.isUser();
     const isProvider = this.authService.isProvider();
-    const isAdmin = this.authService.isAdmin();
-    
+    const isBackoffice = this.authService.isTouryaBackoffice();
+
     // Asignar rol exclusivo según prioridad
-    if (isAdmin) {
+    if (isBackoffice) {
       this.isBackoffice = true;
       this.isProveedor = false;
       this.isCliente = false;


### PR DESCRIPTION
Cierra el andamio FE-15 (PR #66 mergeado) con el reemplazo por pantalla del subset autorizado por Luis en WhatsApp 2026-07-18: **ver reservas, subir pagos, gestionar reportes DIMAR**.

Backend correspondiente ya mergeado en **tourya-api PR #186**.

## Cambios

### Nuevo guard
- `BackofficeGuard` (`core/guards/backoffice.guard.ts`) — permite ADMIN o BACKOFFICE_OPERATION.

### Rutas admin (`admin-routing.module.ts`)
| Ruta | Guard antes | Guard ahora | Motivo |
|---|---|---|---|
| `/admin/dashboard` | (sin guard) | `AdminGuard` | ADMIN puro — métricas de plataforma |
| `/admin/tour-admin` | (sin guard) | `AdminGuard` | ADMIN puro — aprobar tours + editar comisión |
| `/admin/bookings-management` | (sin guard) | `BackofficeGuard` | Subset P2 — ver reservas |

Nota: los 3 hijos hoy no tenían guards individuales, hereden el que le apliquemos. Es una mejora de seguridad además de habilitar BACKOFFICE.

### Reemplazos `isAdmin()` → `isTouryaBackoffice()` (5 componentes autorizados)

| Archivo | Uso |
|---|---|
| `tours-detail.component.ts:227` | Ver reviews CANCELED + moderar |
| `provider-reviews.component.ts:129` | Filtros provider + responder review |
| `provider-panel.component.ts:213` | Invocar endpoint admin de payouts |
| `provider-panel.component.ts:253` | Redirect a `/admin/bookings-management` |
| `provider-payment-details-modal:57,77` | Invocar admin details + navigate |
| `provider-payments.component.ts:91` | Invocar admin list de payouts |
| `provider-payments.component.html:112,139` | Mostrar sección admin del módulo pagos |

### `home-redirect.guard.ts`
- ADMIN → `/admin` (dashboard con métricas).
- BACKOFFICE_OPERATION → `/admin/bookings-management` (subset directo).
- Cliente / provider → home normal.

### NO se tocan
- `app.component.ts:64` — redirect si es provider (contexto distinto).
- `provider-tour-management.component.ts:223, 495` — acciones específicas ADMIN sobre reservas — auditar caso por caso en un fix posterior si Luis pide.
- `tour-schedule.component.html:83` — el flag `isBackoffice` de ese componente ya funciona OK; el provider-panel ya no lleva a schedules siendo backoffice.

## Test plan

- [x] `ng build --configuration=production` limpio (aprendizaje del hotfix #68: siempre production local).
- [ ] Post-merge dev — login como `BACKOFFICE_OPERATION`:
  1. Redirect post-login → `/admin/bookings-management` (no home).
  2. Puede ver reservas cross-provider.
  3. Puede acceder al módulo de pagos y subir comprobantes.
  4. Puede ver / responder reseñas y ver las canceladas en `tours-detail`.
  5. **No** puede acceder a `/admin/dashboard` ni `/admin/tour-admin` (bloqueado por `AdminGuard`).
- [ ] Post-merge dev — login como ADMIN:
  6. Todo lo anterior + acceso al dashboard admin + tour-admin (sin cambio).
- [ ] Post-merge dev — login como CLIENT o PROVIDER:
  7. Sin cambios de comportamiento.

## Backlog

- Cierra **FE-15b** (respuesta P2 opción C completa: backend PR #186 + este frontend PR).
- Sigue pendiente **FE-15c** opcional: UI backoffice para gestionar reportes DIMAR (hoy backend acepta el rol pero no hay UI dedicada — BACKOFFICE puede pegar directo al backend).