### PR TITLE
feat(fe-15c): expose UI reportes DIMAR al rol BACKOFFICE_OPERATION

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1958,5 +1958,15 @@
       "logoutInstruction": "Please log out.",
       "logoutButton": "Log out"
     }
+  },
+  "maritime-reports": {
+    "link": "DIMAR Reports",
+    "confirm_red": {
+      "title": "Publish red flag?",
+      "body": "Active bookings for tours in the selected area and dates will be cancelled automatically. Customers will receive compensatory credit.",
+      "irreversible": "This action cannot be undone.",
+      "cancel_btn": "Cancel",
+      "confirm_btn": "Yes, publish red flag"
+    }
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1959,5 +1959,15 @@
       "logoutInstruction": "Por favor, cierra sesión.",
       "logoutButton": "Cerrar sesión"
     }
+  },
+  "maritime-reports": {
+    "link": "Reportes DIMAR",
+    "confirm_red": {
+      "title": "¿Publicar bandera roja?",
+      "body": "Se cancelarán automáticamente las reservas activas de tours en la zona y fechas seleccionadas. Los clientes recibirán crédito compensatorio.",
+      "irreversible": "Esta acción no se puede deshacer.",
+      "cancel_btn": "Cancelar",
+      "confirm_btn": "Sí, publicar bandera roja"
+    }
   }
 }

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1959,5 +1959,15 @@
       "logoutInstruction": "Por favor, encerre a sessão.",
       "logoutButton": "Encerrar sessão"
     }
+  },
+  "maritime-reports": {
+    "link": "Relatórios DIMAR",
+    "confirm_red": {
+      "title": "Publicar bandeira vermelha?",
+      "body": "As reservas ativas de passeios na zona e datas selecionadas serão canceladas automaticamente. Os clientes receberão crédito compensatório.",
+      "irreversible": "Esta ação não pode ser desfeita.",
+      "cancel_btn": "Cancelar",
+      "confirm_btn": "Sim, publicar bandeira vermelha"
+    }
   }
 }

--- a/src/app/pages/admin/admin-routing.module.ts
+++ b/src/app/pages/admin/admin-routing.module.ts
@@ -30,6 +30,12 @@ const routes: Routes = [
         path: 'bookings-management',
         canActivate: [BackofficeGuard],
         loadChildren: () => import('../providers/provider-tour-management/provider-tour-management.module').then(m => m.ProviderTourManagementModule)
+      },
+      // FE-15c: reportes DIMAR expuestos al rol BACKOFFICE_OPERATION.
+      {
+        path: 'maritime-reports',
+        canActivate: [BackofficeGuard],
+        loadComponent: () => import('../maritime-activity-reports/maritime-activity-reports.component').then(m => m.MaritimeActivityReportsComponent)
       }
     ]
   }

--- a/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.html
+++ b/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.html
@@ -198,7 +198,7 @@
           <button type="button" class="btn-close" (click)="closeModal()" aria-label="Close"></button>
         </div>
         <div class="modal-body p-4">
-          <form [formGroup]="reportForm" (ngSubmit)="saveReport()" id="reportForm">
+          <form [formGroup]="reportForm" (ngSubmit)="attemptSave()" id="reportForm">
             <div class="row g-3">
               <div class="col-md-4">
                 <div class="mb-3">
@@ -270,6 +270,40 @@
           </button>
           <button type="submit" form="reportForm" class="btn btn-primary px-4" [disabled]="reportForm.invalid">
             {{ isEditMode ? 'Actualizar' : 'Guardar' }} Reporte
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- FE-15c: Confirmación explícita para bandera roja (dispara BE-23: cancela reservas activas). -->
+<div *ngIf="showRedConfirmModal">
+  <div class="modal-backdrop fade show" style="z-index: 1060;"></div>
+  <div class="modal fade show d-block" tabindex="-1" style="z-index: 1065;">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content border-0 shadow-lg">
+        <div class="modal-header bg-danger-light border-0">
+          <h5 class="modal-title text-danger">
+            <i class="isax isax-warning-2 me-2"></i>{{ 'maritime-reports.confirm_red.title' | translate }}
+          </h5>
+          <button type="button" class="btn-close" (click)="cancelRedConfirm()" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <div class="alert alert-danger d-flex align-items-start mb-0" role="alert">
+            <i class="isax isax-info-circle fs-4 me-2 mt-1"></i>
+            <div>
+              <p class="mb-1 fw-medium">{{ 'maritime-reports.confirm_red.body' | translate }}</p>
+              <p class="mb-0 fs-14">{{ 'maritime-reports.confirm_red.irreversible' | translate }}</p>
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer border-0">
+          <button type="button" class="btn btn-secondary" (click)="cancelRedConfirm()">
+            {{ 'maritime-reports.confirm_red.cancel_btn' | translate }}
+          </button>
+          <button type="button" class="btn btn-danger" (click)="confirmRedAndSave()">
+            <i class="isax isax-flag me-1"></i>{{ 'maritime-reports.confirm_red.confirm_btn' | translate }}
           </button>
         </div>
       </div>

--- a/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.ts
+++ b/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.ts
@@ -68,6 +68,10 @@ export class MaritimeActivityReportsComponent implements OnInit {
 
   // Enums for UI
   maritimeFlags = Object.values(MaritimeFlag);
+  MaritimeFlag = MaritimeFlag;
+
+  // FE-15c: confirmación explícita antes de disparar BE-23 (cancelación retroactiva).
+  showRedConfirmModal = false;
 
   @ViewChild(MatSort) sort!: MatSort;
 
@@ -280,9 +284,25 @@ export class MaritimeActivityReportsComponent implements OnInit {
     this.showFormModal = false;
   }
 
-  saveReport(): void {
+  attemptSave(): void {
     if (this.reportForm.invalid) return;
+    if (this.reportForm.value.flag === MaritimeFlag.RED) {
+      this.showRedConfirmModal = true;
+      return;
+    }
+    this.persistReport();
+  }
 
+  confirmRedAndSave(): void {
+    this.showRedConfirmModal = false;
+    this.persistReport();
+  }
+
+  cancelRedConfirm(): void {
+    this.showRedConfirmModal = false;
+  }
+
+  private persistReport(): void {
     const reportData = this.reportForm.value;
 
     const countryObj = this.countries.find(c => c.name === reportData.country);

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
@@ -11,6 +11,9 @@
             </div>
 
             <div class="d-flex align-items-center flex-wrap gap-2">
+                <button *ngIf="showMaritimeReportsLink" class="btn btn-sm btn-outline-primary" (click)="goToMaritimeReports()" [title]="'maritime-reports.link' | translate">
+                    <i class="isax isax-flag me-1"></i>{{ 'maritime-reports.link' | translate }}
+                </button>
                 <button *ngIf="currentRole === 'PROVIDER'" class="btn btn-sm btn-success" (click)="navigateToQrScanner('')">
                     <i class="isax isax-scan me-1"></i>{{ 'provider-tour-management.header.confirmBooking' | translate }}
                 </button>

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -83,6 +83,12 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
   // Configuración dinámica según rol
   config!: BookingManagementConfig;
   currentRole!: UserRole;
+  // FE-15c: mostrar acceso a reportes DIMAR cuando el backoffice está viendo /admin/bookings-management.
+  showMaritimeReportsLink = false;
+
+  goToMaritimeReports(): void {
+    this.router.navigate(['/admin/maritime-reports']);
+  }
   
   // Variables de paginación y filtrado
   public pageSize = 10;
@@ -175,6 +181,8 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
     // Detectar rol y cargar configuración
     this.currentRole = this.getUserRole();
     this.config = this.configService.getConfigByRole(this.currentRole);
+    this.showMaritimeReportsLink = this.authService.isTouryaBackoffice()
+      && this.router.url.includes('bookings-management');
     
     // Cargar datos según el rol
     if (this.currentRole === 'CLIENT') {


### PR DESCRIPTION
## Resumen

Cierra el gap de acceso entre backend y frontend para el rol `BACKOFFICE_OPERATION`:
la UI de reportes DIMAR ya existía pero solo era alcanzable via el dashboard admin (bajo `AdminGuard`).
FE-15b abrió el backend al rol; este PR abre el frontend.

## Alcance

- **Ruta nueva** `/admin/maritime-reports` con `BackofficeGuard` (ADMIN + BACKOFFICE_OPERATION).
- **Reutiliza** el componente `MaritimeActivityReportsComponent` existente sin tocar su lógica.
- **Modal de confirmación** explícita cuando `flag=RED` — evita que un click descuidado dispare BE-23 (cancelación retroactiva de reservas + crédito compensatorio).
- **Enlace de navegación** desde `/admin/bookings-management` (visible solo al backoffice).
- **i18n** es/en/pt para modal y enlace.

## Cambios

- `admin-routing.module.ts` — ruta lazy con `loadComponent` (componente ya es standalone).
- `maritime-activity-reports.component.ts` — nuevo `attemptSave()`/`confirmRedAndSave()`/`persistReport()`. El `saveReport` original quedó como `persistReport` privado; ahora el submit del form pasa primero por el modal si `flag=RED`.
- `maritime-activity-reports.component.html` — botón submit ahora llama `attemptSave()`, y modal Bootstrap adicional al final.
- `provider-tour-management.component.ts` — flag `showMaritimeReportsLink` (true solo si `isTouryaBackoffice() && url.includes('bookings-management')`) + `goToMaritimeReports()`.
- `provider-tour-management.component.html` — botón en header condicionado al flag; no afecta providers ni clientes.
- `public/i18n/{es,en,pt}.json` — sección `maritime-reports`.

## Sin regresión

- El embed del dashboard admin sigue funcionando igual (mismo componente).
- El botón nuevo solo aparece si el usuario es ADMIN o BACKOFFICE_OPERATION y está en `bookings-management` — providers/clientes ni lo ven.

## Test plan

- [ ] `ng build --configuration=production` ✅ (verificado local antes de push)
- [ ] Login como BACKOFFICE_OPERATION → `/admin/bookings-management` → botón "Reportes DIMAR" visible → click navega a `/admin/maritime-reports`.
- [ ] Login como PROVIDER → mis reservas → botón "Reportes DIMAR" NO visible.
- [ ] Crear reporte con `flag=GREEN` o `flag=YELLOW` → guarda directo sin modal.
- [ ] Crear reporte con `flag=RED` → modal de confirmación aparece. Cancelar cierra sin guardar. Confirmar guarda y dispara BE-23.
- [ ] Verificar i18n en los 3 idiomas (es/en/pt) del modal y el enlace.