### PR TITLE
fix(tc-005): modal detalle muestra precio del proveedor para rol PROVIDER

### DIFF
--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -428,12 +428,8 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
       customerPhone: reservation.serviceResponsiblePhone || 'N/A',
       travellers: reservation.totalTourists != null ? `${reservation.totalTourists}` : 'N/A',
       duration: reservation.duration ? `${reservation.duration} días` : 'N/A',
-      price:
-        reservation.shoppingTotalPrice != null
-          ? `$${Number(reservation.shoppingTotalPrice).toFixed(2)}`
-          : reservation.price
-          ? `$${Number(reservation.price).toFixed(2)}`
-          : '$0.00',
+      // TC-005: PROVIDER puro ve el neto que recibe (providerPrice del SP); ADMIN/BACKOFFICE/CLIENT ven el precio que paga el cliente.
+      price: this.pickBookingPriceForRole(reservation),
       bookingDate: this.formatDate(reservation.reservationCreatedDate || reservation.createdDate),
       checkInDate: this.formatDateTime(checkInIso),
       returnDate: '—',
@@ -706,6 +702,29 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
   /**
    * Mapea el estado de la reserva del API al formato de la tabla
    */
+  /**
+   * TC-005: selecciona qué precio mostrar en la vista de reserva según el rol del usuario.
+   *
+   * PROVIDER puro (no ADMIN ni BACKOFFICE) ve el neto que recibe (`providerPrice` del SP,
+   * ya corregido por el fix TC-005 backend para tours grupo). ADMIN, BACKOFFICE_OPERATION,
+   * TURISTA y cualquier otro rol ven el monto que paga el cliente (`shoppingTotalPrice`).
+   */
+  private pickBookingPriceForRole(reservation: any): string {
+    const isProviderOnly = this.authService.isProvider() && !this.authService.isTouryaBackoffice();
+    const preferred = isProviderOnly ? reservation.providerPrice : reservation.shoppingTotalPrice;
+    if (preferred != null) {
+      return `$${Number(preferred).toFixed(2)}`;
+    }
+    // Fallbacks conservan el comportamiento previo cuando el campo preferido no llegó.
+    if (reservation.shoppingTotalPrice != null) {
+      return `$${Number(reservation.shoppingTotalPrice).toFixed(2)}`;
+    }
+    if (reservation.price != null) {
+      return `$${Number(reservation.price).toFixed(2)}`;
+    }
+    return '$0.00';
+  }
+
   private mapReservationStatus(apiStatus: 'PENDING' | 'DELIVERED' | 'CANCELLED' | 'CANCELED' | 'RESCHEDULED' | 'TEMPORAL' | 'NO_SHOW' | string): 'Upcoming' | 'Pending' | 'Confirmed' | 'Cancelled' | 'Completed' | 'Temporal' | 'No_Show' | 'Rescheduled' {
     const statusMap: Record<string, 'Upcoming' | 'Pending' | 'Confirmed' | 'Cancelled' | 'Completed' | 'Temporal' | 'No_Show' | 'Rescheduled'> = {
       'PENDING': 'Pending',


### PR DESCRIPTION
Cierra #188 (TC-005 frontend, bug 5b) junto con el PR backend #191 ya mergeado.

## Contexto

Luis reportó en #188 que al abrir "Detalles de Reserva" con el rol PROVIDER, el "Precio total" mostraba lo que paga el cliente ($345,000 para RES-317) en vez del neto que recibe el proveedor ($300,000).

Aclaración en el mismo issue:
> En el mapper: si el usuario es **PROVIDER**, popular con el precio-proveedor. Si el usuario es **TURISTA, ADMIN o BACKOFFICE_OPERATION** dejarlo como se muestra ahorita (el monto que paga el cliente).

## Fix

Nuevo helper `pickBookingPriceForRole` en `provider-tour-management.component.ts`:

```ts
private pickBookingPriceForRole(reservation: any): string {
  const isProviderOnly = this.authService.isProvider() && !this.authService.isTouryaBackoffice();
  const preferred = isProviderOnly ? reservation.providerPrice : reservation.shoppingTotalPrice;
  ...
}
```

Sustituye la asignación estática de `price` en `mapReservationToBooking` (línea 431, usado por `viewBookingDetails` en línea 262). Los otros 2 mappers de la lista quedan intactos:

- `mapProviderReservationToBooking` (línea 597) → ya usaba `providerPrice`. Con el fix del PR api #191 ahora refleja el neto correcto ($300,000) automáticamente sin cambio en este PR.
- `mapClientReservationToBooking` (línea 651) → sigue usando `shoppingTotalPrice`. Correcto — el cliente ve lo que paga.

## Dependencia backend (ya mergeada)

Este PR **requiere** que esté mergeado y desplegado el PR api [#191](https://github.com/Touryapp/tourya-api/pull/191) (migración 079). Sin el fix del SP, el campo `providerPrice` llegaba inflado para tours grupo (`provider_unit_price × pax`).

Con ambos mergeados:
- Login como PROVIDER → detalle RES-317 muestra **$300,000** ✅
- Login como ADMIN o BACKOFFICE_OPERATION → detalle RES-317 muestra **$345,000** ✅
- Login como CLIENT → detalle RES-317 muestra **$345,000** ✅
- Lista provider (`mapProviderReservationToBooking`) → RES-316/317 muestran **$300,000** ✅ (por fix del SP en #191, sin cambio en este PR)

## Alcance

**1 archivo, +25/-6**:
- `src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts` — nuevo helper `pickBookingPriceForRole` + reemplazo del binding en `mapReservationToBooking`.

Cero cambios en HTML, cero cambios en otros mappers, cero cambios en modelos.

## Verificación

- [x] `ng build --configuration=production` verde (regla FE-15b).
- [ ] **Post-merge**: login como PROVIDER (`proveedortourya6@yopmail.com`) → abrir detalle RES-317 → confirmar "Precio total: $300,000".
- [ ] **Post-merge**: login como ADMIN → abrir detalle RES-317 → confirmar "Precio total: $345,000".
- [ ] **Post-merge**: login como BACKOFFICE_OPERATION → abrir detalle RES-317 → confirmar "Precio total: $345,000".

## Preexistencia

Bug frontend introducido por Cristian Amador en el mapper original de junio 2026 (commits `c2c965c` y anteriores). Ningún commit reciente de nuestro equipo lo introdujo.