### PR TITLE
fix(tc-006): UX diferenciada para tours GRUPO en modal + carrito

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1374,6 +1374,7 @@
     "orderSummary": "Your order summary",
     "participantsCount": "{{count}} People",
     "participantsLabel": "People",
+    "groupsLabel": "Group(s)",
     "priceTypeAdult": "Adult",
     "priceTypeChild": "Child",
     "priceTypeBaby": "Baby",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1375,6 +1375,7 @@
     "orderSummary": "Resumen de tu orden",
     "participantsCount": "{{count}} Personas",
     "participantsLabel": "Personas",
+    "groupsLabel": "Grupo(s)",
     "priceTypeAdult": "Adulto",
     "priceTypeChild": "Niño",
     "priceTypeBaby": "Bebe",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1375,6 +1375,7 @@
     "orderSummary": "Resumo do seu pedido",
     "participantsCount": "{{count}} pessoas",
     "participantsLabel": "pessoas",
+    "groupsLabel": "Grupo(s)",
     "priceTypeAdult": "Adulto",
     "priceTypeChild": "Criança",
     "priceTypeBaby": "Bebê",

--- a/src/app/pages/clients/cart-summary/cart-summary.component.html
+++ b/src/app/pages/clients/cart-summary/cart-summary.component.html
@@ -419,14 +419,20 @@
                                                 <i class="fas fa-map-marker-alt me-1"></i>
                                                 {{ item.address.city.length > 15 ? (item.address.city | slice:0:15) + '...' : item.address.city }}, {{ item.address.state.length > 15 ? (item.address.state | slice:0:15) + '...' : item.address.state }}
                                             </p>
-                                            <p class="text-muted small mb-1">
+                                            <!-- TC-006: para tours grupo mostramos la cantidad de grupos; para individual la cantidad de pax. -->
+                                            <p class="text-muted small mb-1" *ngIf="item.tour?.priceType === 'group'">
+                                                <i class="fas fa-users me-1"></i>
+                                                {{ (item.groupCount || 1) }} {{ 'cartSummary.groupsLabel' | translate }}
+                                                <span class="text-secondary">({{ item.totalParticipants }} {{ 'cartSummary.participantsLabel' | translate }})</span>
+                                            </p>
+                                            <p class="text-muted small mb-1" *ngIf="item.tour?.priceType !== 'group'">
                                                 <i class="fas fa-users me-1"></i>
                                                 {{ item.totalParticipants }} {{ 'cartSummary.participantsLabel' | translate }}
                                             </p>
                                         </div>
-                                        
-                                        <!-- Participants Breakdown -->
-                                        <div class="participants-breakdown">
+
+                                        <!-- Participants Breakdown — TC-006: solo tiene sentido para individual (precio por edad). -->
+                                        <div class="participants-breakdown" *ngIf="item.tour?.priceType !== 'group'">
                                             <small class="text-muted d-block mb-1">{{ 'cartSummary.participantsLabel' | translate }}:</small>
                                             <div class="ms-2">
                                                 <div *ngFor="let participant of item.participants" class="d-flex justify-content-between align-items-center mb-1">

--- a/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.html
+++ b/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.html
@@ -170,7 +170,8 @@
             </div>
           </div>
 
-          <div class="participants-list">
+          <!-- TC-006: en tours GRUPO el input de "participantes" no aplica — la cantidad se maneja por groupCount arriba. -->
+          <div class="participants-list" *ngIf="selectedTour?.tour?.priceType !== 'group'">
             <div class="participant-item" *ngFor="let participant of participants">
               <div class="participant-info">
                 <div class="participant-type">{{ participant.label | translate }}</div>
@@ -203,10 +204,15 @@
           </div>
 
           <!-- Summary -->
-          <div class="selection-summary" *ngIf="totalParticipants > 0">
+          <div class="selection-summary" *ngIf="totalParticipants > 0 || selectedTour?.tour?.priceType === 'group'">
             <div class="summary-card">
-              <div class="summary-item">
-                <span class="label">{{ 'tourSlotModal.totalParticipants' | translate }}{{ selectedTour?.tour?.priceType === 'group' ? ' (Total)' : '' }}:</span>
+              <!-- TC-006: para grupo mostramos "Cantidad de grupos" (default 1); para individual "Total participantes". -->
+              <div class="summary-item" *ngIf="selectedTour?.tour?.priceType === 'group'">
+                <span class="label">{{ 'tourSlotModal.selectGroups' | translate }}:</span>
+                <span class="value">{{ groupCount }}</span>
+              </div>
+              <div class="summary-item" *ngIf="selectedTour?.tour?.priceType !== 'group'">
+                <span class="label">{{ 'tourSlotModal.totalParticipants' | translate }}:</span>
                 <span class="value">{{ totalParticipants }}</span>
               </div>
               <div class="summary-item">

--- a/src/app/shared/dto/cart.dto.ts
+++ b/src/app/shared/dto/cart.dto.ts
@@ -10,6 +10,9 @@ export interface CartItem {
     description: string;
     duration: string;
     rating: number;
+    // TC-006: exponer priceType para distinguir grupo/individual en el resumen del carrito.
+    priceType?: string;
+    maxPeople?: number;
   };
   schedule: {
     id: number;

--- a/src/app/shared/services/cart.service.ts
+++ b/src/app/shared/services/cart.service.ts
@@ -877,7 +877,10 @@ export class CartService {
           name: item.tourName || 'Tour sin nombre', // ✅ API: item.tourName
           description: item.tourDescription || 'Descubre los lugares más emblemáticos de la ciudad en este increíble recorrido',
           duration: item.duration || '8 horas',
-          rating: item.rating || 4.5
+          rating: item.rating || 4.5,
+          // TC-006: expone priceType/maxPeople para el resumen del carrito.
+          priceType: item.priceType,
+          maxPeople: item.maxPeople
         },
         schedule: {
           id: item.tourScheduleId, // ✅ API: item.tourScheduleId


### PR DESCRIPTION
Cierra #189 (TC-006). Sub-bug 1 ya estaba resuelto por TC-004 (PR api #190).

## Sub-bugs abordados

| Sub-bug | Estado |
|---|---|
| 1. Disponibilidad = 3 en todos los días | ✅ Ya resuelto por TC-004 (PR api #190) — verificable en UI post-deploy |
| 2. Cantidad "Cualquiera" muestra 2 (pax) por default en grupo | ✅ Este PR — ocultar bloque `participants-list` cuando es grupo |
| 3. Precio total multiplica por pax en vez de grupos | ✅ Este PR — resuelto automáticamente por sub-bug 2 (el `updateTotals` ya calculaba bien, el input engañoso ya no aparece) |
| 4. Carrito muestra "N personas" sin distinguir grupo | ✅ Este PR — cart-summary muestra "N Grupo(s) (M participantes)" |

## Descubrimiento importante

Cristian ya había implementado la infraestructura correcta en `tour-slot-selection-modal.component.ts` (commit `32777c6`, jun-2026):
- `groupCount: number = 1` con `increment/decrement/updateGroupCount`.
- `updateTotals`: para grupo → `totalPrice = baseGroupPrice × groupCount`.
- Validaciones distinguen grupo/individual.
- Bloque `group-selection-list` en template con el input de grupos.

**Lo único que faltaba**: ocultar el bloque `participants-list` (que renderiza los inputs adults/children/infants) cuando el tour es grupo. Coexistían 2 inputs de cantidad y confundían al usuario.

## Cambios

**Modal (`tour-slot-selection-modal.component.html`)**:
- `*ngIf="selectedTour?.tour?.priceType !== 'group'"` en el `<div class=\"participants-list\">`.
- Summary: para grupo mostrar "Cantidad de grupos: {groupCount}" (usa `tourSlotModal.selectGroups` i18n existente) en vez de "Total participantes".

**Cart-summary (`cart-summary.component.html`)**:
- Header del item: para grupo mostrar "N Grupo(s) (M participantes)"; para individual queda igual ("N personas").
- Breakdown de participantes por precio-por-edad: oculto para grupo (irrelevante — precio fijo por grupo).

**DTO (`cart.dto.ts`)**:
- Extender `CartItem.tour` con `priceType?: string` y `maxPeople?: number` opcionales.
- `cart.service.ts`: populate desde la respuesta backend.

**i18n**:
- Nueva key `cartSummary.groupsLabel` en es/en/pt ("Grupo(s)" / "Group(s)" / "Grupo(s)").

## Cero cambios en

- Backend (Java + SPs) — `ShoppingCartService.addToCart` ya distingue GRUPO desde commit `65df429` (Cristian, abr-2026).
- Payload al API — el modal ya enviaba `groupCount` correctamente para grupo (línea 938 del modal).
- Tours INDIVIDUAL — todo el flow queda idéntico (las condicionales `*ngIf` son estrictas).

## Verificación local

- [x] `ng build --configuration=production` verde (regla FE-15b).
- [ ] **Post-merge**: login TURISTA → buscar "Mulita 4 pasajeros" con 2 viajeros → "Consultar disponibilidad" → modal muestra solo input "Cantidad de grupos = 1" (sin bloque "Cualquiera").
- [ ] **Post-merge**: precio total = $345,000 con groupCount=1; al aumentar a 2 → $690,000.
- [ ] **Post-merge**: agregar al carrito → cart-summary muestra "1 Grupo(s) (2 personas)" sin breakdown por edad.
- [ ] **Regresión**: tour INDIVIDUAL sigue mostrando adults/children/infants con precio × pax.
- [ ] **Regresión TC-004**: disponibilidad correcta por día (25-jul muestra availability=5, 24-jul availability=3).

## Preexistencia

Todos los sub-bugs son preexistencias del frontend Angular:
- Cristian implementó la infra `groupCount` en el modal (jun-2026) pero dejó el bloque duplicado de participantes.
- El cart-summary nunca implementó UI diferenciada para grupo.

Nuestro equipo no introdujo estos bugs.