### PR TITLE
fix: priceType 'group' -> 'grupo' + link Reservas en menu admin

### DIFF
--- a/src/app/pages/admin/dashboard/dashboard.component.html
+++ b/src/app/pages/admin/dashboard/dashboard.component.html
@@ -52,6 +52,10 @@
                 class="isax isax-wallet-2"></i> Ordenes de pago</a>
           </li>
           <li>
+            <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToBookingsManagement()"><i
+                class="isax isax-calendar-tick"></i> Reservas</a>
+          </li>
+          <li>
             <a class="d-flex align-items-center" style="cursor: pointer;" (click)="toggleAppConfig()"><i
                 class="isax isax-setting-2"></i> {{ 'app-config-admin.sidebarLink' | translate }}</a>
           </li>

--- a/src/app/pages/admin/dashboard/dashboard.component.ts
+++ b/src/app/pages/admin/dashboard/dashboard.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { RequestProvider } from '../../../shared/dto/requestProvider-response.dto';
 import { RequestProvidersService } from '../../providers/requestproviders/request-providers.service';
 import { RequestProviderDocumentType } from '../../../shared/dto/RequestProviderDocumentTypeList.dto';
@@ -34,8 +35,14 @@ export class DashboardComponent implements OnInit {
 
   constructor(
     private requestProvidersService: RequestProvidersService,
-    private panelStateService: ProviderPanelStateService
+    private panelStateService: ProviderPanelStateService,
+    private router: Router
   ) { }
+
+  /** FE-15b post-fix: navega a la vista de reservas (BookingsManagement) del backoffice. */
+  goToBookingsManagement(): void {
+    this.router.navigate(['/admin/bookings-management']);
+  }
 
   ngOnInit(): void {
     this.cargarSolicitudes();

--- a/src/app/pages/clients/cart-summary/cart-summary.component.html
+++ b/src/app/pages/clients/cart-summary/cart-summary.component.html
@@ -420,19 +420,19 @@
                                                 {{ item.address.city.length > 15 ? (item.address.city | slice:0:15) + '...' : item.address.city }}, {{ item.address.state.length > 15 ? (item.address.state | slice:0:15) + '...' : item.address.state }}
                                             </p>
                                             <!-- TC-006: para tours grupo mostramos la cantidad de grupos; para individual la cantidad de pax. -->
-                                            <p class="text-muted small mb-1" *ngIf="item.tour?.priceType === 'group'">
+                                            <p class="text-muted small mb-1" *ngIf="item.tour?.priceType === 'grupo'">
                                                 <i class="fas fa-users me-1"></i>
                                                 {{ (item.groupCount || 1) }} {{ 'cartSummary.groupsLabel' | translate }}
                                                 <span class="text-secondary">({{ item.totalParticipants }} {{ 'cartSummary.participantsLabel' | translate }})</span>
                                             </p>
-                                            <p class="text-muted small mb-1" *ngIf="item.tour?.priceType !== 'group'">
+                                            <p class="text-muted small mb-1" *ngIf="item.tour?.priceType !== 'grupo'">
                                                 <i class="fas fa-users me-1"></i>
                                                 {{ item.totalParticipants }} {{ 'cartSummary.participantsLabel' | translate }}
                                             </p>
                                         </div>
 
                                         <!-- Participants Breakdown — TC-006: solo tiene sentido para individual (precio por edad). -->
-                                        <div class="participants-breakdown" *ngIf="item.tour?.priceType !== 'group'">
+                                        <div class="participants-breakdown" *ngIf="item.tour?.priceType !== 'grupo'">
                                             <small class="text-muted d-block mb-1">{{ 'cartSummary.participantsLabel' | translate }}:</small>
                                             <div class="ms-2">
                                                 <div *ngFor="let participant of item.participants" class="d-flex justify-content-between align-items-center mb-1">

--- a/src/app/pages/clients/cart-summary/cart-summary.component.ts
+++ b/src/app/pages/clients/cart-summary/cart-summary.component.ts
@@ -1117,7 +1117,7 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
 
       console.log(`🔍 Validando ${priceType}: disponiblidad=${availability}, maxPeople=${maxPeople}`);
 
-      if (priceType === 'group') {
+      if (priceType === 'grupo') {
         const groupsRequested = cartItem.groupCount || 1;
         const totalCapacity = maxPeople * groupsRequested;
 

--- a/src/app/pages/providers/tours/tour-schedule-test/tour-schedule-test.component.ts
+++ b/src/app/pages/providers/tours/tour-schedule-test/tour-schedule-test.component.ts
@@ -138,7 +138,7 @@ export class TourScheduleTestComponent {
   }
 
   get isGroupTour(): boolean {
-    return this.tour?.priceType === 'group';
+    return this.tour?.priceType === 'grupo';
   }
 
   onSubmit() {

--- a/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.ts
+++ b/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.ts
@@ -138,7 +138,7 @@ export class TourScheduleComponent {
   }
 
   get isGroupTour(): boolean {
-    return this.tour?.priceType === 'group';
+    return this.tour?.priceType === 'grupo';
   }
 
   get isUnlimitedCapacity(): boolean {

--- a/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.html
+++ b/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.html
@@ -80,7 +80,7 @@
                   <div class="available-capacity">
                     <i class="isax isax-profile-2user me-1"></i>
                     <span *ngIf="!isSlotFull(slot)">
-                      {{ slot.availability || slot.capacity }} {{ selectedTour?.tour?.priceType === 'group' ? ('tourSlotModal.groupsAvailable' | translate) : ('tourSlotModal.slotsAvailable' | translate) }}
+                      {{ slot.availability || slot.capacity }} {{ selectedTour?.tour?.priceType === 'grupo' ? ('tourSlotModal.groupsAvailable' | translate) : ('tourSlotModal.slotsAvailable' | translate) }}
                     </span>
                     <span *ngIf="isSlotFull(slot)" class="text-danger">
                       {{ 'tourSlotModal.full' | translate }}
@@ -125,12 +125,12 @@
           <div class="section-header">
             <h6 class="section-title">
               <i class="isax isax-people me-2"></i>
-              {{ selectedTour?.tour?.priceType === 'group' ? ('tourSlotModal.participantsByGroup' | translate) : ('tourSlotModal.selectParticipants' | translate) }}
+              {{ selectedTour?.tour?.priceType === 'grupo' ? ('tourSlotModal.participantsByGroup' | translate) : ('tourSlotModal.selectParticipants' | translate) }}
             </h6>
-            <span class="section-subtitle" *ngIf="selectedSlot && selectedTour?.tour?.priceType !== 'group'">
+            <span class="section-subtitle" *ngIf="selectedSlot && selectedTour?.tour?.priceType !== 'grupo'">
               {{ 'tourSlotModal.availablePersons' | translate: { count: selectedSlot.availability } }}
             </span>
-            <span class="section-subtitle" *ngIf="selectedSlot && selectedTour?.tour?.priceType === 'group'">
+            <span class="section-subtitle" *ngIf="selectedSlot && selectedTour?.tour?.priceType === 'grupo'">
               {{ 'tourSlotModal.maxPersonsPerGroup' | translate: { count: selectedTour?.tour?.maxPeople || 99 } }}
             </span>
             <span class="section-subtitle" *ngIf="!selectedSlot">
@@ -139,7 +139,7 @@
           </div>
 
           <!-- Group Selection (Only for Price Type "group") -->
-          <div class="participants-list group-selection-list mb-3" *ngIf="selectedTour?.tour?.priceType === 'group'">
+          <div class="participants-list group-selection-list mb-3" *ngIf="selectedTour?.tour?.priceType === 'grupo'">
             <div class="participant-item">
               <div class="participant-info">
                 <div class="participant-type">{{ 'tourSlotModal.selectGroups' | translate }}</div>
@@ -171,13 +171,13 @@
           </div>
 
           <!-- TC-006: en tours GRUPO el input de "participantes" no aplica — la cantidad se maneja por groupCount arriba. -->
-          <div class="participants-list" *ngIf="selectedTour?.tour?.priceType !== 'group'">
+          <div class="participants-list" *ngIf="selectedTour?.tour?.priceType !== 'grupo'">
             <div class="participant-item" *ngFor="let participant of participants">
               <div class="participant-info">
                 <div class="participant-type">{{ participant.label | translate }}</div>
                 <div class="participant-details">
 
-                  <span class="price" *ngIf="selectedTour?.tour?.priceType !== 'group'">{{ formatPrice(participant.price) }} COP {{ 'tourSlotModal.each' | translate }} </span>
+                  <span class="price" *ngIf="selectedTour?.tour?.priceType !== 'grupo'">{{ formatPrice(participant.price) }} COP {{ 'tourSlotModal.each' | translate }} </span>
                 </div>
               </div>
 
@@ -204,14 +204,14 @@
           </div>
 
           <!-- Summary -->
-          <div class="selection-summary" *ngIf="totalParticipants > 0 || selectedTour?.tour?.priceType === 'group'">
+          <div class="selection-summary" *ngIf="totalParticipants > 0 || selectedTour?.tour?.priceType === 'grupo'">
             <div class="summary-card">
               <!-- TC-006: para grupo mostramos "Cantidad de grupos" (default 1); para individual "Total participantes". -->
-              <div class="summary-item" *ngIf="selectedTour?.tour?.priceType === 'group'">
+              <div class="summary-item" *ngIf="selectedTour?.tour?.priceType === 'grupo'">
                 <span class="label">{{ 'tourSlotModal.selectGroups' | translate }}:</span>
                 <span class="value">{{ groupCount }}</span>
               </div>
-              <div class="summary-item" *ngIf="selectedTour?.tour?.priceType !== 'group'">
+              <div class="summary-item" *ngIf="selectedTour?.tour?.priceType !== 'grupo'">
                 <span class="label">{{ 'tourSlotModal.totalParticipants' | translate }}:</span>
                 <span class="value">{{ totalParticipants }}</span>
               </div>

--- a/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.ts
+++ b/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.ts
@@ -86,7 +86,7 @@ export class TourSlotSelectionModalComponent implements OnInit, AfterViewInit {
   // Rescheduling mode
   isRescheduling: boolean = false;
 
-  // Group selection (for priceType === 'group')
+  // Group selection (for priceType === 'grupo')
   groupCount: number = 1;
   showGroupError: boolean = false;
   showParticipantError: boolean = false;
@@ -509,7 +509,7 @@ export class TourSlotSelectionModalComponent implements OnInit, AfterViewInit {
    * Verifica si se puede agregar un participante más
    */
   private canAddParticipant(): boolean {
-    const isGroup = this.selectedTour?.tour?.priceType === 'group';
+    const isGroup = this.selectedTour?.tour?.priceType === 'grupo';
 
     if (isGroup) {
       // 1. Para tours grupo: el límite de personas total es (maxPeople * groupCount)
@@ -529,7 +529,7 @@ export class TourSlotSelectionModalComponent implements OnInit, AfterViewInit {
   private updateParticipantLimits(): void {
     if (!this.selectedTour) return;
 
-    const isGroup = this.selectedTour?.tour?.priceType === 'group';
+    const isGroup = this.selectedTour?.tour?.priceType === 'grupo';
     let maxCap = 99;
 
     if (isGroup) {
@@ -555,7 +555,7 @@ export class TourSlotSelectionModalComponent implements OnInit, AfterViewInit {
       0
     );
     
-    if (this.selectedTour?.tour?.priceType === 'group') {
+    if (this.selectedTour?.tour?.priceType === 'grupo') {
       const baseGroupPrice = this.participants.length > 0 ? Math.max(...this.participants.map(p => p.price)) : 0;
       this.totalPrice = baseGroupPrice * this.groupCount;
     } else {
@@ -584,7 +584,7 @@ export class TourSlotSelectionModalComponent implements OnInit, AfterViewInit {
     // minCapacity verification removed
 
     const availability = this.currentAvailability;
-    const isGroup = this.selectedTour?.tour?.priceType === 'group';
+    const isGroup = this.selectedTour?.tour?.priceType === 'grupo';
 
     if (isGroup) {
       // 1. Validar grupos disponibles (Campo: slot.availability)
@@ -933,7 +933,7 @@ export class TourSlotSelectionModalComponent implements OnInit, AfterViewInit {
 
     const cartItem: CartItem = {
       id: this.cartService.generateCartItemId(),
-      groupCount: this.selectedTour?.tour?.priceType === 'group' ? this.groupCount : undefined,
+      groupCount: this.selectedTour?.tour?.priceType === 'grupo' ? this.groupCount : undefined,
       dayDate,
       tour: {
         ...this.selectedTour.tour,
@@ -1261,7 +1261,7 @@ export class TourSlotSelectionModalComponent implements OnInit, AfterViewInit {
   dateErrors: Set<string> = new Set<string>();
 
   canSelectDate(date: Date): boolean {
-    const isGroup = this.selectedTour?.tour?.priceType === 'group';
+    const isGroup = this.selectedTour?.tour?.priceType === 'grupo';
     const availability = this.getDayAvailability(date);
     if (availability === '∞') return true;
     
@@ -1365,7 +1365,7 @@ export class TourSlotSelectionModalComponent implements OnInit, AfterViewInit {
 
     if (this.isRescheduling && this.data.originalTravellers) {
       const originalCount = this.data.originalTravellers;
-      const isGroup = this.selectedTour?.tour?.priceType === 'group';
+      const isGroup = this.selectedTour?.tour?.priceType === 'grupo';
 
       if (isGroup) {
         this.updateGroupCount(Math.ceil(originalCount / (this.selectedTour?.tour?.maxPeople || 1)));


### PR DESCRIPTION
Cierra 2 fallas nuestras encontradas en la verificación UI de Luis después de los últimos merges.

## 1. Fix crítico: `priceType === 'group'` en 16 lugares (issue #189 Prueba 1 + 3)

### Causa raíz

**Backend Java** (`PriceTypeEnum.java`):
```java
INDIVIDUAL("individual"),
GRUPO("grupo");
```

Serializa el valor como **`"grupo"`** (español, minúsculas).

**Frontend Angular** — en 16 lugares comparaba:
```typescript
if (priceType === 'group') { ... }   // <-- SIEMPRE FALSE
```

Como `'grupo' === 'group'` es siempre `false`, la rama de "es tour grupo" **nunca se ejecutaba** en el cliente turista → modal siempre mostraba "Cualquiera" con pax, carrito siempre mostraba "N personas", precio siempre × pax.

### Preexistencia + falla nuestra

Bug desde el commit `65df429` de Cristian (**2026-04-03**). Ha estado roto **~4 meses en silencio** — todos los tours grupo se comportaban como individuales sin que nadie lo notara (probablemente no había tours grupo reales hasta hace poco).

Nuestro TC-006 (PR #72) **heredó el mismo string mal escrito**. Es falla nuestra por no haber verificado el enum backend antes de escribir el fix. Aprendizaje: grep del enum del backend antes de comparar strings.

### Cambios

Reemplazado `priceType === 'group'` → `priceType === 'grupo'` (y `!== 'group'` → `!== 'grupo'`) en:

- `src/app/pages/clients/cart-summary/cart-summary.component.{html,ts}` — 3 usos
- `src/app/pages/providers/tours/tour-schedule/tour-schedule.component.ts` — 1
- `src/app/pages/providers/tours/tour-schedule-test/tour-schedule-test.component.ts` — 1
- `src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.{html,ts}` — 11

**Backend intacto** — `ShoppingCartService.addToCart` ya distinguía correctamente con `equals(\"grupo\")` en español. El `total_amount` de `Reservation` que se persiste ya estaba bien (RES-317 en BD tenía $345,000 correcto). El bug era puramente visual/lógico en el cliente turista.

---

## 2. Link "Reservas" en menú admin dashboard (issue #188 Prueba 3)

### Causa raíz

**FE-15b** (PR #69, tourya-front) agregó la ruta protegida `/admin/bookings-management` con `BackofficeGuard`, pero **no incluí el link visible en el sidebar del dashboard admin**. Verificado: `admin-routing.module.ts` tiene el path pero no hay entrada en el HTML del menú.

Falla nuestra por descuido al cerrar FE-15b.

### Cambios

- `dashboard.component.ts`:
  - Inyectar `Router` en el constructor.
  - Nuevo método `goToBookingsManagement()` que navega a `/admin/bookings-management`.
- `dashboard.component.html`:
  - Nuevo `<li>` en el sidebar admin con icono `isax-calendar-tick` y label "Reservas", entre "Ordenes de pago" y `app-config-admin.sidebarLink`.
  - Al click navega via router (el `BackofficeGuard` de FE-15b se encarga de la autorización).

Nota: el mismo link también funcionará para el rol BACKOFFICE_OPERATION cuando entre al dashboard (aunque ese rol aterriza en `/admin/bookings-management` directamente por el `home-redirect.guard.ts`).

---

## Verificación

- [x] `ng build --configuration=production` verde local (regla FE-15b, quinta vez consecutiva).
- [x] Grep final: **0 ocurrencias** restantes de `priceType === 'group'` o `priceType !== 'group'`.

## Test plan post-merge

- [ ] **Login TURISTA** → buscar tour "Mulita 4 pasajeros" con 2 viajeros → "Consultar disponibilidad" → modal muestra **solo** input "Cantidad de grupos = 1" (sin "Cualquiera").
- [ ] Precio total = $345,000 con groupCount=1 → al aumentar a 2 → $690,000.
- [ ] Agregar al carrito → cart-summary muestra "1 Grupo(s) (2 personas)" (no "2 personas" a secas).
- [ ] **Regresión INDIVIDUAL**: buscar un tour INDIVIDUAL → modal sigue con adults/children/infants + precio × pax.
- [ ] **Login ADMIN** → dashboard admin → sidebar muestra "Reservas" con icono calendario → click navega a `/admin/bookings-management`.

---

## Referencias

- Issue #189 (TC-006) — bug modal/carrito grupo, verificación de Luis 2026-07-23.
- Issue #188 (TC-005) — comentario Luis "no aparece Bookings Management en menú".
- Commit `65df429` (Cristian, 2026-04-03) — origen del bug `'group'`.
- PR #69 (tourya-front, FE-15b) — donde debí haber agregado el link admin.
- PR #72 (tourya-front, TC-006) — donde heredé el bug `'group'` sin verificar el enum backend.