### PR TITLE
fix(bookings): ADMIN/BACKOFFICE ven todas las reservas cross-provider

### DIFF
--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -185,10 +185,12 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
       && this.router.url.includes('bookings-management');
     
     // Cargar datos según el rol
+    // TC-005 post-fix: ADMIN/BACKOFFICE_OPERATION también consume el endpoint provider
+    // (el backend devuelve todas las reservas cross-provider cuando no hay providerId).
     if (this.currentRole === 'CLIENT') {
       this.loadClientReservations();
       this.loadPendingReviews();
-    } else if (this.currentRole === 'PROVIDER') {
+    } else if (this.currentRole === 'PROVIDER' || this.currentRole === 'ADMIN') {
       this.loadProviderReservations();
     } else {
       this.loadMockData();
@@ -201,7 +203,7 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
           if (this.currentRole === 'CLIENT') {
             this.loadClientReservations();
             this.loadPendingReviews();
-          } else if (this.currentRole === 'PROVIDER') {
+          } else if (this.currentRole === 'PROVIDER' || this.currentRole === 'ADMIN') {
             this.loadProviderReservations();
           }
           this.cdr.detectChanges();
@@ -496,7 +498,8 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
    * Obtiene el rol del usuario actual
    */
   private getUserRole(): UserRole {
-    if (this.authService.isAdmin()) {
+    // TC-005 post-fix: BACKOFFICE_OPERATION comparte la vista con ADMIN (cross-provider).
+    if (this.authService.isAdmin() || this.authService.isBackofficeOperation()) {
       return 'ADMIN';
     } else if (this.authService.isProvider() || this.authService.isProviderOperator()) {
       return 'PROVIDER';


### PR DESCRIPTION
Cierra el hallazgo de Luis en issue #188 tras el fix del menú (PR #73).

## Bug reportado

> "hice la prueba para revisar que el ADMIN tuviese la opción de 'Reservas' y al revisar vi que si aparece pero **al hacer clic en dicha opción del menú no aparecen las reservas de todos los operadores turísticos**." — @luismendozawass 2026-07-23

## Causa raíz

En `provider-tour-management.component.ts:191-193`:

```typescript
if (this.currentRole === 'CLIENT') {
  this.loadClientReservations();
} else if (this.currentRole === 'PROVIDER') {
  this.loadProviderReservations();
} else {
  this.loadMockData();  // <-- ADMIN caía acá
}
```

Cuando ADMIN o BACKOFFICE_OPERATION aterrizaban en `/admin/bookings-management`, el componente **no consultaba al backend** — cargaba mock data. Además `getUserRole()` línea 498 no tenía case para BACKOFFICE_OPERATION, lanzaba excepción.

Falla nuestra de FE-15b (PR #69) al reutilizar el componente `provider-tour-management` sin adaptar el flujo de carga para el rol ADMIN/BACKOFFICE.

## Fix

1. **`getUserRole()`**: agregar `isBackofficeOperation()` a la rama de ADMIN (política actual: BACKOFFICE_OPERATION comparte permisos cross-provider con ADMIN, consistente con `Utils.isTouryaBackoffice` del backend).
2. **Loading condicional**: extender la rama `PROVIDER` a `PROVIDER || ADMIN` para que llame `loadProviderReservations()`. El endpoint backend `GET /reservations` (`ReservationService.getProviderReservations` línea 963) ya maneja bien el caso: si `Utils.isTouryaBackoffice(roles)`, no fuerza `providerId` → el SP devuelve todas las reservas cross-provider.
3. **Idem para el subscribe pattern** de `reservationUpdated$`.

## Cero cambios backend

El backend ya soportaba el caso ADMIN/BACKOFFICE sin `providerId`:

```java
if (Utils.isProviderSide(roles)) {
    Provider provider = providerService.findByUserAndStatusActive(user);
    finalProviderId = provider.getId();  // provider forzado a su ID
} else if (Utils.isTouryaBackoffice(roles)) {
    finalProviderId = requestedProviderId;  // ADMIN/BACKOFFICE puede pasar null
}
```

Y el SP `sp_get_provider_reservations` acepta `p_provider_id DEFAULT NULL` — sin filtro = todas.

## Mapper — sin cambio necesario

`loadProviderReservations` usa `mapProviderReservationToBooking` que ya tiene la lógica TC-005 de precio por rol (`isProviderOnly = isProvider() && !isTouryaBackoffice()`). Para ADMIN retorna `shoppingTotalPrice` (precio cliente); para PROVIDER puro retorna `providerPrice` (neto proveedor). Correcto.

## Verificación

- [x] `ng build --configuration=production` verde local.

## Test plan post-merge

- [ ] **Login ADMIN** → menú lateral "Reservas" → click → ver TODAS las reservas de TODOS los providers (RES-316, RES-317, RES-318, etc.).
- [ ] Verificar que se muestra `shoppingTotalPrice` para ADMIN (no `providerPrice`).
- [ ] **Login BACKOFFICE_OPERATION** → aterriza automático en `/admin/bookings-management` (via `home-redirect.guard`) → ve todas las reservas.
- [ ] **Login PROVIDER** — regresión: sigue viendo solo sus propias reservas con `providerPrice` como precio mostrado.
- [ ] **Login CLIENT** — regresión: sigue viendo sus reservas de cliente.

## Referencias

- Issue #188 (TC-005) — bug reportado por Luis.
- PR #69 (tourya-front, FE-15b) — donde debí haber contemplado esta adaptación al reutilizar el componente.
- PR #73 (tourya-front) — fix del menú de la sesión anterior.