### PR TITLE
fix(schedule): UX diferenciada de precios por rol + AgeType i18n (TC-008 #195)

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1008,6 +1008,8 @@
         "required": "Price is required",
         "min": "Price must be greater than zero"
       },
+      "clientBadge": "Client",
+      "providerBadge": "Provider",
       "addNew": "Add New Price"
     },
     "actions": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1009,6 +1009,8 @@
         "required": "El precio es requerido",
         "min": "El precio debe ser mayor a cero"
       },
+      "clientBadge": "Cliente",
+      "providerBadge": "Proveedor",
       "addNew": "Agregar Nuevo Precio"
     },
     "actions": {

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1281,6 +1281,8 @@
         "required": "El precio es requerido",
         "min": "El precio debe ser mayor a cero"
       },
+      "clientBadge": "Cliente",
+      "providerBadge": "Fornecedor",
       "addNew": "Agregar Nuevo Precio"
     },
     "actions": {

--- a/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.html
+++ b/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.html
@@ -578,13 +578,18 @@
                                 </strong>
                             </div>
                         </td>
-                        <!-- Precios -->
+                        <!-- Precios — TC-008: PROVIDER solo ve providerPrice; ADMIN/BACKOFFICE ven Cliente + Provider. -->
                         <td>
-                            <div *ngFor="let price of slot.prices" class="d-flex justify-content-between align-items-center mb-1">
+                            <div *ngFor="let price of slot.prices" class="d-flex justify-content-between align-items-center mb-1 flex-wrap">
                                 <span class="text-muted small me-2">{{ getAgeTypeDisplay(price.ageType) }}:</span>
-                                <span class="badge bg-info text-dark fw-semibold">
-                                    {{ (price.price || price.providerPrice) | currency:'COP':'symbol':'1.0-0' }}
-                                </span>
+                                <div class="d-flex gap-1 flex-wrap">
+                                    <span *ngIf="isBackoffice && price.price != null" class="badge bg-info text-dark fw-semibold">
+                                        {{ 'tour-schedule.prices.clientBadge' | translate }}: {{ price.price | currency:'COP':'symbol':'1.0-0' }}
+                                    </span>
+                                    <span class="badge bg-secondary fw-semibold">
+                                        {{ 'tour-schedule.prices.providerBadge' | translate }}: {{ price.providerPrice | currency:'COP':'symbol':'1.0-0' }}
+                                    </span>
+                                </div>
                             </div>
                         </td>
                         <!-- Porcentaje Tourya -->

--- a/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.ts
+++ b/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.ts
@@ -176,7 +176,9 @@ export class TourScheduleComponent {
   }
 
   ngOnInit(): void {
-    this.isBackoffice = this.authService.isAdmin();
+    // TC-008 (FE-15b): usar isTouryaBackoffice para que BACKOFFICE_OPERATION
+    // tambien vea la columna % Tourya y el precio cliente.
+    this.isBackoffice = this.authService.isTouryaBackoffice();
     // Los campos de fecha del formulario (Start Date / End Date) ya NO sincronizan
     // con el calendario grande. Cada lógica es independiente.
     this.tourScheduleForm
@@ -1318,11 +1320,11 @@ export class TourScheduleComponent {
   }
 
   getAgeTypeDisplay(ageType: any): string {
-    if (typeof ageType === 'object' && ageType.name) {
-      return ageType.name;
-    }
+    // TC-008: cuando ageType viene como objeto ({name: 'ADULT'}) tambien hay que
+    // traducir. Antes se retornaba el name crudo y quedaba en ingles en la UI.
     if (!ageType) return '';
-    return this.translate.instant('tour-schedule.prices.ageType.' + ageType);
+    const key = typeof ageType === 'object' && ageType.name ? ageType.name : ageType;
+    return this.translate.instant('tour-schedule.prices.ageType.' + key);
   }
 
   getSlotsByDate(event: any, date: Date): any[] {


### PR DESCRIPTION
Cierra la parte **frontend** de **TC-008** (#195). Complementa el PR backend [tourya-api #199](https://github.com/Touryapp/tourya-api/pull/199).

## Contexto

Luis reportó en #195:
- El PROVIDER veía el `price` cliente en su schedule (debe ver solo su `providerPrice`).
- El ADMIN NO veía el `providerPrice` (debe ver Cliente + Provider + % Tourya).
- Los AgeType aparecían en inglés (\"ADULT\", \"CHILD\") en vez de español (\"ADULTO\", \"NIÑO\").

Franklin confirmó UX **opción A**: 2 badges lado a lado en la misma celda.

## Cambios (3 archivos + 3 i18n)

### 1. `tour-schedule.component.ts:179` — `isBackoffice`
`` `typescript
// Antes:
this.isBackoffice = this.authService.isAdmin();
// Ahora:
this.isBackoffice = this.authService.isTouryaBackoffice();
`` `
Con esto BACKOFFICE_OPERATION también ve columna % Tourya + ambos precios (patrón FE-15b consolidado).

### 2. `tour-schedule.component.ts:1320` — `getAgeTypeDisplay`
`` `typescript
// Antes: cuando ageType era objeto, retornaba el name crudo (bug AgeType inglés)
if (typeof ageType === 'object' && ageType.name) {
  return ageType.name;
}
return this.translate.instant('tour-schedule.prices.ageType.' + ageType);

// Ahora: siempre traduce
const key = typeof ageType === 'object' && ageType.name ? ageType.name : ageType;
return this.translate.instant('tour-schedule.prices.ageType.' + key);
`` `

Las traducciones ya existían en `es.json` (ADULTO/NIÑO/INFANTE), solo faltaba que la función las usara cuando `ageType` era objeto.

### 3. `tour-schedule.component.html:583` — Col Precios

**Antes** (un solo badge, todos los roles):
`` `html
<span class=\"badge bg-info\">
  {{ (price.price || price.providerPrice) | currency }}
</span>
`` `

**Ahora** (2 badges lado a lado, condicional por rol):
`` `html
<span *ngIf=\"isBackoffice && price.price != null\" class=\"badge bg-info\">
  {{ 'clientBadge' | translate }}: {{ price.price | currency }}
</span>
<span class=\"badge bg-secondary\">
  {{ 'providerBadge' | translate }}: {{ price.providerPrice | currency }}
</span>
`` `

- **PROVIDER**: solo ""Proveedor: $300,000"" (backend PR api #199 envía `price=null`).
- **ADMIN/BACKOFFICE**: ""Cliente: $345,000"" + ""Proveedor: $300,000"" en la misma celda.

### 4. i18n — 2 nuevas keys × 3 idiomas

`tour-schedule.prices.clientBadge` / `providerBadge`:
- es: ""Cliente"" / ""Proveedor""
- en: ""Client"" / ""Provider""
- pt: ""Cliente"" / ""Fornecedor""

## Verificación

- [x] `ng build --configuration=production` → exit 0 (regla `feedback_ng_build_production` cuarta vez consecutiva sin sorpresas).
- [x] Warnings preexistentes ajenos al PR: TourAdminDetail/TourGridView/TourListView/ToursDetail (deuda vieja).

## Dependencia

Este PR requiere el merge del **PR backend [tourya-api #199](https://github.com/Touryapp/tourya-api/pull/199)** para que el PROVIDER reciba `price=null`. Sin el backend, el PROVIDER seguiría viendo el `price` cliente en la ""Cliente:"" badge... espera — no: el condicional `*ngIf=\"isBackoffice && price.price != null\"` requiere **ambos** (rol backoffice Y `price` no null). Así que si por alguna razón backend olvida enviar `null`, el frontend igual filtra por rol. Doble protección, no depende estrictamente del orden de merge.

## Test plan

- [ ] Login como PROVIDER en `/providers/tours/{id}/tour-schedule` → click en un día del calendario → tabla muestra columnas Horario + Disponibilidad + Precios (solo ""Proveedor: $X""). Sin columna % Tourya. AgeType en español.
- [ ] Login como ADMIN → tabla muestra columnas Horario + Disponibilidad + Precios (""Cliente: $X"" + ""Proveedor: $Y"") + % Tourya editable. AgeType en español.
- [ ] Login como BACKOFFICE_OPERATION → mismo comportamiento que ADMIN.
- [ ] Regresión: el formulario de edición de precios sigue funcionando para PROVIDER (usa `providerPrice` en el FormArray, no cambió).

## Referencias

- Issue [#195 TC-008](https://github.com/Touryapp/tourya-api/issues/195).
- PR backend gemelo [tourya-api #199](https://github.com/Touryapp/tourya-api/pull/199).