### PR TITLE
fix(reservations): propagar canConfirmReservation al booking en tabla (TC-007 #194)

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -393,6 +393,7 @@
       "confirmedTitle": "Confirmed!",
       "confirmedText": "The booking has been successfully marked as delivered.",
       "confirmErrorText": "Could not confirm the booking. Please try again.",
+      "confirmWrongDayText": "You can only confirm the reservation on the day of the tour. Early confirmation is not allowed.",
       "bookingCanceledTitle": "Booking Canceled",
       "bookingCanceledText": "The booking {{bookingId}} has been marked as canceled.",
       "markAsCompletedTitle": "Mark as completed?",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -394,6 +394,7 @@
       "confirmedTitle": "¡Confirmada!",
       "confirmedText": "La reserva ha sido marcada como entregada exitosamente.",
       "confirmErrorText": "No se pudo confirmar la reserva. Por favor intente nuevamente.",
+      "confirmWrongDayText": "Solo puede confirmar la reserva el mismo día del tour. La confirmación anticipada no está permitida.",
       "bookingCanceledTitle": "Reserva cancelada",
       "bookingCanceledText": "La reserva {{bookingId}} ha sido marcada como cancelada.",
       "markAsCompletedTitle": "¿Marcar como completada?",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -393,6 +393,7 @@
       "confirmedTitle": "Confirmada!",
       "confirmedText": "A reserva foi marcada como entregue com sucesso.",
       "confirmErrorText": "Não foi possível confirmar a reserva. Por favor, tente novamente.",
+      "confirmWrongDayText": "Você só pode confirmar a reserva no mesmo dia do tour. A confirmação antecipada não é permitida.",
       "bookingCanceledTitle": "Reserva cancelada",
       "bookingCanceledText": "A reserva {{bookingId}} foi marcada como cancelada.",
       "markAsCompletedTitle": "Marcar como concluída?",

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -639,6 +639,8 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
       canReschedule: reservation.canReschedule,
       canCancel: reservation.canCancel,
       canRainCancel: reservation.canRainCancel,
+      // TC-007 (RN-056): backend calcula canConfirmReservation=true solo el dia del tour.
+      canConfirmReservation: reservation.canConfirmReservation,
       // Payer info from list API
       payerName: reservation.payerName,
       payerEmail: reservation.payerEmail,
@@ -693,6 +695,8 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
       canReschedule: reservation.canReschedule,
       canCancel: reservation.canCancel,
       canRainCancel: reservation.canRainCancel,
+      // TC-007 (RN-056): backend calcula canConfirmReservation=true solo el dia del tour.
+      canConfirmReservation: reservation.canConfirmReservation,
       // Payer info from list API
       payerName: reservation.payerName,
       payerEmail: reservation.payerEmail,
@@ -1187,9 +1191,15 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
           },
           error: (error) => {
             console.error('❌ Error confirmando reserva:', error);
+            // TC-007 (RN-056): backend responde 400 con "Only can confirm reservation on the tour day"
+            // cuando today != reservationDate en zona Bogota. Mostramos mensaje especifico.
+            const backendMsg = error?.error?.message || error?.message || '';
+            const isWrongDay = error?.status === 400 && backendMsg.includes('Only can confirm reservation on the tour day');
             Swal.fire(
               this.translate.instant('provider-tour-management.swal.error'),
-              this.translate.instant('provider-tour-management.swal.confirmErrorText'),
+              isWrongDay
+                ? this.translate.instant('provider-tour-management.swal.confirmWrongDayText')
+                : this.translate.instant('provider-tour-management.swal.confirmErrorText'),
               'error'
             );
           }


### PR DESCRIPTION
Cierra la parte **frontend** de **TC-007** (#194). Complementa el backend [tourya-api PR #200 (mergeado)](https://github.com/Touryapp/tourya-api/pull/200) que agregó el guard temporal en el endpoint `/consume` + fix zona horaria en el helper `canConfirmReservation`.

## Root cause del bug

- El config de acciones (`booking-management-config.service.ts:300`) **ya respeta** `canConfirmReservation` si viene definido:
  `` `typescript
  visible: (row) => {
    if (row.canConfirmReservation !== undefined) return row.canConfirmReservation;
    return row.status === 'Pending' || ...;  // fallback por status
  }
  `` `
- De los 3 mappers del componente, solo **`mapReservationToBooking`** (línea 398, para modal de detalles) copia `canConfirmReservation`.
- **`mapProviderReservationToBooking`** (línea 600) y **`mapClientReservationToBooking`** (línea 654) — para la tabla de la lista — **NO lo copiaban**, cayendo al fallback por status.
- Resultado: el botón ""Confirmar"" aparecía en la **tabla** (fila de RES-318) aunque no fuera el día del tour.

## Cambios

**1. `provider-tour-management.component.ts`** — ambos mappers ahora copian el flag.

Los 2 sitios tenían el mismo bloque `canReschedule/canCancel/canRainCancel`, así que un `Edit` con `replace_all` los actualizó a la vez preservando el comentario TC-007:

`` `typescript
canReschedule: reservation.canReschedule,
canCancel: reservation.canCancel,
canRainCancel: reservation.canRainCancel,
// TC-007 (RN-056): backend calcula canConfirmReservation=true solo el dia del tour.
canConfirmReservation: reservation.canConfirmReservation,
`` `

**2. Mensaje UX específico si backend rechaza el consume por fecha**

Antes se mostraba un genérico ""No se pudo confirmar la reserva"". Ahora si el error 400 contiene el mensaje del backend (`""Only can confirm reservation on the tour day""`), se muestra:

- **es**: ""Solo puede confirmar la reserva el mismo día del tour. La confirmación anticipada no está permitida.""
- **en**: ""You can only confirm the reservation on the day of the tour. Early confirmation is not allowed.""
- **pt**: ""Você só pode confirmar a reserva no mesmo dia do tour. A confirmação antecipada não é permitida.""

Defense in depth: si el usuario cambió la fecha del sistema o el JS quedó cacheado con `canConfirmReservation=true`, el mensaje sigue siendo claro.

## Verificación

- [x] `ng build --configuration=production` → exit 0 (quinta vez consecutiva con la regla `feedback_ng_build_production`).
- [x] Warnings preexistentes ajenos al PR (TourAdminDetail, TourGridView, TourListView, ToursDetail, TourDetailsProvider, FloatingCart).

## Test plan

- [ ] Con RES-318 (24 jul 2026): login como PROVIDER en `/providers/provider-panel` → **la fila NO muestra el botón ""Confirmar""** (backend ya calcula `canConfirmReservation=false`). Antes lo mostraba por status.
- [ ] Con el mismo RES-318 abrir modal de detalles → el botón ""Confirmar"" tampoco aparece (ya funcionaba desde antes).
- [ ] Cambiar fecha del sistema al 24 jul → el botón sí aparece → click → confirma OK.
- [ ] Regresión: reservas del **día actual** en estado Pending siguen mostrando el botón normalmente.
- [ ] Con reserva expirada + browser cache viejo: el botón podría aparecer con `canConfirmReservation=true` (cacheado). Al hacer click, backend responde 400 → **mensaje amigable en el idioma actual** en vez del genérico.

## Referencias

- Issue [#194 TC-007](https://github.com/Touryapp/tourya-api/issues/194).
- Backend gemelo (ya mergeado): [tourya-api PR #200](https://github.com/Touryapp/tourya-api/pull/200).
- RN-056 (nueva) en `docs/05-reglas-de-negocio.md` del backend.