### PR TITLE
feat(reservations): UI provider decline (FE-24 / BE-24 Fase 1)

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -394,6 +394,12 @@
       "confirmedText": "The booking has been successfully marked as delivered.",
       "confirmErrorText": "Could not confirm the booking. Please try again.",
       "confirmWrongDayText": "You can only confirm the reservation on the day of the tour. Early confirmation is not allowed.",
+      "declineTitle": "Can't fulfill this reservation?",
+      "declineText": "When you confirm, the reservation will be automatically cancelled. The traveler will receive a credit for the amount paid and an email with alternative tours. This action cannot be undone.",
+      "yesDecline": "Yes, I can't fulfill it",
+      "declinedTitle": "Reservation declined",
+      "declinedText": "The traveler was notified and received a credit for the amount paid.",
+      "declineErrorText": "Could not decline the reservation. Please try again.",
       "bookingCanceledTitle": "Booking Canceled",
       "bookingCanceledText": "The booking {{bookingId}} has been marked as canceled.",
       "markAsCompletedTitle": "Mark as completed?",
@@ -457,7 +463,8 @@
         "complete": "Complete",
         "approve": "Approve",
         "suspend": "Suspend",
-        "delete": "Delete"
+        "delete": "Delete",
+        "decline": "Can't fulfill"
       },
       "filters": {
         "status": "Status",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -395,6 +395,12 @@
       "confirmedText": "La reserva ha sido marcada como entregada exitosamente.",
       "confirmErrorText": "No se pudo confirmar la reserva. Por favor intente nuevamente.",
       "confirmWrongDayText": "Solo puede confirmar la reserva el mismo día del tour. La confirmación anticipada no está permitida.",
+      "declineTitle": "¿No puedes atender esta reserva?",
+      "declineText": "Al confirmar, la reserva se cancelará automáticamente. Al turista se le generará un crédito por el monto pagado y recibirá un email con tours alternativos. Esta acción no se puede deshacer.",
+      "yesDecline": "Sí, no puedo atender",
+      "declinedTitle": "Reserva declinada",
+      "declinedText": "El turista fue notificado y recibió un crédito por el monto pagado.",
+      "declineErrorText": "No se pudo declinar la reserva. Por favor intente nuevamente.",
       "bookingCanceledTitle": "Reserva cancelada",
       "bookingCanceledText": "La reserva {{bookingId}} ha sido marcada como cancelada.",
       "markAsCompletedTitle": "¿Marcar como completada?",
@@ -458,7 +464,8 @@
         "complete": "Completar",
         "approve": "Aprobar",
         "suspend": "Suspender",
-        "delete": "Eliminar"
+        "delete": "Eliminar",
+        "decline": "No puedo atender"
       },
       "filters": {
         "status": "Estado",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -394,6 +394,12 @@
       "confirmedText": "A reserva foi marcada como entregue com sucesso.",
       "confirmErrorText": "Não foi possível confirmar a reserva. Por favor, tente novamente.",
       "confirmWrongDayText": "Você só pode confirmar a reserva no mesmo dia do tour. A confirmação antecipada não é permitida.",
+      "declineTitle": "Não pode atender esta reserva?",
+      "declineText": "Ao confirmar, a reserva será cancelada automaticamente. O turista receberá um crédito pelo valor pago e um email com tours alternativos. Esta ação não pode ser desfeita.",
+      "yesDecline": "Sim, não posso atender",
+      "declinedTitle": "Reserva recusada",
+      "declinedText": "O turista foi notificado e recebeu um crédito pelo valor pago.",
+      "declineErrorText": "Não foi possível recusar a reserva. Por favor, tente novamente.",
       "bookingCanceledTitle": "Reserva cancelada",
       "bookingCanceledText": "A reserva {{bookingId}} foi marcada como cancelada.",
       "markAsCompletedTitle": "Marcar como concluída?",
@@ -457,7 +463,8 @@
         "complete": "Completar",
         "approve": "Aprovar",
         "suspend": "Suspender",
-        "delete": "Excluir"
+        "delete": "Excluir",
+        "decline": "Não posso atender"
       },
       "filters": {
         "status": "Status",

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -1322,9 +1322,68 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
       case 'cancel':
         this.openCancelModal(booking);
         break;
+      case 'decline':
+        // FE-24 (BE-24 Fase 1 / RN-055): provider avisa que no puede atender esta reserva.
+        this.openDeclineConfirmModal(booking);
+        break;
       default:
         console.warn('Acción no reconocida:', actionId);
     }
+  }
+
+  /**
+   * FE-24: modal de confirmacion explicita antes de declinar. Es una accion irreversible
+   * que dispara cancel + credito al turista + email de tours alternativos + anula
+   * AccountPayable del provider.
+   */
+  private openDeclineConfirmModal(booking: any): void {
+    Swal.fire({
+      title: this.translate.instant('provider-tour-management.swal.declineTitle'),
+      text: this.translate.instant('provider-tour-management.swal.declineText'),
+      icon: 'warning',
+      showCancelButton: true,
+      confirmButtonText: this.translate.instant('provider-tour-management.swal.yesDecline'),
+      cancelButtonText: this.translate.instant('provider-tour-management.swal.cancel'),
+      confirmButtonColor: '#f0a020'
+    }).then((result) => {
+      if (!result.isConfirmed) return;
+
+      const numericId = typeof booking.id === 'string'
+        ? Number(String(booking.id).replace('RES-', ''))
+        : booking.id;
+
+      Swal.fire({
+        title: this.translate.instant('provider-tour-management.swal.processing'),
+        allowOutsideClick: false,
+        didOpen: () => Swal.showLoading()
+      });
+
+      this.reservationService.declineReservation(numericId).subscribe({
+        next: () => {
+          Swal.fire(
+            this.translate.instant('provider-tour-management.swal.declinedTitle'),
+            this.translate.instant('provider-tour-management.swal.declinedText'),
+            'success'
+          );
+          // Cerrar modal de detalles si esta abierto
+          const modalElement = document.getElementById('bookingDetailModal');
+          if (modalElement) {
+            const modal = (window as any).bootstrap?.Modal.getInstance(modalElement);
+            if (modal) modal.hide();
+          }
+          // Refrescar la lista para que refleje el nuevo estado.
+          this.reservationService.notifyReservationUpdated();
+        },
+        error: (error) => {
+          console.error('❌ Error declinando reserva:', error);
+          Swal.fire(
+            this.translate.instant('provider-tour-management.swal.error'),
+            this.translate.instant('provider-tour-management.swal.declineErrorText'),
+            'error'
+          );
+        }
+      });
+    });
   }
 
   /**

--- a/src/app/shared/services/booking-management-config.service.ts
+++ b/src/app/shared/services/booking-management-config.service.ts
@@ -339,6 +339,20 @@ export class BookingManagementConfigService {
           icon: 'fa fa-flag-checkered',
           color: 'primary',
           visible: (row) => row.status === 'Confirmed' || row.status === 'Upcoming'
+        },
+        {
+          // FE-24 (BE-24 Fase 1 / RN-055): provider avisa que no puede atender la reserva.
+          // Backend cancela + crea credito + envia email alternativas. Solo aplica sobre
+          // reservas activas — mismos estados que 'cancel'.
+          id: 'decline',
+          label: 'provider-tour-management.config.actions.decline',
+          icon: 'fa fa-user-times',
+          color: 'warning',
+          visible: (row) => {
+            const isActionable = row.status === 'Pending' || row.status === 'PENDING'
+              || row.status === 'RESCHEDULED' || row.status === 'Rescheduled';
+            return isActionable;
+          }
         }
       ],
       filters: [

--- a/src/app/shared/services/reservation.service.ts
+++ b/src/app/shared/services/reservation.service.ts
@@ -74,6 +74,18 @@ export class ReservationService {
   }
 
   /**
+   * FE-24 (BE-24 Fase 1 / RN-055): el provider declina una reserva porque no puede atenderla.
+   * Backend cancela automaticamente + crea credito al turista + envia email con tours alternativos +
+   * anula AccountPayable. Idempotente: si ya fue declinada responde 400.
+   *
+   * @param reservationId ID de la reserva a declinar
+   * @returns Observable con la reserva actualizada
+   */
+  declineReservation(reservationId: number | string): Observable<Reservation> {
+    return this.http.put<Reservation>(`${this.apiUrl}/reservations/${reservationId}/decline`, {});
+  }
+
+  /**
    * Reagenda una reserva
    * @param reservationId ID de la reserva a reagendar (formato "RES-98" o número)
    * @param body Objeto con los datos de reagendamiento (newDate, slotId, startTime, endTime, configQuantity)


### PR DESCRIPTION
Cierra **FE-24**. Complementa el backend [tourya-api PR #197](https://github.com/Touryapp/tourya-api/pull/197) que expuso el endpoint `PUT /reservations/{id}/decline` con la cadena automática cancel + crédito + email alternativas + anular AccountPayable.

Hasta ahora el endpoint solo se podía llamar por curl/Postman. Este PR agrega el botón en la UI del provider.

## UX

**Ubicación**: botón nuevo ""No puedo atender"" en la tabla del `/providers/provider-panel` (rol PROVIDER) + en el modal de detalles. Icono `fa-user-times`, color warning (naranja) para diferenciarlo del cancel (rojo) y del confirm (verde).

**Visibilidad**: solo aparece si `status ∈ {Pending, Rescheduled}` — mismo patrón que cancel. Estados terminales (Confirmed/Completed/Cancelled/No_Show) NO muestran el botón (backend igual lo rechazaría con 400).

**Flujo**:
1. Click al botón → **modal Swal de confirmación explícita** con el impacto completo (""Al confirmar, la reserva se cancelará. El turista recibirá un crédito por el monto pagado y un email con tours alternativos. Esta acción no se puede deshacer."").
2. Si el provider confirma → loading Swal → llamada `PUT /reservations/{id}/decline`.
3. Success → Swal ""Reserva declinada. El turista fue notificado y recibió un crédito."" + cerrar modal de detalles + `notifyReservationUpdated()` para refrescar la lista.
4. Error → Swal genérico ""No se pudo declinar la reserva"".

## Cambios (6 archivos)

**Angular** (3 archivos):
- `reservation.service.ts` — nuevo `declineReservation(id): Observable<Reservation>` que hace `PUT /reservations/{id}/decline`.
- `booking-management-config.service.ts` — nueva `ActionConfig` con `id: 'decline'` en el bloque del rol PROVIDER (línea 342).
- `provider-tour-management.component.ts` — case `'decline'` en `handleProviderAction` + método privado `openDeclineConfirmModal(booking)`.

**i18n** (3 archivos × 7 keys):
- `provider-tour-management.config.actions.decline` — label del botón: ""No puedo atender"" / ""Can't fulfill"" / ""Não posso atender"".
- `provider-tour-management.swal.declineTitle`, `declineText`, `yesDecline`, `declinedTitle`, `declinedText`, `declineErrorText`.

## Verificación

- [x] `ng build --configuration=production` → exit 0. Cero warnings adicionales (sexta vez consecutiva con `feedback_ng_build_production`).

## Test plan

- [ ] Login como PROVIDER en `/providers/provider-panel` → ver la tabla de reservas → una reserva `Pending` muestra el nuevo botón naranja ""No puedo atender"" junto a Confirmar/Reagendar/Cancelar.
- [ ] Click al botón → modal Swal explica el impacto → click ""Sí, no puedo atender"" → loading → success Swal.
- [ ] Verificar en DB: `reservation.delivery_status = 'CANCELED'`, `reservation.cancellation_reason = 'PROVIDER_DECLINED'`, `reservation.provider_declined_at IS NOT NULL`, `account_payable.delivery_status = 'CANCELLED'`, nuevo `credit` con `status = 'CREATED'` para el turista.
- [ ] Turista recibe email con tours alternativos.
- [ ] La lista de reservas se actualiza y la reserva ya no muestra los botones activos.
- [ ] Regresión: una reserva `Confirmed`/`Completed`/`Cancelled` NO muestra el botón.
- [ ] Cancel: si el provider abre el modal y cancela sin confirmar, no pasa nada (comportamiento esperado).
- [ ] Idempotencia: intentar declinar la misma reserva 2 veces → segundo intento responde 400 (backend valida `providerDeclinedAt != null`) → mensaje ""No se pudo declinar la reserva"".

## Mobile

**FE-24-mobile** queda como pendiente opcional (talla XS): agregar la misma acción en MAUI `ProviderDashboardViewModel` + botón en `ReservationsPage`. No bloqueante — el provider puede usar la web mientras tanto.

## Referencias

- Backend: [tourya-api PR #197](https://github.com/Touryapp/tourya-api/pull/197) — BE-24 Fase 1 (mergeado).
- Issue backend [#193 BE-24](https://github.com/Touryapp/tourya-api/issues/193) — contexto + plan de pruebas backend.
- RN-055 en `docs/05-reglas-de-negocio.md` — política de decline.