### PR TITLE
fix(cart): floating-cart muestra Grupo(s) para priceType=grupo (#189)

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1330,6 +1330,7 @@
     "days": "days",
     "people": "people",
     "personSingularPlural": "person(s)",
+    "groupsLabel": "Group(s)",
     "selectToursFor": "Select tours for",
     "daysOfTravel": "days of travel",
     "selectedTours": "selected tours",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1331,6 +1331,7 @@
     "days": "días",
     "people": "personas",
     "personSingularPlural": "persona(s)",
+    "groupsLabel": "Grupo(s)",
     "selectToursFor": "Selecciona tours para",
     "daysOfTravel": "días de viaje",
     "selectedTours": "tours seleccionados",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1174,6 +1174,7 @@
     "days": "dias",
     "people": "pessoas",
     "personSingularPlural": "pessoa(s)",
+    "groupsLabel": "Grupo(s)",
     "selectToursFor": "Selecione tours para",
     "daysOfTravel": "dias de viagem",
     "selectedTours": "Passeios Selecionados",

--- a/src/app/shared/common/floating-cart/floating-cart.component.html
+++ b/src/app/shared/common/floating-cart/floating-cart.component.html
@@ -105,8 +105,13 @@
               {{ item.selectedSlot.startTime }} - {{ item.selectedSlot.endTime }}
             </p>
 
-            <!-- Participantes -->
-            <p class="tour-card-participants">
+            <!-- Participantes — TC-006: para tours grupo mostramos cantidad de grupos + total pax. -->
+            <p class="tour-card-participants" *ngIf="item.tour?.priceType === 'grupo'">
+              <i class="isax isax-profile-2user"></i>
+              {{ (item.groupCount || 1) }} {{ 'cart.groupsLabel' | translate }}
+              <span class="text-secondary">({{ item.totalParticipants }} {{ 'cart.personSingularPlural' | translate }})</span>
+            </p>
+            <p class="tour-card-participants" *ngIf="item.tour?.priceType !== 'grupo'">
               <i class="isax isax-profile-2user"></i>
               {{ item.totalParticipants }} {{ 'cart.personSingularPlural' | translate }}
             </p>


### PR DESCRIPTION
Cierra definitivamente **TC-006** (#189) tras que Luis confirmó con DevTools que el response backend traía `priceType: ""grupo""` pero la UI seguía mostrando ""2 personas"".

## Root cause

Hay **2 componentes** que renderizan items del cart:
- `cart-summary.component.html` — la vista principal del carrito. Ya arreglado en PR #73 + PR api #198.
- `floating-cart.component.html` — el mini-carrito del navbar/sidebar. **Nunca fue actualizado**. Quedó fuera del scope de los PRs anteriores.

El floating-cart hardcodeaba:
`` `html
{{ item.totalParticipants }} {{ 'cart.personSingularPlural' | translate }}
`` `

Sin condicional por `priceType`. Renderiza siempre ""N personas"" independiente del tipo de tour.

Luis siempre veía el floating-cart (probablemente al hacer click en el carrito del header), que sigue con el código viejo.

## Fix

Replicar el patrón condicional de cart-summary en `floating-cart.component.html`:

`` `html
<p class=""tour-card-participants"" *ngIf=""item.tour?.priceType === 'grupo'"">
  <i class=""isax isax-profile-2user""></i>
  {{ (item.groupCount || 1) }} {{ 'cart.groupsLabel' | translate }}
  <span class=""text-secondary"">({{ item.totalParticipants }} {{ 'cart.personSingularPlural' | translate }})</span>
</p>
<p class=""tour-card-participants"" *ngIf=""item.tour?.priceType !== 'grupo'"">
  <i class=""isax isax-profile-2user""></i>
  {{ item.totalParticipants }} {{ 'cart.personSingularPlural' | translate }}
</p>
`` `

+ nueva key `cart.groupsLabel` en es/en/pt (""Grupo(s)"" / ""Group(s)"" / ""Grupo(s)"").

No requiere cambios en TypeScript ni backend — `groupCount` y `tour.priceType` ya están presentes en `CartItem`.

## Verificación

- [x] `ng build --configuration=production` → exit 0.
- [x] Warnings preexistentes ajenos al PR.

## Test plan

- [ ] Con un tour tipo GRUPO en el carrito (2 grupos = 4 personas): abrir el floating-cart del navbar → debe mostrar **""2 Grupo(s) (4 personas)""**.
- [ ] Con un tour tipo INDIVIDUAL: debe mostrar **""4 personas""** solo.
- [ ] Regresión cart-summary: la vista principal del carrito sigue funcionando igual (no se tocó).

## Referencias

- Issue [#189 TC-006](https://github.com/Touryapp/tourya-api/issues/189) — confirmación de Luis con DevTools.
- PR previo [#73](https://github.com/Touryapp/tourya-front/pull/73) — fix del cart-summary (no incluía floating-cart).
- PR backend [#198](https://github.com/Touryapp/tourya-api/pull/198) — expone `priceType` en el DTO.