### PR TITLE
fix(reviews): Swal muestra nombre del tour, no [object Object] (#203)

### DIFF
--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -1939,8 +1939,12 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
           this.cdr.detectChanges();
         }
 
-        // Translate parameterized text manually
-        const successMsg = this.translate.instant('provider-tour-management.swal.reviewSentText', { tourName: this.reviewModalBooking!.tourName });
+        // Translate parameterized text manually.
+        // TC-010 (#203): tourName es TranslatedField (jsonb {es,en,pt}), no string —
+        // pasarlo directo al translate.instant hacia String(obj) = "[object Object]".
+        // Mismo patron que list-tours.component.ts:1254 y mapReservationToBooking:405.
+        const tourNameText = this.i18nService.getValue(this.reviewModalBooking!.tourName) || 'N/A';
+        const successMsg = this.translate.instant('provider-tour-management.swal.reviewSentText', { tourName: tourNameText });
         Swal.fire({
           icon: 'success',
           title: this.translate.instant('provider-tour-management.swal.reviewSent'),


### PR DESCRIPTION
Cierra **TC-010** (#203). Bug idéntico a TC-002 ya resuelto — mismo patrón `[object Object]`.

## Bug reportado por Luis

Al enviar una reseña como TURISTA, el modal de éxito muestra:

> ¡Reseña enviada!
> Tu reseña para **[object Object]** ha sido guardada exitosamente.

## Root cause

`provider-tour-management.component.ts:1943`:
`` `typescript
const successMsg = this.translate.instant(
    'provider-tour-management.swal.reviewSentText',
    { tourName: this.reviewModalBooking!.tourName }  // ← objeto TranslatedField
);
`` `

`tourName` es un `TranslatedField` (jsonb `{es, en, pt}`), no string. ngx-translate al interpolar hace `String(obj) = ""[object Object]""`.

## Fix (1 línea)

Aplicar el mismo patrón que ya se usa en la línea 405 del mismo archivo (`mapReservationToBooking`):

`` `typescript
const tourNameText = this.i18nService.getValue(this.reviewModalBooking!.tourName) || 'N/A';
const successMsg = this.translate.instant('provider-tour-management.swal.reviewSentText',
    { tourName: tourNameText });
`` `

El servicio `i18nService` ya estaba inyectado (línea 169).

## Audit adicional

Grep completo por `translate.instant.*tourName` en todo el frontend retornó solo 2 lugares:

| Archivo | Estado |
|---|---|
| `list-tours.component.ts:1254` | ✅ Ya usa `i18nService.getValue` correctamente |
| `provider-tour-management.component.ts:1943` | ❌ Este bug — arreglado en el PR |

**No hay otros `[object Object]` latentes** con este patrón.

## Verificación

- [x] `ng build --configuration=production` → exit 0.

## Test plan

- [ ] Login como TURISTA con una reserva completada → abrir modal ""Dejar reseña"" → enviar → el Swal de éxito debe decir ""Tu reseña para **[Nombre real del tour]** ha sido guardada exitosamente"" en el idioma actual (es/en/pt).
- [ ] Regresión: verificar que el resto del flujo de review sigue funcionando (guarda en BD, aparece en el tour, afecta calificación).

## Referencias

- Issue [#203 TC-010](https://github.com/Touryapp/tourya-api/issues/203).
- Bug análogo previo: TC-002 galería con `[object Object]` (cerrado 2026-07-18 en tourya-front PR #65) — mismo patrón `TranslatedField` mal renderizado.