### PR TITLE
feat(admin): CRUD UI BACKOFFICE_OPERATION users (FE-15d)

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1750,6 +1750,72 @@
       "addressLabel": "Our address:"
     }
   },
+  "backofficeUsers": {
+    "sidebarLink": "Backoffice Users",
+    "title": "Backoffice Users",
+    "subtitle": "Manage users with BACKOFFICE_OPERATION role (Tourya staff).",
+    "loading": "Loading users...",
+    "empty": "No BACKOFFICE_OPERATION users yet.",
+    "mustChangePassword": "Must change temporary password",
+    "columns": {
+      "fullName": "Full name",
+      "email": "Email",
+      "phone": "Phone",
+      "status": "Status",
+      "actions": "Actions"
+    },
+    "status": {
+      "enabled": "Active",
+      "disabled": "Inactive"
+    },
+    "actions": {
+      "create": "Create user",
+      "edit": "Edit",
+      "resetPassword": "Reset password",
+      "disable": "Disable",
+      "enable": "Re-enable",
+      "cancel": "Cancel",
+      "save": "Save"
+    },
+    "create": { "title": "Create backoffice user" },
+    "edit": { "title": "Edit backoffice user" },
+    "resetPassword": {
+      "title": "Reset temporary password",
+      "for": "For:"
+    },
+    "form": {
+      "firstname": "First name",
+      "lastname": "Last name",
+      "email": "Email",
+      "phone": "Phone",
+      "temporaryPassword": "Temporary password",
+      "temporaryPasswordHint": "Minimum 8 characters. User must change it on first login."
+    },
+    "swal": {
+      "errorTitle": "Error",
+      "yesConfirm": "Yes, confirm",
+      "cancel": "Cancel",
+      "createdTitle": "User created",
+      "createdText": "The user was created. Share the temporary password with them.",
+      "updatedTitle": "Updated",
+      "updatedText": "User details were updated.",
+      "passwordResetTitle": "Password reset",
+      "passwordResetText": "User must change it on next login.",
+      "confirmToggleTitle": "Confirm?",
+      "confirmDisableText": "You are about to disable {{name}}. They will lose access.",
+      "confirmEnableText": "You are about to re-enable {{name}}. They will regain access.",
+      "disabledTitle": "User disabled",
+      "enabledTitle": "User re-enabled"
+    },
+    "errors": {
+      "loadFailed": "Could not load the user list.",
+      "createFailed": "Could not create the user.",
+      "updateFailed": "Could not update the user.",
+      "resetFailed": "Could not reset the password.",
+      "disableFailed": "Could not disable the user.",
+      "enableFailed": "Could not re-enable the user."
+    }
+  },
   "app-config-admin": {
     "sidebarLink": "Settings",
     "title": "System settings",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1751,6 +1751,72 @@
       "addressLabel": "Nuestra dirección:"
     }
   },
+  "backofficeUsers": {
+    "sidebarLink": "Usuarios Backoffice",
+    "title": "Usuarios Backoffice",
+    "subtitle": "Gestión de usuarios con rol BACKOFFICE_OPERATION (staff Tourya).",
+    "loading": "Cargando usuarios...",
+    "empty": "Aún no hay usuarios BACKOFFICE_OPERATION.",
+    "mustChangePassword": "Debe cambiar la contraseña temporal",
+    "columns": {
+      "fullName": "Nombre completo",
+      "email": "Email",
+      "phone": "Teléfono",
+      "status": "Estado",
+      "actions": "Acciones"
+    },
+    "status": {
+      "enabled": "Activo",
+      "disabled": "Inactivo"
+    },
+    "actions": {
+      "create": "Crear usuario",
+      "edit": "Editar",
+      "resetPassword": "Resetear contraseña",
+      "disable": "Deshabilitar",
+      "enable": "Reactivar",
+      "cancel": "Cancelar",
+      "save": "Guardar"
+    },
+    "create": { "title": "Crear usuario Backoffice" },
+    "edit": { "title": "Editar usuario Backoffice" },
+    "resetPassword": {
+      "title": "Resetear contraseña temporal",
+      "for": "Para:"
+    },
+    "form": {
+      "firstname": "Nombre",
+      "lastname": "Apellido",
+      "email": "Email",
+      "phone": "Teléfono",
+      "temporaryPassword": "Contraseña temporal",
+      "temporaryPasswordHint": "Mínimo 8 caracteres. El usuario deberá cambiarla en el primer login."
+    },
+    "swal": {
+      "errorTitle": "Error",
+      "yesConfirm": "Sí, confirmar",
+      "cancel": "Cancelar",
+      "createdTitle": "Usuario creado",
+      "createdText": "El usuario fue creado. Comunícale la contraseña temporal.",
+      "updatedTitle": "Actualizado",
+      "updatedText": "Los datos del usuario fueron actualizados.",
+      "passwordResetTitle": "Contraseña restablecida",
+      "passwordResetText": "El usuario deberá cambiarla en el próximo login.",
+      "confirmToggleTitle": "¿Confirmar?",
+      "confirmDisableText": "Vas a deshabilitar a {{name}}. No podrá acceder a la plataforma.",
+      "confirmEnableText": "Vas a reactivar a {{name}}. Volverá a poder acceder.",
+      "disabledTitle": "Usuario deshabilitado",
+      "enabledTitle": "Usuario reactivado"
+    },
+    "errors": {
+      "loadFailed": "No se pudo cargar la lista de usuarios.",
+      "createFailed": "No se pudo crear el usuario.",
+      "updateFailed": "No se pudo actualizar el usuario.",
+      "resetFailed": "No se pudo restablecer la contraseña.",
+      "disableFailed": "No se pudo deshabilitar al usuario.",
+      "enableFailed": "No se pudo reactivar al usuario."
+    }
+  },
   "app-config-admin": {
     "sidebarLink": "Configuraciones",
     "title": "Configuraciones del sistema",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1751,6 +1751,72 @@
       "addressLabel": "Nosso endereço:"
     }
   },
+  "backofficeUsers": {
+    "sidebarLink": "Usuários Backoffice",
+    "title": "Usuários Backoffice",
+    "subtitle": "Gestão de usuários com papel BACKOFFICE_OPERATION (equipe Tourya).",
+    "loading": "Carregando usuários...",
+    "empty": "Ainda não há usuários BACKOFFICE_OPERATION.",
+    "mustChangePassword": "Deve alterar a senha temporária",
+    "columns": {
+      "fullName": "Nome completo",
+      "email": "Email",
+      "phone": "Telefone",
+      "status": "Status",
+      "actions": "Ações"
+    },
+    "status": {
+      "enabled": "Ativo",
+      "disabled": "Inativo"
+    },
+    "actions": {
+      "create": "Criar usuário",
+      "edit": "Editar",
+      "resetPassword": "Redefinir senha",
+      "disable": "Desativar",
+      "enable": "Reativar",
+      "cancel": "Cancelar",
+      "save": "Salvar"
+    },
+    "create": { "title": "Criar usuário Backoffice" },
+    "edit": { "title": "Editar usuário Backoffice" },
+    "resetPassword": {
+      "title": "Redefinir senha temporária",
+      "for": "Para:"
+    },
+    "form": {
+      "firstname": "Nome",
+      "lastname": "Sobrenome",
+      "email": "Email",
+      "phone": "Telefone",
+      "temporaryPassword": "Senha temporária",
+      "temporaryPasswordHint": "Mínimo 8 caracteres. O usuário deverá alterá-la no primeiro login."
+    },
+    "swal": {
+      "errorTitle": "Erro",
+      "yesConfirm": "Sim, confirmar",
+      "cancel": "Cancelar",
+      "createdTitle": "Usuário criado",
+      "createdText": "O usuário foi criado. Comunique a senha temporária.",
+      "updatedTitle": "Atualizado",
+      "updatedText": "Os dados do usuário foram atualizados.",
+      "passwordResetTitle": "Senha redefinida",
+      "passwordResetText": "O usuário deverá alterá-la no próximo login.",
+      "confirmToggleTitle": "Confirmar?",
+      "confirmDisableText": "Você vai desativar {{name}}. Não poderá acessar a plataforma.",
+      "confirmEnableText": "Você vai reativar {{name}}. Voltará a poder acessar.",
+      "disabledTitle": "Usuário desativado",
+      "enabledTitle": "Usuário reativado"
+    },
+    "errors": {
+      "loadFailed": "Não foi possível carregar a lista de usuários.",
+      "createFailed": "Não foi possível criar o usuário.",
+      "updateFailed": "Não foi possível atualizar o usuário.",
+      "resetFailed": "Não foi possível redefinir a senha.",
+      "disableFailed": "Não foi possível desativar o usuário.",
+      "enableFailed": "Não foi possível reativar o usuário."
+    }
+  },
   "app-config-admin": {
     "sidebarLink": "Configurações",
     "title": "Configurações do sistema",

--- a/src/app/pages/admin/admin-routing.module.ts
+++ b/src/app/pages/admin/admin-routing.module.ts
@@ -36,6 +36,12 @@ const routes: Routes = [
         path: 'maritime-reports',
         canActivate: [BackofficeGuard],
         loadComponent: () => import('../maritime-activity-reports/maritime-activity-reports.component').then(m => m.MaritimeActivityReportsComponent)
+      },
+      // FE-15d: CRUD de usuarios BACKOFFICE_OPERATION. Solo ADMIN puede gestionar.
+      {
+        path: 'backoffice-users',
+        canActivate: [AdminGuard],
+        loadComponent: () => import('./backoffice-users/backoffice-users.component').then(m => m.BackofficeUsersComponent)
       }
     ]
   }

--- a/src/app/pages/admin/backoffice-users/backoffice-users.component.html
+++ b/src/app/pages/admin/backoffice-users/backoffice-users.component.html
@@ -1,0 +1,204 @@
+<!-- FE-15d: gestion de usuarios BACKOFFICE_OPERATION (solo ADMIN). -->
+<div class="card border-0 shadow-sm mb-4">
+  <div class="card-body">
+    <div class="d-flex align-items-center justify-content-between flex-wrap gap-3">
+      <div>
+        <h5 class="mb-1">
+          <i class="isax isax-people me-2 text-primary"></i>{{ 'backofficeUsers.title' | translate }}
+        </h5>
+        <p class="text-muted mb-0 small">{{ 'backofficeUsers.subtitle' | translate }}</p>
+      </div>
+      <button class="btn btn-primary d-flex align-items-center gap-2" (click)="openCreateModal()">
+        <i class="isax isax-add-circle fs-18"></i> {{ 'backofficeUsers.actions.create' | translate }}
+      </button>
+    </div>
+  </div>
+</div>
+
+<div class="card border-0 shadow-sm overflow-hidden">
+  <div class="card-body p-0">
+    <div *ngIf="isLoading" class="text-center py-5">
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">{{ 'backofficeUsers.loading' | translate }}</span>
+      </div>
+      <p class="mt-2 text-muted small">{{ 'backofficeUsers.loading' | translate }}</p>
+    </div>
+
+    <div *ngIf="errorMessage && !isLoading" class="alert alert-danger m-3">
+      {{ errorMessage }}
+    </div>
+
+    <div class="table-responsive" *ngIf="!isLoading">
+      <table mat-table [dataSource]="dataSource" matSort class="table table-hover mb-0 w-100">
+
+        <ng-container matColumnDef="userId">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>#</th>
+          <td mat-cell *matCellDef="let user">{{ user.userId }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="fullName">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'backofficeUsers.columns.fullName' | translate }}</th>
+          <td mat-cell *matCellDef="let user">{{ user.fullName || '—' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="email">
+          <th mat-header-cell *matHeaderCellDef mat-sort-header>{{ 'backofficeUsers.columns.email' | translate }}</th>
+          <td mat-cell *matCellDef="let user">{{ user.email }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="phone">
+          <th mat-header-cell *matHeaderCellDef>{{ 'backofficeUsers.columns.phone' | translate }}</th>
+          <td mat-cell *matCellDef="let user">{{ user.phone || '—' }}</td>
+        </ng-container>
+
+        <ng-container matColumnDef="accountEnabled">
+          <th mat-header-cell *matHeaderCellDef>{{ 'backofficeUsers.columns.status' | translate }}</th>
+          <td mat-cell *matCellDef="let user">
+            <span class="badge" [ngClass]="user.accountEnabled ? 'bg-success' : 'bg-secondary'">
+              {{ (user.accountEnabled ? 'backofficeUsers.status.enabled' : 'backofficeUsers.status.disabled') | translate }}
+            </span>
+            <span *ngIf="user.mustChangePassword" class="badge bg-warning text-dark ms-1"
+                  [title]="'backofficeUsers.mustChangePassword' | translate">
+              <i class="isax isax-info-circle"></i>
+            </span>
+          </td>
+        </ng-container>
+
+        <ng-container matColumnDef="actions">
+          <th mat-header-cell *matHeaderCellDef class="text-end">{{ 'backofficeUsers.columns.actions' | translate }}</th>
+          <td mat-cell *matCellDef="let user" class="text-end">
+            <button class="btn btn-sm btn-outline-primary me-1" (click)="openEditModal(user)"
+                    [title]="'backofficeUsers.actions.edit' | translate">
+              <i class="isax isax-edit"></i>
+            </button>
+            <button class="btn btn-sm btn-outline-warning me-1" (click)="openResetPasswordModal(user)"
+                    [title]="'backofficeUsers.actions.resetPassword' | translate">
+              <i class="isax isax-key"></i>
+            </button>
+            <button class="btn btn-sm" [ngClass]="user.accountEnabled ? 'btn-outline-danger' : 'btn-outline-success'"
+                    (click)="toggleEnabled(user)"
+                    [title]="(user.accountEnabled ? 'backofficeUsers.actions.disable' : 'backofficeUsers.actions.enable') | translate">
+              <i class="isax" [ngClass]="user.accountEnabled ? 'isax-lock' : 'isax-unlock'"></i>
+            </button>
+          </td>
+        </ng-container>
+
+        <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+      </table>
+
+      <div *ngIf="!isLoading && users.length === 0" class="text-center py-5 text-muted">
+        {{ 'backofficeUsers.empty' | translate }}
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ─── Create Modal ─────────────────────────────────────────────────────── -->
+<div class="modal fade show d-block" *ngIf="activeModal === 'create'" tabindex="-1"
+     style="background: rgba(0,0,0,0.5);">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <form [formGroup]="createForm" (ngSubmit)="submitCreate()">
+        <div class="modal-header">
+          <h5 class="modal-title">{{ 'backofficeUsers.create.title' | translate }}</h5>
+          <button type="button" class="btn-close" (click)="closeModal()"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">{{ 'backofficeUsers.form.firstname' | translate }} *</label>
+            <input type="text" class="form-control" formControlName="firstname" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">{{ 'backofficeUsers.form.lastname' | translate }}</label>
+            <input type="text" class="form-control" formControlName="lastname">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">{{ 'backofficeUsers.form.email' | translate }} *</label>
+            <input type="email" class="form-control" formControlName="email" required>
+          </div>
+          <div class="mb-3">
+            <label class="form-label">{{ 'backofficeUsers.form.phone' | translate }}</label>
+            <input type="text" class="form-control" formControlName="phone">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">{{ 'backofficeUsers.form.temporaryPassword' | translate }} *</label>
+            <input type="text" class="form-control" formControlName="temporaryPassword" required minlength="8">
+            <small class="text-muted">{{ 'backofficeUsers.form.temporaryPasswordHint' | translate }}</small>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" (click)="closeModal()">{{ 'backofficeUsers.actions.cancel' | translate }}</button>
+          <button type="submit" class="btn btn-primary" [disabled]="createForm.invalid">
+            {{ 'backofficeUsers.actions.create' | translate }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- ─── Edit Modal ─────────────────────────────────────────────────────── -->
+<div class="modal fade show d-block" *ngIf="activeModal === 'edit'" tabindex="-1"
+     style="background: rgba(0,0,0,0.5);">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <form [formGroup]="editForm" (ngSubmit)="submitEdit()">
+        <div class="modal-header">
+          <h5 class="modal-title">{{ 'backofficeUsers.edit.title' | translate }}</h5>
+          <button type="button" class="btn-close" (click)="closeModal()"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">{{ 'backofficeUsers.form.firstname' | translate }}</label>
+            <input type="text" class="form-control" formControlName="firstname">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">{{ 'backofficeUsers.form.lastname' | translate }}</label>
+            <input type="text" class="form-control" formControlName="lastname">
+          </div>
+          <div class="mb-3">
+            <label class="form-label">{{ 'backofficeUsers.form.phone' | translate }}</label>
+            <input type="text" class="form-control" formControlName="phone">
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" (click)="closeModal()">{{ 'backofficeUsers.actions.cancel' | translate }}</button>
+          <button type="submit" class="btn btn-primary">{{ 'backofficeUsers.actions.save' | translate }}</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+<!-- ─── Reset Password Modal ─────────────────────────────────────────────── -->
+<div class="modal fade show d-block" *ngIf="activeModal === 'resetPassword'" tabindex="-1"
+     style="background: rgba(0,0,0,0.5);">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <form [formGroup]="resetPasswordForm" (ngSubmit)="submitResetPassword()">
+        <div class="modal-header">
+          <h5 class="modal-title">{{ 'backofficeUsers.resetPassword.title' | translate }}</h5>
+          <button type="button" class="btn-close" (click)="closeModal()"></button>
+        </div>
+        <div class="modal-body">
+          <p class="text-muted small">
+            {{ 'backofficeUsers.resetPassword.for' | translate }}
+            <strong>{{ selectedUser?.email }}</strong>
+          </p>
+          <div class="mb-3">
+            <label class="form-label">{{ 'backofficeUsers.form.temporaryPassword' | translate }} *</label>
+            <input type="text" class="form-control" formControlName="temporaryPassword" required minlength="8">
+            <small class="text-muted">{{ 'backofficeUsers.form.temporaryPasswordHint' | translate }}</small>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" (click)="closeModal()">{{ 'backofficeUsers.actions.cancel' | translate }}</button>
+          <button type="submit" class="btn btn-warning" [disabled]="resetPasswordForm.invalid">
+            {{ 'backofficeUsers.actions.resetPassword' | translate }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/admin/backoffice-users/backoffice-users.component.scss
+++ b/src/app/pages/admin/backoffice-users/backoffice-users.component.scss
@@ -1,0 +1,11 @@
+// FE-15d: estilos minimos del CRUD backoffice users.
+
+.modal.d-block {
+  z-index: 1055;
+}
+
+table.mat-mdc-table {
+  th, td {
+    padding: 12px 16px;
+  }
+}

--- a/src/app/pages/admin/backoffice-users/backoffice-users.component.ts
+++ b/src/app/pages/admin/backoffice-users/backoffice-users.component.ts
@@ -1,0 +1,259 @@
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  FormBuilder,
+  FormGroup,
+  Validators
+} from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { Subject, takeUntil } from 'rxjs';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+
+import { MatTableDataSource } from '@angular/material/table';
+import { MatSort } from '@angular/material/sort';
+
+import { SharedModule } from '../../../shared/shared-module';
+import { materialModule } from '../../../shared/material.module';
+import { BackofficeUsersService } from '../../../shared/services/backoffice-users.service';
+import {
+  BackofficeUser,
+  CreateBackofficeUserRequest,
+  UpdateBackofficeUserRequest
+} from '../../../shared/models/backoffice-user.model';
+import Swal from 'sweetalert2';
+
+type ModalType = 'create' | 'edit' | 'resetPassword' | null;
+
+/**
+ * FE-15d: CRUD de usuarios con rol BACKOFFICE_OPERATION. Solo accesible por
+ * ADMIN (protegido por AdminGuard en la ruta). Basado en el patron de
+ * provider-users, sin la relacion tours/principal (los BACKOFFICE_OPERATION
+ * son staff Tourya, no tienen tours asignados).
+ */
+@Component({
+  selector: 'app-backoffice-users',
+  standalone: true,
+  templateUrl: './backoffice-users.component.html',
+  styleUrls: ['./backoffice-users.component.scss'],
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    RouterModule,
+    SharedModule,
+    materialModule,
+    TranslateModule
+  ]
+})
+export class BackofficeUsersComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+
+  users: BackofficeUser[] = [];
+  dataSource = new MatTableDataSource<BackofficeUser>([]);
+  displayedColumns: string[] = [
+    'userId',
+    'fullName',
+    'email',
+    'phone',
+    'accountEnabled',
+    'actions'
+  ];
+
+  @ViewChild(MatSort) sort!: MatSort;
+
+  activeModal: ModalType = null;
+  selectedUser: BackofficeUser | null = null;
+  isLoading = false;
+  errorMessage = '';
+
+  createForm: FormGroup;
+  editForm: FormGroup;
+  resetPasswordForm: FormGroup;
+
+  constructor(
+    private fb: FormBuilder,
+    private backofficeUsersService: BackofficeUsersService,
+    private translate: TranslateService
+  ) {
+    this.createForm = this.fb.group({
+      firstname: ['', [Validators.required, Validators.minLength(2)]],
+      lastname: [''],
+      email: ['', [Validators.required, Validators.email]],
+      phone: [''],
+      temporaryPassword: ['', [Validators.required, Validators.minLength(8)]]
+    });
+
+    this.editForm = this.fb.group({
+      firstname: [''],
+      lastname: [''],
+      phone: ['']
+    });
+
+    this.resetPasswordForm = this.fb.group({
+      temporaryPassword: ['', [Validators.required, Validators.minLength(8)]]
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadUsers();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private loadUsers(): void {
+    this.isLoading = true;
+    this.errorMessage = '';
+    this.backofficeUsersService.getAll()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (users) => {
+          this.users = users;
+          this.dataSource = new MatTableDataSource(users);
+          this.dataSource.sort = this.sort;
+          this.isLoading = false;
+        },
+        error: (err) => {
+          console.error('Error cargando backoffice users', err);
+          this.errorMessage = this.translate.instant('backofficeUsers.errors.loadFailed');
+          this.isLoading = false;
+        }
+      });
+  }
+
+  openCreateModal(): void {
+    this.createForm.reset();
+    this.activeModal = 'create';
+  }
+
+  openEditModal(user: BackofficeUser): void {
+    this.selectedUser = user;
+    const [firstname, ...rest] = (user.fullName || '').split(' ');
+    this.editForm.patchValue({
+      firstname: firstname || '',
+      lastname: rest.join(' ') || '',
+      phone: user.phone || ''
+    });
+    this.activeModal = 'edit';
+  }
+
+  openResetPasswordModal(user: BackofficeUser): void {
+    this.selectedUser = user;
+    this.resetPasswordForm.reset();
+    this.activeModal = 'resetPassword';
+  }
+
+  closeModal(): void {
+    this.activeModal = null;
+    this.selectedUser = null;
+  }
+
+  submitCreate(): void {
+    if (this.createForm.invalid) {
+      this.createForm.markAllAsTouched();
+      return;
+    }
+    const body: CreateBackofficeUserRequest = {
+      firstname: this.createForm.value.firstname,
+      lastname: this.createForm.value.lastname || undefined,
+      email: this.createForm.value.email,
+      phone: this.createForm.value.phone || null,
+      temporaryPassword: this.createForm.value.temporaryPassword
+    };
+    this.backofficeUsersService.create(body).subscribe({
+      next: () => {
+        Swal.fire({
+          icon: 'success',
+          title: this.translate.instant('backofficeUsers.swal.createdTitle'),
+          text: this.translate.instant('backofficeUsers.swal.createdText')
+        });
+        this.closeModal();
+        this.loadUsers();
+      },
+      error: (err) => this.showApiError(err, 'backofficeUsers.errors.createFailed')
+    });
+  }
+
+  submitEdit(): void {
+    if (!this.selectedUser || this.editForm.invalid) return;
+    const body: UpdateBackofficeUserRequest = {
+      firstname: this.editForm.value.firstname || undefined,
+      lastname: this.editForm.value.lastname || undefined,
+      phone: this.editForm.value.phone || null
+    };
+    this.backofficeUsersService.update(this.selectedUser.userId, body).subscribe({
+      next: () => {
+        Swal.fire({
+          icon: 'success',
+          title: this.translate.instant('backofficeUsers.swal.updatedTitle'),
+          text: this.translate.instant('backofficeUsers.swal.updatedText')
+        });
+        this.closeModal();
+        this.loadUsers();
+      },
+      error: (err) => this.showApiError(err, 'backofficeUsers.errors.updateFailed')
+    });
+  }
+
+  submitResetPassword(): void {
+    if (!this.selectedUser || this.resetPasswordForm.invalid) return;
+    this.backofficeUsersService.resetPassword(this.selectedUser.userId, {
+      temporaryPassword: this.resetPasswordForm.value.temporaryPassword
+    }).subscribe({
+      next: () => {
+        Swal.fire({
+          icon: 'success',
+          title: this.translate.instant('backofficeUsers.swal.passwordResetTitle'),
+          text: this.translate.instant('backofficeUsers.swal.passwordResetText')
+        });
+        this.closeModal();
+        this.loadUsers();
+      },
+      error: (err) => this.showApiError(err, 'backofficeUsers.errors.resetFailed')
+    });
+  }
+
+  toggleEnabled(user: BackofficeUser): void {
+    const action = user.accountEnabled
+      ? this.backofficeUsersService.disable(user.userId)
+      : this.backofficeUsersService.enable(user.userId);
+    const titleKey = user.accountEnabled ? 'backofficeUsers.swal.disabledTitle' : 'backofficeUsers.swal.enabledTitle';
+    const errorKey = user.accountEnabled ? 'backofficeUsers.errors.disableFailed' : 'backofficeUsers.errors.enableFailed';
+
+    Swal.fire({
+      title: this.translate.instant('backofficeUsers.swal.confirmToggleTitle'),
+      text: user.accountEnabled
+        ? this.translate.instant('backofficeUsers.swal.confirmDisableText', { name: user.fullName })
+        : this.translate.instant('backofficeUsers.swal.confirmEnableText', { name: user.fullName }),
+      icon: 'question',
+      showCancelButton: true,
+      confirmButtonText: this.translate.instant('backofficeUsers.swal.yesConfirm'),
+      cancelButtonText: this.translate.instant('backofficeUsers.swal.cancel')
+    }).then((result) => {
+      if (!result.isConfirmed) return;
+      action.subscribe({
+        next: () => {
+          Swal.fire({
+            icon: 'success',
+            title: this.translate.instant(titleKey)
+          });
+          this.loadUsers();
+        },
+        error: (err) => this.showApiError(err, errorKey)
+      });
+    });
+  }
+
+  private showApiError(err: any, fallbackKey: string): void {
+    const backendMsg = err?.error?.message || err?.error?.error || '';
+    Swal.fire({
+      icon: 'error',
+      title: this.translate.instant('backofficeUsers.swal.errorTitle'),
+      text: backendMsg || this.translate.instant(fallbackKey)
+    });
+  }
+}

--- a/src/app/pages/admin/dashboard/dashboard.component.html
+++ b/src/app/pages/admin/dashboard/dashboard.component.html
@@ -56,6 +56,10 @@
                 class="isax isax-calendar-tick"></i> Reservas</a>
           </li>
           <li>
+            <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToBackofficeUsers()"><i
+                class="isax isax-people"></i> {{ 'backofficeUsers.sidebarLink' | translate }}</a>
+          </li>
+          <li>
             <a class="d-flex align-items-center" style="cursor: pointer;" (click)="toggleAppConfig()"><i
                 class="isax isax-setting-2"></i> {{ 'app-config-admin.sidebarLink' | translate }}</a>
           </li>

--- a/src/app/pages/admin/dashboard/dashboard.component.ts
+++ b/src/app/pages/admin/dashboard/dashboard.component.ts
@@ -44,6 +44,11 @@ export class DashboardComponent implements OnInit {
     this.router.navigate(['/admin/bookings-management']);
   }
 
+  /** FE-15d: navega al CRUD de usuarios BACKOFFICE_OPERATION (solo ADMIN). */
+  goToBackofficeUsers(): void {
+    this.router.navigate(['/admin/backoffice-users']);
+  }
+
   ngOnInit(): void {
     this.cargarSolicitudes();
     this.showGalleryFiles();

--- a/src/app/shared/models/backoffice-user.model.ts
+++ b/src/app/shared/models/backoffice-user.model.ts
@@ -1,0 +1,30 @@
+/**
+ * FE-15d: modelos para gestion de usuarios BACKOFFICE_OPERATION.
+ * Backend endpoint: /admin/backoffice-users (solo ADMIN puede gestionarlos).
+ */
+export interface BackofficeUser {
+  userId: number;
+  email: string;
+  fullName: string;
+  phone?: string | null;
+  accountEnabled: boolean;
+  mustChangePassword: boolean;
+}
+
+export interface CreateBackofficeUserRequest {
+  firstname: string;
+  lastname: string;
+  email: string;
+  phone?: string | null;
+  temporaryPassword: string;
+}
+
+export interface UpdateBackofficeUserRequest {
+  firstname?: string;
+  lastname?: string;
+  phone?: string | null;
+}
+
+export interface ResetBackofficeUserPasswordRequest {
+  temporaryPassword: string;
+}

--- a/src/app/shared/services/backoffice-users.service.ts
+++ b/src/app/shared/services/backoffice-users.service.ts
@@ -1,0 +1,46 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import {
+  BackofficeUser,
+  CreateBackofficeUserRequest,
+  ResetBackofficeUserPasswordRequest,
+  UpdateBackofficeUserRequest
+} from '../models/backoffice-user.model';
+
+/**
+ * FE-15d: cliente HTTP para el modulo /admin/backoffice-users del backend
+ * (PR api #204). Solo lo puede consumir un ADMIN.
+ */
+@Injectable({ providedIn: 'root' })
+export class BackofficeUsersService {
+  private apiUrl = environment.apiUrl + '/admin/backoffice-users';
+
+  constructor(private http: HttpClient) {}
+
+  getAll(): Observable<BackofficeUser[]> {
+    return this.http.get<BackofficeUser[]>(this.apiUrl);
+  }
+
+  create(body: CreateBackofficeUserRequest): Observable<BackofficeUser> {
+    return this.http.post<BackofficeUser>(this.apiUrl, body);
+  }
+
+  update(userId: number, body: UpdateBackofficeUserRequest): Observable<BackofficeUser> {
+    return this.http.put<BackofficeUser>(`${this.apiUrl}/${userId}`, body);
+  }
+
+  resetPassword(userId: number, body: ResetBackofficeUserPasswordRequest): Observable<any> {
+    return this.http.put<any>(`${this.apiUrl}/${userId}/reset-password`, body);
+  }
+
+  /** Soft delete: user queda con enabled = false, no se borra del BD. */
+  disable(userId: number): Observable<any> {
+    return this.http.delete<any>(`${this.apiUrl}/${userId}`);
+  }
+
+  enable(userId: number): Observable<any> {
+    return this.http.put<any>(`${this.apiUrl}/${userId}/enable`, null);
+  }
+}


### PR DESCRIPTION
Cierra frontend de FE-15d. Complementa backend PR api #204 (mergeado). Desbloquea Prueba 3 de #195 TC-008.

Modulo /admin/backoffice-users con MatTable + MatSort, 3 modales inline (create/edit/reset), toggle enable/disable con confirmacion Swal, guard AdminGuard en la ruta.

Basado en el patron de provider-users pero sin tours/principal (BACKOFFICE_OPERATION es staff Tourya).

11 archivos:
- backoffice-user.model.ts (4 interfaces)
- backoffice-users.service.ts (6 metodos HTTP)
- pages/admin/backoffice-users/ (ts + html + scss)
- admin-routing.module.ts (ruta lazy con AdminGuard)
- dashboard.component (link Usuarios Backoffice en sidebar)
- i18n es/en/pt (bloque backofficeUsers.* con ~40 keys)

Verificado: ng build --configuration=production exit 0.

Ref: Issue #195 TC-008, backend PR #204.