### PR TITLE
fix(login): redirect BACKOFFICE_OPERATION post-login (#195)

### DIFF
--- a/src/app/auth/login-tourist/login-tourist.component.ts
+++ b/src/app/auth/login-tourist/login-tourist.component.ts
@@ -205,6 +205,10 @@ export class LoginTouristComponent implements OnInit, OnDestroy {
   redirectByRole(role: RoleDto[]) {
     if (role.some(r => r.id === Roles.ADMIN)) {
       this.router.navigate(["admin"]);
+    } else if (role.some(r => r.id === Roles.BACKOFFICE_OPERATION)) {
+      // FE-15d fix (#195): sin este branch el user quedaba clavado en login post-auth.
+      // Mismo destino que HomeRedirectGuard para este rol.
+      this.router.navigate(["admin/bookings-management"]);
     } else if (role.some(r => r.id === Roles.PROVIDER || r.id === Roles.PROVIDER_OPERATOR)) {
       this.router.navigate(["providers/provider-panel"]);
     } else if (role.some(r => r.id === Roles.USER)) {


### PR DESCRIPTION
Cierra la re-apertura de **#195** por Luis (25-jul 01:40 UTC).

## Bug reportado

Luis creó un usuario BACKOFFICE_OPERATION con FE-15d exitosamente pero no podia autenticarse — visualmente parecia login fallido.

## Root cause (backend está perfecto)

Cloud Run logs de las últimas 24h: todos los POST `/auth/authenticate` desde la IP de Luis retornaron **200 OK** con JWT válido entre 01:16 y 01:52 UTC.

El bug esta en el frontend: `login-tourist.component.ts:205` `redirectByRole` tenía branches para ADMIN, PROVIDER/OPERATOR y USER, pero **no tenía branch para BACKOFFICE_OPERATION** (`Roles.id=35`). Cuando el user logeaba exitosamente:

1. POST /auth/authenticate → 200 OK, JWT emitido.
2. `setUser` + `performNavigation` → `redirectByRole`.
3. Ninguna branch matcheaba → no ejecuta `router.navigate`.
4. Usuario queda clavado en `/authentication/login-tourist` — parece login fallido.

## Fix (2 líneas)

Nueva branch en `redirectByRole`:

```typescript
} else if (role.some(r => r.id === Roles.BACKOFFICE_OPERATION)) {
  this.router.navigate(["admin/bookings-management"]);
}
```

Mismo destino que ya usa `HomeRedirectGuard` para este rol tras un refresh — ahora consistente en el post-login.

## Verificación

- `ng build --configuration=production` exit 0.
- Sin cambios en backend, sin tests nuevos.

## Referencias

- Issue [#195](https://github.com/Touryapp/tourya-api/issues/195) reabierto por Luis.
- PR previo [tourya-front #80](https://github.com/Touryapp/tourya-front/pull/80) — FE-15d UI create user (funcionó).
- PR backend [tourya-api #204](https://github.com/Touryapp/tourya-api/pull/204) — endpoints REST (funcionan).