### PR TITLE
fix(TC-008 #195): ChunkLoadError post-deploy — PR a develop (re-apply)

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -17,10 +17,25 @@ http {
     root /usr/share/nginx/html;
     index index.html;
 
+    # TC-008 (#195): assets estaticos deben devolver 404 real cuando no existen,
+    # no el index.html (que rompe `import()` dinamico de Angular con
+    # "Failed to fetch dynamically imported module").
+    location ~* \.(?:js|mjs|css|map|json|png|jpg|jpeg|gif|svg|ico|webp|woff2?|ttf|otf|eot)$ {
+      try_files $uri =404;
+      # Assets con hash → cache larga.
+      expires 1y;
+      add_header Cache-Control "public, immutable";
+    }
+
+    # index.html nunca debe cachearse: contiene los hashes de los chunks del deploy actual.
+    location = /index.html {
+      add_header Cache-Control "no-store, no-cache, must-revalidate";
+      expires -1;
+    }
+
+    # SPA fallback: cualquier ruta de navegacion (sin extension) cae al index.html.
     location / {
       try_files $uri $uri/ /index.html;
     }
-
-    error_page 404 /index.html;
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from "@angular/core";
+import { ErrorHandler, NgModule } from "@angular/core";
 import { BrowserModule } from "@angular/platform-browser";
 import { registerLocaleData } from '@angular/common';
 import localeEs from '@angular/common/locales/es';
@@ -13,6 +13,7 @@ import { provideAnimationsAsync } from "@angular/platform-browser/animations/asy
 import { NgScrollbarModule } from "ngx-scrollbar";
 import { HTTP_INTERCEPTORS, HttpClientModule } from "@angular/common/http";
 import { AuthInterceptor } from "./core/interceptors/auth.interceptor";
+import { ChunkLoadErrorHandler } from "./core/chunk-load-error-handler";
 
 // Importaciones para Firebase
 import { initializeApp } from "firebase/app";
@@ -79,6 +80,7 @@ export const auth = getAuth(app);
       useClass: AuthInterceptor,
       multi: true,
     },
+    { provide: ErrorHandler, useClass: ChunkLoadErrorHandler },
     provideHttpClient(withInterceptorsFromDi()),
   ],
   bootstrap: [AppComponent],

--- a/src/app/core/chunk-load-error-handler.ts
+++ b/src/app/core/chunk-load-error-handler.ts
@@ -1,0 +1,57 @@
+import { ErrorHandler, Injectable } from '@angular/core';
+
+/**
+ * TC-008 (#195): recuperacion automatica cuando un chunk lazy-loaded del bundle
+ * ya no existe en el servidor (deploy nuevo re-genera hashes) y el navegador
+ * tiene main.js cacheado apuntando al hash viejo.
+ *
+ * Sintomas: `Failed to fetch dynamically imported module`, `ChunkLoadError`,
+ * `Loading chunk X failed`. Sin este handler el usuario queda clavado sin
+ * navegacion posible; con `location.reload()` fuerza recarga de index.html y
+ * su main.js apunta a los chunks del deploy vigente.
+ *
+ * Guard `chunkReloadInProgress` en sessionStorage: evita loop infinito si el
+ * reload no soluciona el problema (bug real, no cache stale).
+ */
+@Injectable({ providedIn: 'root' })
+export class ChunkLoadErrorHandler implements ErrorHandler {
+  private static readonly RELOAD_FLAG = 'chunkReloadInProgress';
+
+  handleError(error: unknown): void {
+    const message = this.extractMessage(error);
+
+    if (this.isChunkLoadError(message)) {
+      const alreadyReloaded = sessionStorage.getItem(ChunkLoadErrorHandler.RELOAD_FLAG);
+      if (!alreadyReloaded) {
+        sessionStorage.setItem(ChunkLoadErrorHandler.RELOAD_FLAG, '1');
+        window.location.reload();
+        return;
+      }
+      console.error('ChunkLoadError persistio despues de reload — no es cache stale:', error);
+      sessionStorage.removeItem(ChunkLoadErrorHandler.RELOAD_FLAG);
+    } else {
+      sessionStorage.removeItem(ChunkLoadErrorHandler.RELOAD_FLAG);
+    }
+
+    console.error(error);
+  }
+
+  private extractMessage(error: unknown): string {
+    if (!error) return '';
+    if (typeof error === 'string') return error;
+    if (error instanceof Error) return error.message;
+    const anyError = error as { message?: unknown; toString?: () => string };
+    if (typeof anyError.message === 'string') return anyError.message;
+    return String(error);
+  }
+
+  private isChunkLoadError(message: string): boolean {
+    if (!message) return false;
+    return (
+      message.includes('Failed to fetch dynamically imported module') ||
+      message.includes('error loading dynamically imported module') ||
+      /Loading chunk .+ failed/i.test(message) ||
+      message.includes('ChunkLoadError')
+    );
+  }
+}


### PR DESCRIPTION
## Contexto

El PR #83 se mergeo por error a \`main\` (base branch default), no a \`develop\`.
Ese PR arrastro ademas ~100 archivos del diff \`develop → main\`.

Este PR es un cherry-pick del commit del fix (\`e518486\`) apuntado correctamente a \`develop\`, solo con los 3 archivos que hacen falta:

- \`nginx.conf\` — SPA fallback correcto (assets \`.js/.css/...\` retornan 404 real, no HTML)
- \`src/app/core/chunk-load-error-handler.ts\` — ErrorHandler global que hace \`window.location.reload()\` al detectar \`Failed to fetch dynamically imported module\`
- \`src/app/app.module.ts\` — registra el ErrorHandler

Ver PR #83 para el analisis completo del root cause y detalles tecnicos.

## Test plan

- [ ] Pipeline verde y despliega a Cloud Run dev.
- [ ] \`curl -sI https://tourya-dev-front-.../chunk-INEXISTENTE.js\` retorna **404** (no 200 con text/html).
- [ ] Luis puede logearse con ADMIN y con BACKOFFICE_OPERATION.

Closes #195 tras validacion de Luis.