### PR TITLE
fix(TC-009 #196): documentType + foto opcional + fallback social en guest-info-modal

### DIFF
--- a/src/app/shared/common/guest-info-modal/guest-info-modal.component.html
+++ b/src/app/shared/common/guest-info-modal/guest-info-modal.component.html
@@ -53,8 +53,23 @@
               </div>
           </div>
 
+          <!-- TC-009 (#196): documento con tipo + numero. documentType persiste en tourist_profile. -->
           <div class="row">
-              <div class="col-md-6 mb-3">
+              <div class="col-md-3 mb-3">
+                  <label class="form-label text-nowrap" for="documentType">Tipo</label>
+                  <select id="documentType" formControlName="documentType" class="form-control form-control-lg">
+                      <option value="CC">CC</option>
+                      <option value="CE">CE</option>
+                      <option value="PP">PP</option>
+                      <option value="NIT">NIT</option>
+                      <option value="TI">TI</option>
+                  </select>
+                  <div *ngIf="guestInfoForm.controls['documentType'].invalid && (guestInfoForm.controls['documentType'].dirty || guestInfoForm.controls['documentType'].touched)" class="text-danger mt-1 fs-14">
+                      <div *ngIf="guestInfoForm.controls['documentType'].errors?.['required']">Tipo de documento es requerido</div>
+                  </div>
+              </div>
+
+              <div class="col-md-3 mb-3">
                   <label class="form-label text-nowrap" for="documentNumber">Número de Documento</label>
                   <div class="input-icon">
                       <span class="input-icon-addon">

--- a/src/app/shared/common/guest-info-modal/guest-info-modal.component.ts
+++ b/src/app/shared/common/guest-info-modal/guest-info-modal.component.ts
@@ -13,6 +13,7 @@ import { CityService } from '../../services/city.service';
 import { GuestInfoService } from '../../services/guest-info.service';
 import { TouristService } from "../../services/tourist.service";
 import { TouristProfileDto } from "../../dto/tourist-profile.dto";
+import { AuthService } from "../../../core/services/auth.service";
 
 
 
@@ -48,7 +49,8 @@ export class GuestInfoModalComponent implements OnInit {
     private departmentService: DepartmentService,
     private cityService: CityService,
     private guestInfoService: GuestInfoService,
-    private touristService: TouristService
+    private touristService: TouristService,
+    private authService: AuthService
   ) {
 
     this.guestInfoForm = new FormGroup({
@@ -62,8 +64,10 @@ export class GuestInfoModalComponent implements OnInit {
         Validators.minLength(2),
         Validators.maxLength(50),
       ]),
+      // TC-009 (#196): tipo de documento persistido en tourist_profile (CC/CE/PP/NIT/TI).
+      documentType: new FormControl("CC", [Validators.required]),
       documentNumber: new FormControl("", [
-        Validators.required, 
+        Validators.required,
         Validators.minLength(6)
       ]),
       phone: new FormControl("", [
@@ -77,7 +81,8 @@ export class GuestInfoModalComponent implements OnInit {
       country: new FormControl("", [Validators.required]),
       department: new FormControl("", [Validators.required]),
       city: new FormControl("", [Validators.required]),
-      photo: new FormControl(null, [Validators.required])
+      // TC-009 (#196): foto opcional (Luis 2026-07-23).
+      photo: new FormControl(null)
     });
   }
 
@@ -91,11 +96,13 @@ export class GuestInfoModalComponent implements OnInit {
       next: (profile: TouristProfileDto) => {
         this.profileData = profile;
         if (!profile) {
+          this.applySocialFallback();
           this.getCountries(true);
           return;
         }
 
-        const simpleFields: (keyof TouristProfileDto)[] = ['firstName', 'lastName', 'documentNumber', 'phone', 'email'];
+        // TC-009 (#196): documentType tambien viaja en el perfil (nuevo campo).
+        const simpleFields: (keyof TouristProfileDto)[] = ['firstName', 'lastName', 'documentType', 'documentNumber', 'phone', 'email'];
         simpleFields.forEach(field => {
           if (profile[field]) {
             this.guestInfoForm.get(field as string)?.patchValue(profile[field]);
@@ -107,13 +114,55 @@ export class GuestInfoModalComponent implements OnInit {
           this.guestInfoForm.get('photo')?.patchValue(profile.photoUrl);
         }
 
+        // Si el perfil vino pero incompleto (typicamente user recien registrado
+        // con Google/Facebook), completar los huecos con la sesion social.
+        this.applySocialFallback();
+
         this.getCountries(true);
       },
       error: (err) => {
         console.error('Error loading profile', err);
+        this.applySocialFallback();
         this.getCountries(true);
       }
     });
+  }
+
+  /**
+   * TC-009 (#196): rellena firstName / lastName / email / filePreview desde la
+   * sesion social (Firebase user) SOLO si el campo del form aun esta vacio.
+   * Evita pisar datos que ya vinieron del `tourist_profile`.
+   *
+   * Opcion B decidida (usar Firebase actual). Cuando SEC-06 Fase B mergee, este
+   * bloque se refactoriza para consumir firstname/lastname directamente del
+   * backend Token Exchange (mas confiable que split del displayName).
+   */
+  private applySocialFallback(): void {
+    const socialUser = this.authService.getCurrentUser();
+    if (!socialUser) return;
+
+    const setIfEmpty = (fieldName: string, value: string | null | undefined) => {
+      if (!value) return;
+      const ctrl = this.guestInfoForm.get(fieldName);
+      if (ctrl && !ctrl.value) {
+        ctrl.patchValue(value);
+      }
+    };
+
+    const displayName = (socialUser as any).displayName as string | null | undefined;
+    if (displayName) {
+      const parts = displayName.trim().split(/\s+/);
+      const first = parts.shift() ?? '';
+      const last = parts.join(' ');
+      setIfEmpty('firstName', first);
+      if (last) setIfEmpty('lastName', last);
+    }
+    setIfEmpty('email', (socialUser as any).email);
+
+    const photoURL = (socialUser as any).photoURL as string | null | undefined;
+    if (photoURL && !this.filePreview) {
+      this.filePreview = photoURL;
+    }
   }
 
 

--- a/src/app/shared/dto/tourist-profile.dto.ts
+++ b/src/app/shared/dto/tourist-profile.dto.ts
@@ -3,6 +3,7 @@ export interface TouristProfileDto {
   userId?: number;
   firstName: string;
   lastName: string;
+  documentType: string;
   documentNumber: string;
   phone: string;
   email: string;


### PR DESCRIPTION
## Cambios (respuestas de Luis 2026-07-23)

1. **\`documentType\`** ahora se persiste en \`tourist_profile\` (columna agregada en migracion 083 del PR backend #213). El modal ofrece un \`<select>\` **CC/CE/PP/NIT/TI** junto al numero de documento.
2. **Foto opcional**: quitado \`Validators.required\` del campo \`photo\` (Luis: "todos los campos son obligatorios excepto la imagen").
3. **Fallback social Firebase**: cuando \`getProfile()\` retorna null o el perfil viene con huecos, \`applySocialFallback()\` completa \`firstName\`, \`lastName\`, \`email\` y \`filePreview\` desde el user de Firebase (\`displayName\`, \`email\`, \`photoURL\`). **No pisa datos ya presentes** en el form.

## Notas

- **Opcion B decidida** (usar Firebase actual). Cuando SEC-06 Fase B mergee, el helper \`applySocialFallback\` se refactoriza para consumir \`firstname\`/\`lastname\` directamente del backend Token Exchange (mas confiable que \`displayName.split\`).
- El backend PR #213 ya persiste \`documentType\`. Este PR consume ese campo.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] User existente con perfil completo: modal abre pre-llenado incluyendo \`documentType\` correcto (no siempre 'CC').
- [ ] User recien registrado sin perfil: modal pre-llena \`firstName\`, \`lastName\` y \`email\` desde la sesion social (Google/Facebook). Foto de perfil social aparece como preview.
- [ ] Guardar el modal (con foto o sin foto) persiste \`documentType\` en \`tourist_profile\` — verificar con \`GET /api/v1/tourist/profile\`.
- [ ] Sin foto se guarda OK (no debe bloquear).

Closes #196 tras validacion de Luis.