### PR TITLE
fix(TC-007 #194 scope extra): esconder boton No puedo atender cuando scheduleDate ya paso

### DIFF
--- a/src/app/shared/services/booking-management-config.service.ts
+++ b/src/app/shared/services/booking-management-config.service.ts
@@ -351,7 +351,17 @@ export class BookingManagementConfigService {
           visible: (row) => {
             const isActionable = row.status === 'Pending' || row.status === 'PENDING'
               || row.status === 'RESCHEDULED' || row.status === 'Rescheduled';
-            return isActionable;
+            if (!isActionable) return false;
+            // TC-007 (#194 scope extra): esconder el boton si el scheduleDate ya paso.
+            // El endpoint backend tambien lo rechaza con 400. La reserva debe pasar a
+            // NO_SHOW via job, no via decline manual.
+            const rawDate: string | undefined = row.rawCheckInDate;
+            if (!rawDate) return true;
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            const scheduleDate = new Date(rawDate + 'T00:00:00');
+            scheduleDate.setHours(0, 0, 0, 0);
+            return scheduleDate.getTime() >= today.getTime();
           }
         }
       ],


### PR DESCRIPTION
## Contexto

Simetria con el boton **"Confirmar"** (que ya tiene guard temporal). El endpoint backend tambien lo rechaza con 400 (PR api #214); esto solo mejora la UX escondiendo el boton en filas donde ya no aplica.

## Cambio

\`booking-management-config.service.ts:351-355\`: la funcion \`visible\` del action \`decline\` ahora, ademas de chequear el status (Pending/Rescheduled), valida que \`row.rawCheckInDate >= today (local)\`. Si scheduleDate ya paso, el boton no aparece.

## Test plan

- [ ] Login como PROVIDER -> tabla Mis Reservas.
- [ ] Reserva Pending con \`scheduleDate = HOY\` -> boton **visible**.
- [ ] Reserva Pending con \`scheduleDate < HOY\` -> boton **oculto**.
- [ ] Reserva Pending con \`scheduleDate futuro\` -> boton visible.
- [ ] Reservas en estado terminal (Cancelled, Delivered, No_Show) -> boton oculto (regresion).

Relacionado con #194. Complementa PR api #214.