### PR TITLE
fix(TC-008 #195 3ra iter): mover rescue ChunkLoadError a script inline en index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -26,6 +26,64 @@
   <!-- Wompi Widget Script -->
   <script type="text/javascript" src="https://checkout.wompi.co/widget.js"></script>
 
+  <!--
+    TC-008 (#195): rescate global de ChunkLoadError.
+
+    Vive inline en index.html (fuera del bundle Angular) para estar disponible
+    ANTES que cualquier chunk lazy intente cargarse. Si un import() dinamico
+    falla (bundle stale del navegador vs deploy nuevo), forzamos reload del
+    index.html + main.js del deploy vigente. sessionStorage evita loop infinito
+    si el reload no soluciona (bug real, no cache stale).
+
+    Redundancia dentro de Angular en `main.ts` (bootstrap) via ErrorHandler.
+  -->
+  <script>
+    (function () {
+      var FLAG = 'ttChunkReloadInProgress';
+
+      function isChunkLoadError(err) {
+        if (!err) return false;
+        var m = (err && err.message) ? String(err.message) : String(err);
+        return m.indexOf('Failed to fetch dynamically imported module') !== -1
+          || m.indexOf('error loading dynamically imported module') !== -1
+          || /Loading chunk .+ failed/i.test(m)
+          || m.indexOf('ChunkLoadError') !== -1;
+      }
+
+      function handleChunkError(err) {
+        if (!isChunkLoadError(err)) return false;
+        try {
+          if (sessionStorage.getItem(FLAG)) {
+            sessionStorage.removeItem(FLAG);
+            return false;
+          }
+          sessionStorage.setItem(FLAG, '1');
+          window.location.reload();
+          return true;
+        } catch (_) {
+          return false;
+        }
+      }
+
+      window.addEventListener('error', function (event) {
+        if (handleChunkError(event.error || event.message)) {
+          event.preventDefault();
+        }
+      });
+
+      window.addEventListener('unhandledrejection', function (event) {
+        if (handleChunkError(event.reason)) {
+          event.preventDefault();
+        }
+      });
+
+      // Al iniciar una navegacion exitosa (sin recarga), limpiar la flag.
+      try {
+        sessionStorage.removeItem(FLAG);
+      } catch (_) { /* private mode */ }
+    })();
+  </script>
+
 </head>
 
 <body>


### PR DESCRIPTION
## Root cause de la iteracion anterior

El fix del PR #84 registro \`ChunkLoadErrorHandler\` como \`ErrorHandler\` provider en \`app.module.ts\`. Angular **tree-shakeo la clase a un chunk lazy** (\`chunk-RJKQIMBC.js\`). Paradoja: si el sintoma es que un chunk lazy falla al cargar, el handler que rescata ese error tambien es un chunk lazy y no esta disponible cuando lo necesita.

Verificado con:
\`\`\`
curl main-XXXX.js | grep chunkReloadInProgress  -> vacio
curl chunk-RJKQIMBC.js | grep chunkReloadInProgress -> 1 hit
\`\`\`

## Fix

Rescate global inline en \`<head>\` de \`src/index.html\`, fuera del bundle Angular. Registra listeners \`window.error\` y \`window.unhandledrejection\` que:

1. Filtran por strings tipicos de chunk-load-error.
2. Si detectan, ejecutan \`window.location.reload()\` una vez (guard \`sessionStorage\` contra loop infinito).
3. \`event.preventDefault()\` para que el usuario no vea la excepcion.

**Ventaja**: disponible ANTES que Angular arranque y ANTES que cualquier \`import()\` dinamico. Cubre incluso el caso de un usuario con \`main-VIEJO.js\` cacheado apuntando a chunks que ya no existen.

El ErrorHandler Angular del PR #84 se mantiene como **backup redundante** para errores dentro del ciclo de change detection.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] \`curl https://tourya-dev-front-.../ | grep ttChunkReloadInProgress\` retorna 1.
- [ ] Luis (sin Ctrl+F5): abrir la app, login BO -> el rescue detecta el ChunkLoadError, reload silencioso, aterriza en /admin/bookings-management.
- [ ] Regresion: usuarios sin cache stale entran normal.
- [ ] No hay loop infinito (guard sessionStorage).

Relacionado con #195. Sigue esta 3ra iteracion despues del reporte de Luis del 29-jul 03:41 con pantalla blanca post-login BO.