### PR TITLE
fix(TC-009 #196): nginx no-cache para i18n/*.json + reducir tipos documento a 4

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -17,6 +17,15 @@ http {
     root /usr/share/nginx/html;
     index index.html;
 
+    # TC-009 (#196): i18n JSON tiene URL fija (sin hash) y su contenido cambia
+    # entre deploys. Debe refrescarse en cada carga; si no, usuarios con cache
+    # viejo ven la modal con keys faltantes (fallback a ingles).
+    location ~* ^/i18n/.*\.json$ {
+      try_files $uri =404;
+      add_header Cache-Control "no-store, no-cache, must-revalidate";
+      expires -1;
+    }
+
     # TC-008 (#195): assets estaticos deben devolver 404 real cuando no existen,
     # no el index.html (que rompe `import()` dinamico de Angular con
     # "Failed to fetch dynamically imported module").

--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1380,9 +1380,7 @@
       "CC": "Citizenship ID (CC)",
       "CE": "Foreigner ID (CE)",
       "PP": "Passport",
-      "PPT": "Temporary Protection Permit (PPT)",
-      "NIT": "Tax ID (NIT)",
-      "TI": "Minor ID (TI)"
+      "PPT": "Temporary Protection Permit (PPT)"
     },
     "documentNumber": "Document Number",
     "documentNumberPlaceholder": "Enter your document",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1381,9 +1381,7 @@
       "CC": "Cédula de Ciudadanía",
       "CE": "Cédula de Extranjería",
       "PP": "Pasaporte",
-      "PPT": "Permiso por Protección Temporal",
-      "NIT": "NIT",
-      "TI": "Tarjeta de Identidad"
+      "PPT": "Permiso por Protección Temporal"
     },
     "documentNumber": "Número de Documento",
     "documentNumberPlaceholder": "Ingresa tu documento",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1381,9 +1381,7 @@
       "CC": "Cédula de Cidadania (CC)",
       "CE": "Cédula de Estrangeiro (CE)",
       "PP": "Passaporte",
-      "PPT": "Permissão de Proteção Temporária (PPT)",
-      "NIT": "NIT",
-      "TI": "Cartão de Identidade (TI)"
+      "PPT": "Permissão de Proteção Temporária (PPT)"
     },
     "documentNumber": "Número do Documento",
     "documentNumberPlaceholder": "Digite seu documento",

--- a/src/app/shared/common/guest-info-modal/guest-info-modal.component.html
+++ b/src/app/shared/common/guest-info-modal/guest-info-modal.component.html
@@ -62,8 +62,6 @@
                       <option value="CE">{{ 'guestInfoModal.documentTypes.CE' | translate }}</option>
                       <option value="PP">{{ 'guestInfoModal.documentTypes.PP' | translate }}</option>
                       <option value="PPT">{{ 'guestInfoModal.documentTypes.PPT' | translate }}</option>
-                      <option value="NIT">{{ 'guestInfoModal.documentTypes.NIT' | translate }}</option>
-                      <option value="TI">{{ 'guestInfoModal.documentTypes.TI' | translate }}</option>
                   </select>
                   <div *ngIf="guestInfoForm.controls['documentType'].invalid && (guestInfoForm.controls['documentType'].dirty || guestInfoForm.controls['documentType'].touched)" class="text-danger mt-1 fs-14">
                       <div *ngIf="guestInfoForm.controls['documentType'].errors?.['required']">{{ 'guestInfoModal.errors.documentTypeRequired' | translate }}</div>


### PR DESCRIPTION
## Bug reportado por Luis (2026-07-31 01:16)

1. Al cambiar idioma a PT la modal seguia en INGLES (mientras el resto del sitio ya estaba en PT).
2. Pidio dejar solo 4 tipos de documento: **CC, CE, PP, PPT**. Quitar NIT y TI.

## Root cause del bug PT

En el PR #84 el \`nginx.conf\` aplicaba \`Cache-Control: public, immutable, expires 1y\` a **todos** los archivos con extension \`.json\`, incluyendo \`/i18n/{es,en,pt}.json\`. Los i18n NO tienen hash en la URL — su contenido cambia entre deploys pero la URL es estable. Con cache "immutable" el browser NUNCA los re-descarga hasta que expire (1 año).

Luis tenia \`pt.json\` viejo cacheado (sin las keys \`guestInfoModal.*\`). ngx-translate hizo fallback a \`en.json\` (que si las tenia) → modal en ingles.

## Fix

### \`nginx.conf\`
Nuevo bloque \`location ~* ^/i18n/.*\.json$ { Cache-Control: no-store }\` **antes** del bloque generico de assets. i18n siempre se pide fresco. Los bundles con hash (\`main-XXX.js\`, \`chunk-XXX.js\`) mantienen su cache larga.

### Tipos documento
Reducidos a 4 en el \`<select>\` del guest-info-modal + eliminadas keys \`NIT\` y \`TI\` de los 3 JSON (es/en/pt). Quedan: CC, CE, PP, PPT.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] \`curl -sI .../i18n/pt.json | grep -i cache-control\` → \`no-store, no-cache, must-revalidate\`.
- [ ] \`curl -sI .../main-XXX.js | grep -i cache-control\` → \`public, immutable, max-age=31536000\`.
- [ ] Luis (sin Ctrl+F5, primera carga fresca): cambiar a PT, abrir modal — todo en portugues incluyendo select tipos.
- [ ] Select tipo documento muestra solo 4 opciones en los 3 idiomas.

Relacionado con #196.