### PR TITLE
diag(TC-008 #195 4ta iter): logs diagnostico login redirect flow

### DIFF
--- a/src/app/auth/login-tourist/login-tourist.component.ts
+++ b/src/app/auth/login-tourist/login-tourist.component.ts
@@ -90,6 +90,11 @@ export class LoginTouristComponent implements OnInit, OnDestroy {
               email: response.email,
               roles: response.roleList,
             });
+            // TC-008 #195 (4ta iter): diagnostico. Ver que roleList llega y como queda en localStorage.
+            console.log('[TC-008 diag] login OK. roleList response=', response.roleList,
+              ' mustChangePassword=', (response as any).mustChangePassword,
+              ' user guardado=', this.authService.getUser(),
+              ' isBackofficeOperation=', this.authService.isBackofficeOperation());
             this.getConsultDataAndRedirect(response.roleList);
           } else {
             this.errorMessage =
@@ -203,17 +208,32 @@ export class LoginTouristComponent implements OnInit, OnDestroy {
   }
 
   redirectByRole(role: RoleDto[]) {
+    // TC-008 #195 (4ta iter): logging de diagnostico para detectar por que el redirect
+    // no completa. Luis reporto que despues de "Redirigiendo basado en rol" la URL
+    // sigue en /login. Este log muestra el path resuelto y el resultado de navigate().
+    const roleIds = role.map(r => r.id);
+    let target: string | null = null;
     if (role.some(r => r.id === Roles.ADMIN)) {
-      this.router.navigate(["admin"]);
+      target = "/admin";
     } else if (role.some(r => r.id === Roles.BACKOFFICE_OPERATION)) {
       // FE-15d fix (#195): sin este branch el user quedaba clavado en login post-auth.
-      // Mismo destino que HomeRedirectGuard para este rol.
-      this.router.navigate(["admin/bookings-management"]);
+      target = "/admin/bookings-management";
     } else if (role.some(r => r.id === Roles.PROVIDER || r.id === Roles.PROVIDER_OPERATOR)) {
-      this.router.navigate(["providers/provider-panel"]);
+      target = "/providers/provider-panel";
     } else if (role.some(r => r.id === Roles.USER)) {
-      this.router.navigate(["home"]);
+      target = "/home";
     }
+
+    console.log('[TC-008 diag] redirectByRole: roleIds=', roleIds, ' target=', target);
+    if (target === null) {
+      console.error('[TC-008 diag] redirectByRole: ningun branch matcheo. roleIds=', roleIds);
+      return;
+    }
+
+    this.router.navigate([target]).then(
+      ok => console.log('[TC-008 diag] navigate result:', ok, 'url ahora:', this.router.url),
+      err => console.error('[TC-008 diag] navigate error:', err)
+    );
   }
 
   getConsultDataAndRedirect(roleList: RoleDto[]) {

--- a/src/app/core/guards/backoffice.guard.ts
+++ b/src/app/core/guards/backoffice.guard.ts
@@ -20,15 +20,24 @@ export class BackofficeGuard implements CanActivate {
   ) {}
 
   canActivate(): boolean {
-    if (!this.authService.isAuthenticated()) {
+    const authed = this.authService.isAuthenticated();
+    const isBO = this.authService.isTouryaBackoffice();
+    // TC-008 #195 (4ta iter): logging de diagnostico.
+    console.log('[TC-008 diag] BackofficeGuard: authenticated=', authed,
+      ' isTouryaBackoffice=', isBO,
+      ' user=', this.authService.getUser());
+
+    if (!authed) {
+      console.warn('[TC-008 diag] BackofficeGuard: no authenticated, redirigiendo a /');
       this.router.navigate(['/']);
       return false;
     }
 
-    if (this.authService.isTouryaBackoffice()) {
+    if (isBO) {
       return true;
     }
 
+    console.warn('[TC-008 diag] BackofficeGuard: no es TouryaBackoffice, redirigiendo a /');
     this.router.navigate(['/']);
     return false;
   }

--- a/src/app/core/interceptors/auth.interceptor.ts
+++ b/src/app/core/interceptors/auth.interceptor.ts
@@ -86,6 +86,9 @@ export class AuthInterceptor implements HttpInterceptor {
   }
 
   private forceLogout(): void {
+    // TC-008 #195 (4ta iter): logging para detectar si es el interceptor el que
+    // esta tirando al user de vuelta a /login por 401 sin refresh token valido.
+    console.warn('[TC-008 diag] AuthInterceptor.forceLogout ejecutado, redirigiendo a /login');
     this.authService.removeTokens();
     this.router.navigate(['/login']);
   }


### PR DESCRIPTION
Luis reporta login BO sigue sin redirigir. Captura muestra "Redirigiendo basado en rol" en console y despues nada — URL sigue en /login. No hay ChunkLoadError (todos los chunks 200 OK), asi que el bug esta en la logica de navegacion, no en el bundle.

Necesito ver EXACTAMENTE que pasa entre \`router.navigate([...])\` y el aterrizaje esperado. Agrego logging en 4 puntos criticos:

1. **\`login-tourist.onSubmit next\`**: muestra \`roleList\` del response, \`mustChangePassword\`, user post-setUser en localStorage, resultado de \`isBackofficeOperation()\`.
2. **\`login-tourist.redirectByRole\`**: cambio paths a absolutos (\`/admin/bookings-management\` con slash inicial). Muestra target elegido y resultado de la Promise de \`router.navigate\` — vemos si la nav resuelve \`true\`, \`false\`, o falla.
3. **\`BackofficeGuard.canActivate\`**: log de \`isAuthenticated\` y \`isTouryaBackoffice\` antes de decidir. Warn cuando redirige a \`/\`.
4. **\`AuthInterceptor.forceLogout\`**: warn cuando se ejecuta (por si un 401 silencioso esta tirando al user de vuelta a /login).

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] Luis: F12 -> Console -> "Preserve log" activo -> Login BO -> screenshot de la Console mostrando la cascada \`[TC-008 diag]\`.
- [ ] Con esa data cierro el diagnostico en 1 turno.

Cambio unico funcional: los paths de \`redirectByRole\` ahora tienen slash inicial (\`/admin\` vs \`admin\`) por si el path relativo era el problema. El resto son puros \`console.log\`.

Relacionado con #195.