### PR TITLE
fix(TC-008 #195 5ta iter): AdminGuard padre /admin bloqueaba BO — cambiar a BackofficeGuard

### DIFF
--- a/src/app/pages/pages-module-routing.module.ts
+++ b/src/app/pages/pages-module-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from "@angular/router";
 import { PagesModuleComponent } from "./pages-module.component";
 import { AuthGuard } from "../core/guards/auth.guard";
 import { AdminGuard } from "../core/guards/admin.guard";
+import { BackofficeGuard } from "../core/guards/backoffice.guard";
 import { ContactanosComponent } from "./contactanos/contactanos.component";
 import { ConocenosComponent } from "./conocenos/conocenos.component";
 import { LegalSiteComponent } from "./legal-site/legal-site.component";
@@ -25,10 +26,15 @@ const routes: Routes = [
           import("./providers/providers.module").then((m) => m.ProvidersModule),
       },
       {
+        // TC-008 (#195 5ta iter): el padre acepta ADMIN o BACKOFFICE_OPERATION.
+        // Los hijos internos siguen protegidos individualmente (AdminGuard para
+        // dashboard/tour-admin/backoffice-users, BackofficeGuard para bookings-management/
+        // maritime-reports). Antes AdminGuard aca rechazaba a BO antes de que
+        // BackofficeGuard del hijo pudiera evaluar — quedaba clavado en /login.
         path: "admin",
         loadChildren: () =>
           import("./admin/admin.module").then((m) => m.AdminModule),
-        canActivate: [AdminGuard],
+        canActivate: [BackofficeGuard],
       },
       { path: "contactanos", loadComponent: () => import('./contactanos/contactanos.component').then(m => m.ContactanosComponent) },
       { path: "conocenos", loadComponent: () => import('./conocenos/conocenos.component').then(m => m.ConocenosComponent) },


### PR DESCRIPTION
## Root cause definitivo (confirmado con los logs \`[TC-008 diag]\`)

Console de Luis en la última prueba mostró:
\`\`\`
[TC-008 diag] isBackofficeOperation= true
[TC-008 diag] redirectByRole: target= /admin/bookings-management
[TC-008 diag] navigate result: FALSE url ahora: /login
\`\`\`

**Clave**: \`navigate=false\` **sin log del \`BackofficeGuard\`** del hijo → la nav fue rechazada ANTES de llegar al guard hijo.

Culpable: \`pages-module-routing.module.ts:31\` tenía \`canActivate: [AdminGuard]\` en el path padre \`/admin\`. **AdminGuard solo acepta ADMIN** — rechazaba a BO en el padre y la navegación al hijo \`bookings-management\` (que sí tiene BackofficeGuard) nunca corría.

## Fix (1 línea + import)

\`canActivate: [AdminGuard]\` → \`canActivate: [BackofficeGuard]\` en el padre. Los hijos internos siguen protegidos por su guard propio:
- \`dashboard\`, \`tour-admin\`, \`backoffice-users\` → **AdminGuard** (ADMIN puro).
- \`bookings-management\`, \`maritime-reports\` → **BackofficeGuard** (ADMIN o BO).

Así BO puede entrar al padre y llegar a los hijos que le corresponden, sin poder acceder a los hijos ADMIN-only.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] Login como **BACKOFFICE_OPERATION** → aterriza en \`/admin/bookings-management\`.
- [ ] Login como **ADMIN** → sigue funcionando (redirect a \`/admin/dashboard\`).
- [ ] BO intenta ir a \`/admin/dashboard\` → AdminGuard (hijo) rechaza.
- [ ] BO intenta ir a \`/admin/bookings-management\` → OK.

Cierra el hilo del TC-008 tras 4 iteraciones de diagnóstico. Closes #195.