### PR TITLE
fix(TC-009 #196 v3): my-profile campos + lugar procedencia cascada + boton Cancelar

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1237,6 +1237,14 @@
     "lastName": "Last name",
     "email": "Email",
     "phone": "Phone",
+    "documentType": "Document Type",
+    "documentNumber": "Document Number",
+    "documentTypes": {
+      "CC": "Citizenship ID (CC)",
+      "CE": "Foreigner ID (CE)",
+      "PP": "Passport",
+      "PPT": "Temporary Protection Permit (PPT)"
+    },
     "addressInfo": "Address Information",
     "address": "Address",
     "country": "Country",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1238,6 +1238,14 @@
     "lastName": "Apellido",
     "email": "Correo Electrónico",
     "phone": "Teléfono",
+    "documentType": "Tipo de Documento",
+    "documentNumber": "Número de Documento",
+    "documentTypes": {
+      "CC": "Cédula de Ciudadanía",
+      "CE": "Cédula de Extranjería",
+      "PP": "Pasaporte",
+      "PPT": "Permiso por Protección Temporal"
+    },
     "addressInfo": "Información de Dirección",
     "address": "Dirección",
     "country": "País",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1081,6 +1081,14 @@
     "lastName": "Sobrenome",
     "email": "E-mail",
     "phone": "Telefone",
+    "documentType": "Tipo de Documento",
+    "documentNumber": "Número do Documento",
+    "documentTypes": {
+      "CC": "Cédula de Cidadania (CC)",
+      "CE": "Cédula de Estrangeiro (CE)",
+      "PP": "Passaporte",
+      "PPT": "Permissão de Proteção Temporária (PPT)"
+    },
     "addressInfo": "Informações de endereço",
     "address": "Endereço",
     "country": "País",

--- a/src/app/pages/clients/cart-summary/cart-summary.component.ts
+++ b/src/app/pages/clients/cart-summary/cart-summary.component.ts
@@ -17,6 +17,7 @@ import { CreditService } from '../../../shared/services/credit.service';
 import { ClientCredit } from '../../../shared/models/credit.model';
 import { SearchToursService } from '../list-tours/search-tours.service';
 import { TouristService } from '../../../shared/services/tourist.service';
+import { TouristProfileDto } from '../../../shared/dto/tourist-profile.dto';
 import { CountryService } from '../../../shared/services/country.service';
 import { DepartmentService } from '../../../shared/services/department.service';
 import { CityService } from '../../../shared/services/city.service';
@@ -160,6 +161,10 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
    * los campos minimos (address-complete = false), abrir el guest-info-modal
    * para que el usuario complete su informacion aca (antes se disparaba al
    * agregar el primer tour al carrito, muy temprano y bloqueante).
+   *
+   * TC-009 (#196 v3): si el usuario cancela el modal sin completar el perfil,
+   * redirigir a /clients/list-tours (Luis 2026-07-31: "no dejarnos hacer la
+   * compra sin la informacion del usuario").
    */
   private openGuestModalIfProfileIncomplete(): void {
     this.touristService.checkAddressComplete()
@@ -175,7 +180,15 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
             });
             ref.afterClosed()
               .pipe(takeUntil(this.destroy$))
-              .subscribe(() => this.loadUserProfile());
+              .subscribe((result) => {
+                const cancelled = !result || (typeof result === 'object' && result.profileSuccess !== true);
+                if (cancelled) {
+                  console.log('CartSummary: modal cancelado sin completar perfil -> volver a list-tours');
+                  this.router.navigate(['/clients/list-tours']);
+                  return;
+                }
+                this.loadUserProfile();
+              });
           }
         },
         error: (err) => console.error('CartSummary: error checkAddressComplete', err)
@@ -298,14 +311,17 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
             this.contactForm.lastName = profile.lastName || this.contactForm.lastName;
             this.contactForm.email = profile.email || this.contactForm.email;
             this.contactForm.phone = profile.phone || this.contactForm.phone;
-            this.contactForm.country = this.mapCountryToIsoCode(profile.country) || this.contactForm.country;
-            this.contactForm.city = profile.city || this.contactForm.city;
-            
+
             // Asignar campos adicionales si el backend los envía (dirección, info adicional)
             if ((profile as any).address) {
               this.contactForm.address1 = (profile as any).address || this.contactForm.address1;
             }
 
+            // TC-009 (#196 v3): matchear country/state/city del perfil a IDs
+            // reales de los dropdowns "Lugar de procedencia". Antes solo se
+            // asignaba `mapCountryToIsoCode` que devolvia 'CO'/'US'/'ES' pero los
+            // <select> usan `country.id` numerico → nada matchea → dropdown vacio.
+            this.matchPlaceOfOriginFromProfile(profile);
 
             this.syncFormsData();
           }
@@ -313,6 +329,54 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
         error: (error) => {
           console.error('CartSummary: Error cargando perfil de usuario:', error);
         }
+      });
+  }
+
+  /**
+   * TC-009 (#196 v3): matching en cascada nombre → id para lugar de procedencia.
+   * Backend guarda `country/state/city` como strings (Colombia, Bolivar, Cartagena);
+   * los <select> del cart-summary usan IDs numericos. Este helper hace el matching.
+   */
+  private matchPlaceOfOriginFromProfile(profile: TouristProfileDto): void {
+    if (!profile.country) return;
+    this.countryService.getCountries()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (countries) => {
+          this.countries = countries || [];
+          const matchedCountry = this.countries.find(c =>
+            c.name?.toLowerCase() === profile.country?.toLowerCase());
+          if (!matchedCountry) return;
+          this.contactForm.country = String(matchedCountry.id);
+          if (!profile.state) return;
+          this.departmentService.getDepartmentsByCountryId(matchedCountry.id)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe({
+              next: (depts) => {
+                this.departments = depts || [];
+                const matchedDept = this.departments.find(d =>
+                  d.name?.toLowerCase() === profile.state?.toLowerCase());
+                if (!matchedDept) return;
+                this.contactForm.state = String(matchedDept.id);
+                if (!profile.city) return;
+                this.cityService.getCitiesByDepartmentId(matchedDept.id)
+                  .pipe(takeUntil(this.destroy$))
+                  .subscribe({
+                    next: (cities) => {
+                      this.cities = cities || [];
+                      const matchedCity = this.cities.find(c =>
+                        c.name?.toLowerCase() === profile.city?.toLowerCase());
+                      if (matchedCity) {
+                        this.contactForm.city = String(matchedCity.id);
+                      }
+                    },
+                    error: (err) => console.error('matchPlaceOfOriginFromProfile cities error', err)
+                  });
+              },
+              error: (err) => console.error('matchPlaceOfOriginFromProfile departments error', err)
+            });
+        },
+        error: (err) => console.error('matchPlaceOfOriginFromProfile countries error', err)
       });
   }
 

--- a/src/app/pages/clients/my-profile/my-profile.component.html
+++ b/src/app/pages/clients/my-profile/my-profile.component.html
@@ -73,15 +73,22 @@
                                         <p>{{ profileData?.phone || 'N/A' }}</p>
                                     </div>
                                 </div>
+                                <!-- TC-009 (#196): documento pedido por Luis 2026-07-31. -->
+                                <div class="col-md-6">
+                                    <div class="mb-2">
+                                        <h6 class="fs-14">{{ 'myProfile.documentType' | translate }}</h6>
+                                        <p>{{ profileData?.documentType ? (('myProfile.documentTypes.' + (profileData?.documentType || '')) | translate) : 'N/A' }}</p>
+                                    </div>
+                                </div>
+                                <div class="col-md-6">
+                                    <div class="mb-2">
+                                        <h6 class="fs-14">{{ 'myProfile.documentNumber' | translate }}</h6>
+                                        <p>{{ profileData?.documentNumber || 'N/A' }}</p>
+                                    </div>
+                                </div>
                             </div>
                             <h6 class="fs-16 mb-3">{{ 'myProfile.addressInfo' | translate }}</h6>
                             <div class="row g-2">
-                                <div class="col-md-12">
-                                    <div>
-                                        <h6 class="fs-14">{{ 'myProfile.address' | translate }}</h6>
-                                        <p>N/A</p>
-                                    </div>
-                                </div>
                                 <div class="col-md-6">
                                     <div>
                                         <h6 class="fs-14">{{ 'myProfile.country' | translate }}</h6>
@@ -98,12 +105,6 @@
                                     <div>
                                         <h6 class="fs-14">{{ 'myProfile.city' | translate }}</h6>
                                         <p>{{ profileData?.city || 'N/A' }}</p>
-                                    </div>
-                                </div>
-                                <div class="col-md-6">
-                                    <div>
-                                        <h6 class="fs-14">{{ 'myProfile.zipCode' | translate }}</h6>
-                                        <p>N/A</p>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Refinamientos pedidos por Luis en el comentario del 2026-07-31 23:54.

## A. \`/clients/my-profile\` refleja los mismos campos que la modal

- Agregado \`documentType\` (con label i18n del nombre completo) y \`documentNumber\` al bloque "Información Básica".
- Removidos \`address\` y \`zipCode\` que siempre mostraban N/A (no existen en el TouristProfileDto ni en la modal).
- Nuevas keys i18n \`myProfile.documentType\`, \`myProfile.documentNumber\` y \`myProfile.documentTypes.{CC,CE,PP,PPT}\` en los 3 JSON.

## B. "Lugar de procedencia" se llena en cart-summary

Antes \`loadUserProfile\` solo asignaba \`country = 'CO'\` (código ISO) al contactForm. Los \`<select>\` usan \`country.id\` numérico → nada matcheaba y los dropdowns quedaban vacíos.

Nuevo \`matchPlaceOfOriginFromProfile(profile)\` hace cascada nombre → id:
1. Carga countries → find por \`profile.country\` → set \`contactForm.country = id\`.
2. Carga departments del país → find por \`profile.state\` → set \`state = id\`.
3. Carga cities del depto → find por \`profile.city\` → set \`city = id\`.

## C. Botón Cancelar del guest-info-modal desde cart-summary

Cuando el usuario cancela el modal sin llenar la información, se redirige a \`/clients/list-tours\` para evitar que continúe la compra sin datos. Detección: \`result\` de \`afterClosed\` es null/undefined o \`profileSuccess !== true\` → cancelled.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] \`/clients/my-profile?section=profile\` muestra documentType y documentNumber con nombre completo. i18n en es/en/pt.
- [ ] Login como turista con perfil completo → cart-summary "Lugar de procedencia" se llena automático con país/estado/ciudad correctos.
- [ ] Modal en cart-summary → **Cancelar** → redirige a \`/clients/list-tours\`.
- [ ] Modal en cart-summary → Continuar (submit OK) → sigue en cart-summary con datos pre-llenados.

Relacionado con #196.