### PR TITLE
fix(TC-008 #195 sidebar BO): extraer Ordenes de pago + sidebar 3 items en bookings-management

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -224,6 +224,12 @@
     }
   },
   "provider-tour-management": {
+    "sidebar": {
+      "section": "Backoffice Panel",
+      "bookings": "Bookings",
+      "maritimeReports": "Maritime Activity Reports",
+      "providerPayments": "Payment Orders"
+    },
     "header": {
       "totalBookings": "Total Bookings",
       "confirmBooking": "Confirm Booking",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -225,6 +225,12 @@
     }
   },
   "provider-tour-management": {
+    "sidebar": {
+      "section": "Panel Backoffice",
+      "bookings": "Reservas",
+      "maritimeReports": "Reporte de Actividades Marítimas",
+      "providerPayments": "Órdenes de pago"
+    },
     "header": {
       "totalBookings": "Total de Reservas",
       "confirmBooking": "Confirmar Reserva",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -224,6 +224,12 @@
     }
   },
   "provider-tour-management": {
+    "sidebar": {
+      "section": "Painel Backoffice",
+      "bookings": "Reservas",
+      "maritimeReports": "Relatório de Atividades Marítimas",
+      "providerPayments": "Ordens de Pagamento"
+    },
     "header": {
       "totalBookings": "Total de Reservas",
       "confirmBooking": "Confirmar Reserva",

--- a/src/app/pages/admin/admin-routing.module.ts
+++ b/src/app/pages/admin/admin-routing.module.ts
@@ -37,6 +37,16 @@ const routes: Routes = [
         canActivate: [BackofficeGuard],
         loadComponent: () => import('../maritime-activity-reports/maritime-activity-reports.component').then(m => m.MaritimeActivityReportsComponent)
       },
+      // TC-008 (#195 refinamiento Luis 2026-08-03): ordenes de pago expuestas al
+      // rol BACKOFFICE_OPERATION. El componente ya existia dentro del dashboard;
+      // ahora es una ruta propia para que BO pueda acceder sin AdminGuard.
+      // Se usa loadChildren + un pequeno wrapper routing para mantener el modulo
+      // NgModule original (que no tenia RouterModule.forChild propio).
+      {
+        path: 'provider-payments',
+        canActivate: [BackofficeGuard],
+        loadChildren: () => import('./provider-payments-wrapper-routing.module').then(m => m.ProviderPaymentsWrapperRoutingModule)
+      },
       // FE-15d: CRUD de usuarios BACKOFFICE_OPERATION. Solo ADMIN puede gestionar.
       {
         path: 'backoffice-users',

--- a/src/app/pages/admin/provider-payments-wrapper-routing.module.ts
+++ b/src/app/pages/admin/provider-payments-wrapper-routing.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ProviderPaymentsComponent } from '../providers/provider-payments/provider-payments.component';
+import { ProviderPaymentsModule } from '../providers/provider-payments/provider-payments.module';
+
+/**
+ * TC-008 (#195 refinamiento Luis 2026-08-03): monta ProviderPaymentsComponent
+ * bajo /admin/provider-payments. El modulo original ProviderPaymentsModule no
+ * tenia routing propio (se usaba embebido en dashboard); este wrapper le agrega
+ * la ruta sin modificar el modulo original.
+ */
+const routes: Routes = [
+  { path: '', component: ProviderPaymentsComponent }
+];
+
+@NgModule({
+  imports: [
+    ProviderPaymentsModule,
+    RouterModule.forChild(routes)
+  ]
+})
+export class ProviderPaymentsWrapperRoutingModule {}

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
@@ -1,6 +1,35 @@
 <!-- Provider Tour Management -->
 <div class="provider-tour-management">
-    
+<div class="row">
+<!-- TC-008 (#195 sidebar BO): menu lateral con 3 items para ADMIN/BO en la vista
+     bookings-management. No aparece para PROVIDER ni CLIENT. -->
+<aside *ngIf="showAdminSidebar" class="col-xl-3 col-lg-4 admin-sidebar mb-4 mb-lg-0">
+  <div class="card user-sidebar theiaStickySidebar">
+    <div class="card-body user-sidebar-body">
+      <ul>
+        <li><span class="fs-14 text-gray-3 fw-medium mb-2">{{ 'provider-tour-management.sidebar.section' | translate }}</span></li>
+        <li>
+          <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToBookingsManagement()">
+            <i class="isax isax-calendar-tick me-2"></i>{{ 'provider-tour-management.sidebar.bookings' | translate }}
+          </a>
+        </li>
+        <li>
+          <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToMaritimeReports()">
+            <i class="isax isax-flag me-2"></i>{{ 'provider-tour-management.sidebar.maritimeReports' | translate }}
+          </a>
+        </li>
+        <li>
+          <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToProviderPayments()">
+            <i class="isax isax-wallet-2 me-2"></i>{{ 'provider-tour-management.sidebar.providerPayments' | translate }}
+          </a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</aside>
+
+<div [ngClass]="showAdminSidebar ? 'col-xl-9 col-lg-8' : 'col-12'">
+
     <!-- Booking Header -->
     <div class="card booking-header mb-4">
         <div class="card-body header-content d-flex align-items-center justify-content-between flex-wrap">
@@ -876,3 +905,8 @@
     </div>
 }
 <!-- /Reschedule Date Selection Modal -->
+
+</div><!-- /col main -->
+</div><!-- /row wrapper -->
+</div><!-- /provider-tour-management -->
+

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -91,9 +91,20 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
   currentRole!: UserRole;
   // FE-15c: mostrar acceso a reportes DIMAR cuando el backoffice está viendo /admin/bookings-management.
   showMaritimeReportsLink = false;
+  // TC-008 (#195 sidebar): mostrar sidebar admin con 3 items solo cuando el user
+  // es ADMIN o BACKOFFICE_OPERATION en la vista bookings-management.
+  showAdminSidebar = false;
 
   goToMaritimeReports(): void {
     this.router.navigate(['/admin/maritime-reports']);
+  }
+
+  goToBookingsManagement(): void {
+    this.router.navigate(['/admin/bookings-management']);
+  }
+
+  goToProviderPayments(): void {
+    this.router.navigate(['/admin/provider-payments']);
   }
   
   // Variables de paginación y filtrado
@@ -189,6 +200,9 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
     this.config = this.configService.getConfigByRole(this.currentRole);
     this.showMaritimeReportsLink = this.authService.isTouryaBackoffice()
       && this.router.url.includes('bookings-management');
+    // TC-008 (#195 sidebar): mismo criterio que showMaritimeReportsLink pero
+    // ahora tambien decide si mostrar el sidebar admin con 3 items.
+    this.showAdminSidebar = this.showMaritimeReportsLink;
     
     // Cargar datos según el rol
     // TC-005 post-fix: ADMIN/BACKOFFICE_OPERATION también consume el endpoint provider


### PR DESCRIPTION
Luis 2026-08-03: BO ingresó OK a \`/admin/bookings-management\` pero la vista no mostraba menú lateral. Pidió sidebar con 3 items: **Reservas, Reporte Actividades Marítimas, Órdenes de pago**.

## Cambios

### Nueva ruta \`/admin/provider-payments\`
- \`admin-routing.module.ts\`: nueva ruta con \`BackofficeGuard\`.
- \`provider-payments-wrapper-routing.module.ts\` (nuevo): wrapper que agrega routing al \`ProviderPaymentsModule\` (original no tenía RouterModule).
- El componente ya existía (\`ProviderPaymentsComponent\`); antes vivía embebido en el dashboard bajo el toggle \`mostrarProviderPayments\`, ahora accesible por URL directa.

### Sidebar en la vista bookings-management
- \`provider-tour-management.component.html\`: envuelve el contenido en un \`row\` Bootstrap con un \`<aside>\` condicional (col-xl-3) que solo aparece cuando \`showAdminSidebar\` es true. Contenido pasa a col-xl-9 si el sidebar está visible; col-12 si no (evita hueco en las vistas PROVIDER/CLIENT).
- \`provider-tour-management.component.ts\`: nuevos métodos \`goToBookingsManagement\`, \`goToProviderPayments\` (ya existía \`goToMaritimeReports\`). Nueva flag \`showAdminSidebar\` = \`showMaritimeReportsLink\` (ambas basadas en \`isTouryaBackoffice() && url.includes('bookings-management')\`).

### i18n \`provider-tour-management.sidebar.*\` en los 3 JSON
\`section\`, \`bookings\`, \`maritimeReports\`, \`providerPayments\` en es/en/pt.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] Login como **BO** → aterriza en \`/admin/bookings-management\` → sidebar visible con 3 items en el idioma actual.
- [ ] Click "Reservas" en sidebar → sigue en \`/admin/bookings-management\`.
- [ ] Click "Reporte de Actividades Marítimas" → navega a \`/admin/maritime-reports\`.
- [ ] Click "Órdenes de pago" → navega a \`/admin/provider-payments\` (nueva ruta).
- [ ] Login como **ADMIN** → mismo sidebar visible.
- [ ] Login como **PROVIDER** → NO se muestra el sidebar (vista sin col-xl-3).
- [ ] Cambiar idioma a EN/PT → labels del sidebar se traducen.

Relacionado con #195.