### PR TITLE
fix(TC-009 #196 v4): limpiar profileCache al logout + eliminar race procedencia

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, Optional } from '@angular/core';
+import { TouristService } from '../../shared/services/tourist.service';
 import {
   GoogleAuthProvider,
   FacebookAuthProvider,
@@ -39,7 +40,10 @@ export class AuthService {
   public currentUser: Observable<User | null> = this.currentUserSubject.asObservable();
   private baseUrl = environment.apiUrl + "/auth";
 
-  constructor(private http: HttpClient) {
+  constructor(
+    private http: HttpClient,
+    private touristService: TouristService
+  ) {
     onAuthStateChanged(auth, (user) => {
       this.currentUserSubject.next(user);
     });
@@ -101,6 +105,9 @@ export class AuthService {
     localStorage.removeItem(ACCESS_TOKEN_KEY);
     localStorage.removeItem(REFRESH_TOKEN_KEY);
     localStorage.removeItem(LEGACY_TOKEN_KEY);
+    // TC-009 (#196 v4): invalidar caches por-user para que un logout limpio no
+    // deje datos del user anterior visibles al proximo login (Luis 2026-08-03).
+    this.touristService.clearProfileCache();
   }
 
   setUser(user: any): void {

--- a/src/app/pages/clients/cart-summary/cart-summary.component.ts
+++ b/src/app/pages/clients/cart-summary/cart-summary.component.ts
@@ -151,8 +151,10 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
     console.log('CartSummary: Iniciando componente...');
     this.loadCartData();
     this.loadUserCredits();
+    // TC-009 (#196 v4): la carga de countries ahora vive dentro de loadUserProfile ->
+    // matchPlaceOfOriginFromProfile para evitar race con getCountries() del ngOnInit
+    // (bug intermitente reportado por Luis 2026-08-03: Country vacio pero State/City llenos).
     this.loadUserProfile();
-    this.getCountries();
     this.openGuestModalIfProfileIncomplete();
   }
 
@@ -301,7 +303,7 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
    * Carga los datos del perfil del usuario y pre-llena el formulario
    */
   private loadUserProfile(): void {
-    this.touristService.getProfile()
+    this.touristService.getProfile(true)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (profile) => {
@@ -317,37 +319,43 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
               this.contactForm.address1 = (profile as any).address || this.contactForm.address1;
             }
 
-            // TC-009 (#196 v3): matchear country/state/city del perfil a IDs
-            // reales de los dropdowns "Lugar de procedencia". Antes solo se
-            // asignaba `mapCountryToIsoCode` que devolvia 'CO'/'US'/'ES' pero los
-            // <select> usan `country.id` numerico → nada matchea → dropdown vacio.
-            this.matchPlaceOfOriginFromProfile(profile);
-
             this.syncFormsData();
           }
+          // TC-009 (#196 v4): siempre cargar countries — aun sin profile con
+          // country, para que el usuario pueda seleccionar manualmente.
+          this.matchPlaceOfOriginFromProfile(profile || {} as TouristProfileDto);
         },
         error: (error) => {
           console.error('CartSummary: Error cargando perfil de usuario:', error);
+          // Sin profile, igual cargamos countries para permitir seleccion manual.
+          this.matchPlaceOfOriginFromProfile({} as TouristProfileDto);
         }
       });
   }
 
   /**
-   * TC-009 (#196 v3): matching en cascada nombre → id para lugar de procedencia.
+   * TC-009 (#196 v3-v4): matching en cascada nombre → id para lugar de procedencia.
    * Backend guarda `country/state/city` como strings (Colombia, Bolivar, Cartagena);
-   * los <select> del cart-summary usan IDs numericos. Este helper hace el matching.
+   * los <select> del cart-summary usan IDs numericos.
+   *
+   * v4 (Luis 2026-08-03): siempre carga la lista de countries (aun sin profile.country)
+   * para eliminar el race con el `getCountries()` paralelo del ngOnInit anterior.
+   * El match parcial (solo country, o country+state) queda tolerado — el resto queda
+   * en '' y el usuario los completa a mano.
    */
   private matchPlaceOfOriginFromProfile(profile: TouristProfileDto): void {
-    if (!profile.country) return;
     this.countryService.getCountries()
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: (countries) => {
           this.countries = countries || [];
+          if (!profile.country) return;
           const matchedCountry = this.countries.find(c =>
             c.name?.toLowerCase() === profile.country?.toLowerCase());
           if (!matchedCountry) return;
-          this.contactForm.country = String(matchedCountry.id);
+          // NgModel de <option [value]="country.id"> compara con el binding; para evitar
+          // mismatches string vs number, usar el mismo tipo que las options (number).
+          this.contactForm.country = matchedCountry.id as any;
           if (!profile.state) return;
           this.departmentService.getDepartmentsByCountryId(matchedCountry.id)
             .pipe(takeUntil(this.destroy$))
@@ -357,7 +365,7 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
                 const matchedDept = this.departments.find(d =>
                   d.name?.toLowerCase() === profile.state?.toLowerCase());
                 if (!matchedDept) return;
-                this.contactForm.state = String(matchedDept.id);
+                this.contactForm.state = matchedDept.id as any;
                 if (!profile.city) return;
                 this.cityService.getCitiesByDepartmentId(matchedDept.id)
                   .pipe(takeUntil(this.destroy$))
@@ -367,7 +375,7 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
                       const matchedCity = this.cities.find(c =>
                         c.name?.toLowerCase() === profile.city?.toLowerCase());
                       if (matchedCity) {
-                        this.contactForm.city = String(matchedCity.id);
+                        this.contactForm.city = matchedCity.id as any;
                       }
                     },
                     error: (err) => console.error('matchPlaceOfOriginFromProfile cities error', err)

--- a/src/app/shared/services/tourist.service.ts
+++ b/src/app/shared/services/tourist.service.ts
@@ -18,6 +18,15 @@ export class TouristService {
 
   private profileCache$: Observable<TouristProfileDto> | null = null;
 
+  /**
+   * TC-009 (#196 v4): invalidar el cache del perfil. Se llama desde AuthService
+   * en logout/removeTokens para evitar que un user vea datos del user anterior
+   * cuando cierra sesion y entra con otro (bug reportado por Luis 2026-08-03).
+   */
+  clearProfileCache(): void {
+    this.profileCache$ = null;
+  }
+
   checkAddressComplete(): Observable<AddressCompleteResponseDto> {
     return this.http.get<AddressCompleteResponseDto>(`${this.baseUrl}/profile/address-complete`);
   }


### PR DESCRIPTION
Bugs reportados por Luis 2026-08-03 22:21 en #196.

## Bug 1 (CRÍTICO): my-profile muestra datos del user anterior post-logout

**Reproducción**: login user A → ver profile → logout → login user B → ir a my-profile → muestra datos del user A.

**Root cause**: \`TouristService.profileCache$\` es un Observable con \`shareReplay(1)\` que vive en un servicio singleton (\`providedIn: 'root'\`). El \`AuthService.logout\` solo limpiaba tokens de localStorage, no invalidaba el cache. Al próximo login \`getProfile()\` devolvía el observable cacheado con datos del user anterior.

**Fix**:
- \`TouristService.clearProfileCache()\` nuevo método público.
- \`AuthService.removeTokens()\` (llamado por logout + interceptor forceLogout) ahora invoca \`touristService.clearProfileCache()\`.
- Inyección de TouristService en el constructor de AuthService.

## Bug 2: procedencia intermitente en cart-summary

**Síntoma**: en la sección "Lugar de procedencia", Country queda vacío pero State y City muestran valores (captura de Luis: State "Norte de Santander", City "Cúcuta", Country "Select country").

**Root cause**: race entre \`getCountries()\` del \`ngOnInit\` y \`matchPlaceOfOriginFromProfile\` (dentro de \`loadUserProfile\`). Ambos asignan \`this.countries = ...\` en paralelo. Cuando el orden se invierte, el \`getCountries\` original sobreescribe la lista con nueva referencia y Angular re-renderiza el select de Country perdiendo el binding con \`contactForm.country\`.

**Fix**:
- Eliminar \`this.getCountries()\` del ngOnInit. El matcher hace la carga única.
- \`matchPlaceOfOriginFromProfile\` siempre carga countries (aun sin profile), para que dropdowns funcionen incluso sin perfil.
- Usar el id número directo (sin \`String()\`) para matchear los \`<option [value]="country.id">\`.
- \`getProfile(true)\` (forceRefresh) desde cart-summary — defensa extra contra cache stale además del clear al logout.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] Login user A → profile OK → logout → login user B → profile muestra datos de B (no A).
- [ ] Cart-summary con perfil completo: Country/State/City todos pre-llenados correctamente (probar varias veces).

Relacionado con #196.