### PR TITLE
fix(TC-008 #195 reabierto): sidebar admin persistente en shell con items por rol

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -223,13 +223,20 @@
       }
     }
   },
-  "provider-tour-management": {
+  "admin": {
     "sidebar": {
-      "section": "Backoffice Panel",
-      "bookings": "Bookings",
+      "section": "Admin Panel",
+      "dashboard": "Dashboard",
+      "requests": "Request List",
+      "toursManagement": "Tour Management",
       "maritimeReports": "Maritime Activity Reports",
-      "providerPayments": "Payment Orders"
-    },
+      "providerPayments": "Payment Orders",
+      "bookings": "Bookings",
+      "backofficeUsers": "Backoffice Users",
+      "appConfig": "System Configuration"
+    }
+  },
+  "provider-tour-management": {
     "header": {
       "totalBookings": "Total Bookings",
       "confirmBooking": "Confirm Booking",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -224,13 +224,20 @@
       }
     }
   },
-  "provider-tour-management": {
+  "admin": {
     "sidebar": {
-      "section": "Panel Backoffice",
+      "section": "Panel Administración",
+      "dashboard": "Dashboard",
+      "requests": "Lista de Solicitudes",
+      "toursManagement": "Gestión de Tours",
+      "maritimeReports": "Reporte Actividades Marítimas",
+      "providerPayments": "Órdenes de pago",
       "bookings": "Reservas",
-      "maritimeReports": "Reporte de Actividades Marítimas",
-      "providerPayments": "Órdenes de pago"
-    },
+      "backofficeUsers": "Usuarios Backoffice",
+      "appConfig": "Configuración del sistema"
+    }
+  },
+  "provider-tour-management": {
     "header": {
       "totalBookings": "Total de Reservas",
       "confirmBooking": "Confirmar Reserva",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -223,13 +223,20 @@
       }
     }
   },
-  "provider-tour-management": {
+  "admin": {
     "sidebar": {
-      "section": "Painel Backoffice",
-      "bookings": "Reservas",
+      "section": "Painel de Administração",
+      "dashboard": "Dashboard",
+      "requests": "Lista de Solicitações",
+      "toursManagement": "Gestão de Tours",
       "maritimeReports": "Relatório de Atividades Marítimas",
-      "providerPayments": "Ordens de Pagamento"
-    },
+      "providerPayments": "Ordens de Pagamento",
+      "bookings": "Reservas",
+      "backofficeUsers": "Usuários Backoffice",
+      "appConfig": "Configuração do sistema"
+    }
+  },
+  "provider-tour-management": {
     "header": {
       "totalBookings": "Total de Reservas",
       "confirmBooking": "Confirmar Reserva",

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -1,9 +1,76 @@
 <div class="admin-wrapper">
-  <div class="admin-header">
-  </div>
-  
-  <div class="admin-content">
-    <router-outlet></router-outlet>
-  </div>
-</div> 
+  <div class="admin-header"></div>
 
+  <div class="admin-content">
+    <!-- TC-008 (#195 reabierto): sidebar persistente en todas las vistas admin
+         excepto /admin/dashboard (que ya tiene su propio con toggles). ADMIN ve
+         8 items; BACKOFFICE_OPERATION ve 3. -->
+    <div class="row" *ngIf="showShellSidebar; else noSidebar">
+      <aside class="col-xl-3 col-lg-4 admin-sidebar mb-4 mb-lg-0">
+        <div class="card user-sidebar theiaStickySidebar">
+          <div class="card-body user-sidebar-body">
+            <ul>
+              <li><span class="fs-14 text-gray-3 fw-medium mb-2">{{ 'admin.sidebar.section' | translate }}</span></li>
+
+              <ng-container *ngIf="isAdmin">
+                <li>
+                  <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToDashboard()">
+                    <i class="isax isax-grid-55 me-2"></i>{{ 'admin.sidebar.dashboard' | translate }}
+                  </a>
+                </li>
+                <li>
+                  <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToDashboardSolicitudes()">
+                    <i class="isax isax-user me-2"></i>{{ 'admin.sidebar.requests' | translate }}
+                  </a>
+                </li>
+                <li>
+                  <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToDashboardTours()">
+                    <i class="isax isax-map me-2"></i>{{ 'admin.sidebar.toursManagement' | translate }}
+                  </a>
+                </li>
+              </ng-container>
+
+              <!-- Comunes ADMIN y BO -->
+              <li>
+                <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToMaritimeReports()">
+                  <i class="isax isax-flag me-2"></i>{{ 'admin.sidebar.maritimeReports' | translate }}
+                </a>
+              </li>
+              <li>
+                <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToProviderPayments()">
+                  <i class="isax isax-wallet-2 me-2"></i>{{ 'admin.sidebar.providerPayments' | translate }}
+                </a>
+              </li>
+              <li>
+                <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToBookingsManagement()">
+                  <i class="isax isax-calendar-tick me-2"></i>{{ 'admin.sidebar.bookings' | translate }}
+                </a>
+              </li>
+
+              <ng-container *ngIf="isAdmin">
+                <li>
+                  <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToBackofficeUsers()">
+                    <i class="isax isax-people me-2"></i>{{ 'admin.sidebar.backofficeUsers' | translate }}
+                  </a>
+                </li>
+                <li>
+                  <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToDashboardAppConfig()">
+                    <i class="isax isax-setting-2 me-2"></i>{{ 'admin.sidebar.appConfig' | translate }}
+                  </a>
+                </li>
+              </ng-container>
+            </ul>
+          </div>
+        </div>
+      </aside>
+
+      <div class="col-xl-9 col-lg-8">
+        <router-outlet></router-outlet>
+      </div>
+    </div>
+
+    <ng-template #noSidebar>
+      <router-outlet></router-outlet>
+    </ng-template>
+  </div>
+</div>

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -1,16 +1,102 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subject, filter, takeUntil } from 'rxjs';
+import { AuthService } from '../../core/services/auth.service';
 
+/**
+ * TC-008 (#195 reabierto Luis 2026-08-04): shell del panel admin.
+ *
+ * <p>Antes era un `<router-outlet>` a secas y cada pantalla dibujaba su propio
+ * sidebar (o no lo dibujaba). Ahora aporta un sidebar navegacional persistente
+ * en TODAS las vistas admin excepto `/admin/dashboard` (que tiene su propio
+ * sidebar con toggles internos). Items del sidebar dependen del rol: ADMIN ve
+ * 8, BACKOFFICE_OPERATION ve 3.</p>
+ */
 @Component({
   selector: 'app-admin',
   templateUrl: './admin.component.html',
   styleUrls: ['./admin.component.scss'],
   standalone: false
 })
-export class AdminComponent implements OnInit {
+export class AdminComponent implements OnInit, OnDestroy {
+  private readonly destroy$ = new Subject<void>();
 
-  constructor() { }
+  isAdmin = false;
+  isBackofficeOperation = false;
+  showShellSidebar = false;
+
+  constructor(
+    private router: Router,
+    private authService: AuthService
+  ) {}
 
   ngOnInit(): void {
+    this.isAdmin = this.authService.isAdmin();
+    this.isBackofficeOperation = this.authService.isBackofficeOperation();
+    this.recomputeShellSidebar(this.router.url);
+
+    this.router.events
+      .pipe(
+        filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(e => this.recomputeShellSidebar(e.urlAfterRedirects || e.url));
   }
 
-} 
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  /**
+   * Sidebar visible en todas las rutas admin excepto /admin/dashboard (que ya
+   * dibuja su propio sidebar con toggles). Evita mostrar dos sidebars.
+   */
+  private recomputeShellSidebar(url: string): void {
+    const path = (url || '').split('?')[0];
+    this.showShellSidebar = path.startsWith('/admin')
+      && !path.startsWith('/admin/dashboard')
+      && path !== '/admin'
+      && path !== '/admin/';
+  }
+
+  /** ADMIN va al dashboard con la seccion Solicitudes activa. */
+  goToDashboardSolicitudes(): void {
+    this.router.navigate(['/admin/dashboard'], { queryParams: { section: 'solicitudes' } });
+  }
+
+  /** ADMIN va al dashboard con la seccion Gestion de Tours activa. */
+  goToDashboardTours(): void {
+    this.router.navigate(['/admin/dashboard'], { queryParams: { section: 'tours' } });
+  }
+
+  /** Reportes DIMAR: ruta propia (BackofficeGuard). */
+  goToMaritimeReports(): void {
+    this.router.navigate(['/admin/maritime-reports']);
+  }
+
+  /** Ordenes de pago: ruta propia (BackofficeGuard). */
+  goToProviderPayments(): void {
+    this.router.navigate(['/admin/provider-payments']);
+  }
+
+  /** Reservas cross-provider (BackofficeGuard). */
+  goToBookingsManagement(): void {
+    this.router.navigate(['/admin/bookings-management']);
+  }
+
+  /** Usuarios Backoffice (AdminGuard). */
+  goToBackofficeUsers(): void {
+    this.router.navigate(['/admin/backoffice-users']);
+  }
+
+  /** App config: dashboard con seccion appConfig. */
+  goToDashboardAppConfig(): void {
+    this.router.navigate(['/admin/dashboard'], { queryParams: { section: 'appConfig' } });
+  }
+
+  /** Volver al dashboard principal (sin section). */
+  goToDashboard(): void {
+    this.router.navigate(['/admin/dashboard']);
+  }
+}

--- a/src/app/pages/admin/dashboard/dashboard.component.ts
+++ b/src/app/pages/admin/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { RequestProvider } from '../../../shared/dto/requestProvider-response.dto';
 import { RequestProvidersService } from '../../providers/requestproviders/request-providers.service';
 import { RequestProviderDocumentType } from '../../../shared/dto/RequestProviderDocumentTypeList.dto';
@@ -36,7 +36,8 @@ export class DashboardComponent implements OnInit {
   constructor(
     private requestProvidersService: RequestProvidersService,
     private panelStateService: ProviderPanelStateService,
-    private router: Router
+    private router: Router,
+    private route: ActivatedRoute
   ) { }
 
   /** FE-15b post-fix: navega a la vista de reservas (BookingsManagement) del backoffice. */
@@ -57,6 +58,15 @@ export class DashboardComponent implements OnInit {
     if (this.panelStateService.hasPaymentToOpen()) {
       this.toggleProviderPayments();
     }
+
+    // TC-008 (#195 reabierto): el shell admin puede navegar aqui con
+    // ?section=solicitudes|tours|appConfig para activar la seccion correspondiente.
+    this.route.queryParamMap.subscribe(params => {
+      const section = params.get('section');
+      if (section === 'solicitudes' && !this.mostrarSolicitudes) this.toggleSolicitudes();
+      else if (section === 'tours' && !this.mostrarTourList) this.toggleTourList();
+      else if (section === 'appConfig' && !this.mostrarAppConfig) this.toggleAppConfig();
+    });
   }
 
   toggleTourList(): void {

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
@@ -1,34 +1,8 @@
 <!-- Provider Tour Management -->
+<!-- TC-008 (#195 reabierto Luis 2026-08-04): sidebar removido de aca — ahora vive
+     en AdminComponent (shell) con items completos segun rol. Layout vuelve al
+     original full-width. -->
 <div class="provider-tour-management">
-<div class="row">
-<!-- TC-008 (#195 sidebar BO): menu lateral con 3 items para ADMIN/BO en la vista
-     bookings-management. No aparece para PROVIDER ni CLIENT. -->
-<aside *ngIf="showAdminSidebar" class="col-xl-3 col-lg-4 admin-sidebar mb-4 mb-lg-0">
-  <div class="card user-sidebar theiaStickySidebar">
-    <div class="card-body user-sidebar-body">
-      <ul>
-        <li><span class="fs-14 text-gray-3 fw-medium mb-2">{{ 'provider-tour-management.sidebar.section' | translate }}</span></li>
-        <li>
-          <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToBookingsManagement()">
-            <i class="isax isax-calendar-tick me-2"></i>{{ 'provider-tour-management.sidebar.bookings' | translate }}
-          </a>
-        </li>
-        <li>
-          <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToMaritimeReports()">
-            <i class="isax isax-flag me-2"></i>{{ 'provider-tour-management.sidebar.maritimeReports' | translate }}
-          </a>
-        </li>
-        <li>
-          <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToProviderPayments()">
-            <i class="isax isax-wallet-2 me-2"></i>{{ 'provider-tour-management.sidebar.providerPayments' | translate }}
-          </a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</aside>
-
-<div [ngClass]="showAdminSidebar ? 'col-xl-9 col-lg-8' : 'col-12'">
 
     <!-- Booking Header -->
     <div class="card booking-header mb-4">
@@ -906,7 +880,5 @@
 }
 <!-- /Reschedule Date Selection Modal -->
 
-</div><!-- /col main -->
-</div><!-- /row wrapper -->
 </div><!-- /provider-tour-management -->
 

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -91,20 +91,9 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
   currentRole!: UserRole;
   // FE-15c: mostrar acceso a reportes DIMAR cuando el backoffice está viendo /admin/bookings-management.
   showMaritimeReportsLink = false;
-  // TC-008 (#195 sidebar): mostrar sidebar admin con 3 items solo cuando el user
-  // es ADMIN o BACKOFFICE_OPERATION en la vista bookings-management.
-  showAdminSidebar = false;
 
   goToMaritimeReports(): void {
     this.router.navigate(['/admin/maritime-reports']);
-  }
-
-  goToBookingsManagement(): void {
-    this.router.navigate(['/admin/bookings-management']);
-  }
-
-  goToProviderPayments(): void {
-    this.router.navigate(['/admin/provider-payments']);
   }
   
   // Variables de paginación y filtrado
@@ -200,9 +189,6 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
     this.config = this.configService.getConfigByRole(this.currentRole);
     this.showMaritimeReportsLink = this.authService.isTouryaBackoffice()
       && this.router.url.includes('bookings-management');
-    // TC-008 (#195 sidebar): mismo criterio que showMaritimeReportsLink pero
-    // ahora tambien decide si mostrar el sidebar admin con 3 items.
-    this.showAdminSidebar = this.showMaritimeReportsLink;
     
     // Cargar datos según el rol
     // TC-005 post-fix: ADMIN/BACKOFFICE_OPERATION también consume el endpoint provider


### PR DESCRIPTION
Luis 2026-08-04 en #195 (reabierto): mi PR #94 (sidebar BO en bookings-management) **reemplazaba el sidebar admin** cuando ADMIN entraba a Reservas — solo veía 3 items en vez de 8. Además \`/admin/backoffice-users\` no mostraba ningún sidebar. Ambos casos rompían la UX del ADMIN.

## Refactor

### \`AdminComponent\` (shell)

Ahora aporta un sidebar **navegacional persistente en todas las rutas admin excepto \`/admin/dashboard\`** (que tiene su propio sidebar con toggles internos). Se detecta la ruta con \`Router.events + NavigationEnd\` → \`showShellSidebar\`.

Items por rol:
- **ADMIN (8)**: Dashboard, Solicitudes, Gestión Tours, Reportes DIMAR, Órdenes de pago, Reservas, Usuarios Backoffice, App config.
- **BACKOFFICE_OPERATION (3)**: Reportes DIMAR, Órdenes de pago, Reservas.

Los items que apuntan a secciones del dashboard (Solicitudes, Gestión Tours, App config) navegan a \`/admin/dashboard?section=X\` — \`DashboardComponent\` lee el query param en \`ngOnInit\` y activa el toggle correspondiente.

### \`provider-tour-management\`

- HTML: removido el sidebar wrapper que PR #94 agregó (ahora vive en el shell). Layout vuelve al full-width original para vistas PROVIDER/CLIENT.
- TS: removidos \`showAdminSidebar\`, \`goToBookingsManagement\`, \`goToProviderPayments\` (todos migrados al shell).

### i18n

- Nueva key \`admin.sidebar.*\` en es/en/pt (9 sub-keys).
- Removida key \`provider-tour-management.sidebar.*\` (ya no se usa).

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] **ADMIN** en \`/admin/dashboard\` → ve su sidebar dashboard (con toggles). Shell sidebar NO aparece (evita duplicado).
- [ ] **ADMIN** en \`/admin/bookings-management\` → shell sidebar con **8 items**.
- [ ] **ADMIN** en \`/admin/backoffice-users\` → shell sidebar con **8 items**.
- [ ] **ADMIN** click "Solicitudes" en shell sidebar → va a \`/admin/dashboard?section=solicitudes\` y la sección se activa.
- [ ] **BO** en \`/admin/bookings-management\` → shell sidebar con **3 items**.

Relacionado con #195. Cierra el hilo del sidebar BO (regresión introducida por PR #94).