### PR TITLE
fix(TC-015 #218): UI para editar porcentajeTourya post-aceptacion + mostrar valor actual

### DIFF
--- a/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.html
+++ b/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.html
@@ -246,6 +246,11 @@
                   <h6 class="fw-medium">Price</h6>
                   <p class="flex-fill">{{ tour.price ? ('$' + tour.price) : '—' }}</p>
                 </div>
+                <!-- TC-015 (#218): visibilidad del % Tourya actual para ADMIN. -->
+                <div class="d-flex align-items-center justify-content-between details-info">
+                  <h6 class="fw-medium">% Tourya</h6>
+                  <p class="flex-fill">{{ getPorcentajeTouryaDisplay() || '—' }}</p>
+                </div>
               </div>
             </div>
           </div>
@@ -277,8 +282,12 @@
               <button class="btn btn-warning w-100 mb-2 fs-14" (click)="openReturnModal()" [disabled]="canReturn()">
                 <i class="isax isax-rotate-left me-2"></i>Devolver Tour
               </button>
-              <button class="btn btn-danger w-100 fs-14" (click)="openCancelModal()" [disabled]="!canCancel()">
+              <button class="btn btn-danger w-100 mb-2 fs-14" (click)="openCancelModal()" [disabled]="!canCancel()">
                 <i class="isax isax-close-circle me-2"></i>Cancelar Tour
+              </button>
+              <!-- TC-015 (#218): editar % Tourya para tours ya aceptados. -->
+              <button class="btn btn-outline-primary w-100 fs-14" (click)="openEditPorcentajeModal()" [disabled]="!canEditPorcentaje()">
+                <i class="isax isax-percentage-square me-2"></i>Editar % Tourya
               </button>
             </div>
           </div>
@@ -333,11 +342,12 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Confirmar Aceptación</h5>
+        <h5 class="modal-title">{{ porcentajeModalEditMode ? 'Editar % Tourya' : 'Confirmar Aceptación' }}</h5>
         <button type="button" class="btn-close" (click)="closeAcceptModal()" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <p>¿Estás seguro de que deseas aceptar este tour?</p>
+        <p *ngIf="!porcentajeModalEditMode">¿Estás seguro de que deseas aceptar este tour?</p>
+        <p *ngIf="porcentajeModalEditMode">Actualiza el porcentaje Tourya de este tour. El cambio no afecta los slots ya creados.</p>
 
         <div class="mb-3">
           <label for="porcentajeTouryaInput" class="form-label fw-semibold">
@@ -363,7 +373,7 @@
           </div>
         </div>
 
-        <div class="alert alert-success mb-0">
+        <div class="alert alert-success mb-0" *ngIf="!porcentajeModalEditMode">
           <i class="isax isax-info-circle me-2"></i>
           <small>El tour pasará a estado "Aceptado" y estará disponible para los usuarios.</small>
         </div>
@@ -375,7 +385,7 @@
           (click)="acceptTour()"
           [disabled]="savingPorcentajeTourya || !isPorcentajeTouryaValid()"
         >
-          <span *ngIf="!savingPorcentajeTourya">Sí, Aceptar</span>
+          <span *ngIf="!savingPorcentajeTourya">{{ porcentajeModalEditMode ? 'Guardar' : 'Sí, Aceptar' }}</span>
           <span *ngIf="savingPorcentajeTourya">Guardando…</span>
         </button>
         <button

--- a/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.ts
+++ b/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.ts
@@ -20,6 +20,8 @@ export class TourAdminDetailComponent implements OnInit, AfterViewChecked {
   tour: TourAdminDto | null = null;
   loading: boolean = false;
   showAcceptModal: boolean = false;
+  // TC-015 (#218): true = editar % sin aceptar el tour; false = flujo original de aceptar tour.
+  porcentajeModalEditMode: boolean = false;
   showCancelModal: boolean = false;
   showReturnModal: boolean = false;
 
@@ -221,6 +223,7 @@ export class TourAdminDetailComponent implements OnInit, AfterViewChecked {
   }
 
   openAcceptModal(): void {
+    this.porcentajeModalEditMode = false;
     const current = this.tour?.porcentajeTourya;
     if (typeof current === 'number' && Number.isFinite(current)) {
       this.porcentajeTouryaInput = this.round2(current * 100);
@@ -228,6 +231,36 @@ export class TourAdminDetailComponent implements OnInit, AfterViewChecked {
       this.porcentajeTouryaInput = this.DEFAULT_PORCENTAJE_TOURYA_PERCENT;
     }
     this.showAcceptModal = true;
+  }
+
+  /**
+   * TC-015 (#218): abre el mismo modal pero en modo edicion — el submit solo
+   * actualiza el porcentajeTourya sin llamar a acceptTour. Habilitado para
+   * tours ya aceptados (canEditPorcentaje()).
+   */
+  openEditPorcentajeModal(): void {
+    this.porcentajeModalEditMode = true;
+    const current = this.tour?.porcentajeTourya;
+    if (typeof current === 'number' && Number.isFinite(current)) {
+      this.porcentajeTouryaInput = this.round2(current * 100);
+    } else {
+      this.porcentajeTouryaInput = this.DEFAULT_PORCENTAJE_TOURYA_PERCENT;
+    }
+    this.showAcceptModal = true;
+  }
+
+  canEditPorcentaje(): boolean {
+    return this.tour?.status === 'accepted';
+  }
+
+  /**
+   * TC-015 (#218): visualizacion del % actual en el sidebar. Retorna null si
+   * el backend aun no expone el valor (evita mostrar "0%" enganoso).
+   */
+  getPorcentajeTouryaDisplay(): string | null {
+    const p = this.tour?.porcentajeTourya;
+    if (typeof p !== 'number' || !Number.isFinite(p)) return null;
+    return `${this.round2(p * 100)}%`;
   }
 
   closeAcceptModal(): void {
@@ -272,6 +305,32 @@ export class TourAdminDetailComponent implements OnInit, AfterViewChecked {
       typeof this.tour.porcentajeTourya === 'number' && Number.isFinite(this.tour.porcentajeTourya)
         ? this.round2(this.tour.porcentajeTourya * 100) / 100
         : null;
+
+    // TC-015 (#218): en modo edicion, solo PATCH del %; no llama a acceptTour.
+    if (this.porcentajeModalEditMode) {
+      if (currentDecimal !== null && Math.abs(currentDecimal - newDecimal) <= 0.00001) {
+        // Nada cambio -> cerrar sin request.
+        this.showAcceptModal = false;
+        return;
+      }
+      this.savingPorcentajeTourya = true;
+      this.tourAdminService.updatePorcentajeTourya(tourId, newDecimal).subscribe({
+        next: () => {
+          if (this.tour) {
+            this.tour.porcentajeTourya = newDecimal;
+          }
+          this.savingPorcentajeTourya = false;
+          this.openSnackBar('Porcentaje Tourya actualizado');
+          this.showAcceptModal = false;
+        },
+        error: (error) => {
+          this.savingPorcentajeTourya = false;
+          console.error('Error al actualizar el porcentaje Tourya:', error);
+          this.openSnackBar('Error al actualizar el porcentaje Tourya');
+        }
+      });
+      return;
+    }
 
     const doAccept = () => {
       this.tourAdminService.acceptTour(tourId).subscribe({


### PR DESCRIPTION
Luis 2026-08-06: el ADMIN podía definir % Tourya al aceptar el tour pero **no tenía forma de actualizarlo después** (el modal solo se abría si \`status === 'submitted'\`). Además no había visibilidad del valor actual en el detalle.

## Cambios

### \`tour-admin-detail.component.ts\`

- Nueva flag \`porcentajeModalEditMode\` para reutilizar el modal existente en modo edición.
- \`openEditPorcentajeModal()\`: abre el modal con el % actual pre-cargado. Habilitado por \`canEditPorcentaje()\` (\`status === 'accepted'\`).
- \`acceptTour()\`: en modo edición, solo hace PATCH del porcentaje y cierra sin llamar a acceptTour (el tour ya está aceptado).
- \`getPorcentajeTouryaDisplay()\`: helper para mostrar el % actual formateado (null si el backend aún no expone el valor).

### \`tour-admin-detail.component.html\`

- Sidebar "Tour Details": nueva fila "% Tourya" con el valor actual.
- Sidebar "Administrative Actions": nuevo botón "Editar % Tourya" (outline primary) habilitado solo para tours aceptados.
- Modal: título, mensaje y label del botón submit condicionales por \`porcentajeModalEditMode\`.

## Depende de

PR api #223 (backend expone \`porcentajeTourya\` en \`TourFullDataResponse\`). Sin ese fix el sidebar mostrará "—" siempre.

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] ADMIN en \`/admin/tour-admin/detail/{id}\` con tour aceptado: sidebar muestra "% Tourya: 25%" (o el valor real).
- [ ] Botón "Editar % Tourya" habilitado → abre modal título "Editar % Tourya" con input pre-cargado.
- [ ] Cambiar valor y guardar → PATCH exitoso, snackbar "Porcentaje Tourya actualizado", modal cierra, sidebar refleja el nuevo valor.
- [ ] Tour en estado submitted: botón "Editar %" deshabilitado; "Aceptar Tour" habilitado (flujo original intacto).

Closes #218 tras validación de Luis.