### PR TITLE
feat(TC-016 #219 A): render meeting point con nombre + pais + ciudad + estado

### DIFF
--- a/src/app/pages/clients/tours-detail/tours-detail.component.html
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.html
@@ -177,11 +177,21 @@
                             
                         </div>
                         <!-- /Map -->
+                        <!-- TC-016 (#219): mostrar tambien nombre location + pais + ciudad debajo del mapa, no solo la direccion textual. -->
                         <div class="mt-3" *ngIf="tour?.locations?.length">
                             <h6 class="fs-16 mb-2"><i class="isax isax-location me-1"></i>{{ 'tours-detail.booking.meetingPoint' | translate }}</h6>
-                            <p class="mb-2" *ngFor="let loc of tour.locations">
-                                <i class="isax isax-location5 text-primary me-2"></i>{{ loc.address }}
-                            </p>
+                            <div class="mb-2" *ngFor="let loc of tour.locations">
+                                <p class="mb-1 fw-medium" *ngIf="loc.location">
+                                    <i class="isax isax-location5 text-primary me-2"></i>{{ (loc.location | localizedName) || loc.location }}
+                                </p>
+                                <p class="mb-1 text-gray-6" *ngIf="loc.address">
+                                    <i class="isax isax-map me-2"></i>{{ loc.address }}
+                                </p>
+                                <p class="mb-0 text-gray-6 fs-14" *ngIf="loc.cityName || loc.stateName || loc.countryName">
+                                    <i class="isax isax-global me-2"></i>
+                                    <ng-container *ngIf="loc.cityName">{{ loc.cityName }}</ng-container><ng-container *ngIf="loc.cityName && (loc.stateName || loc.countryName)">, </ng-container><ng-container *ngIf="loc.stateName">{{ loc.stateName }}</ng-container><ng-container *ngIf="loc.stateName && loc.countryName">, </ng-container><ng-container *ngIf="loc.countryName">{{ loc.countryName }}</ng-container>
+                                </p>
+                            </div>
                         </div>
                     </div>
 

--- a/src/app/pages/clients/tours-detail/tours-detail.component.ts
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.ts
@@ -481,10 +481,14 @@ export class ToursDetailComponent implements OnInit, OnDestroy, AfterViewChecked
     const loc = this.tour?.locations && this.tour.locations.length ? this.tour.locations[0] : undefined;
     if (!loc) return [];
 
-    // try to find city/state names from locationsPublic
+    // TC-016 (#219): el backend ahora expone countryName/stateName/cityName
+    // directo en TourAddressResponse. Se usa primero; si por compatibilidad
+    // hacia atras vinieran null, se cae al catalogo locationsPublic.
+    const anyLoc = loc as any;
     const found = this.locationsPublic.find(lp => lp.cityId === loc.cityId && lp.stateId === loc.stateId);
-    const cityName = found ? found.cityName : undefined;
-    const stateName = found ? found.stateName : undefined;
+    const cityName = anyLoc.cityName ?? (found ? found.cityName : undefined);
+    const stateName = anyLoc.stateName ?? (found ? found.stateName : undefined);
+    const countryName = anyLoc.countryName ?? (found ? (found as any).countryName : undefined);
 
     const parts: { isI18n: boolean, text: any }[] = [];
     if (loc.location) parts.push({ isI18n: true, text: loc.location }); // friendly name of the location
@@ -493,6 +497,8 @@ export class ToursDetailComponent implements OnInit, OnDestroy, AfterViewChecked
     else if (loc.cityId) parts.push({ isI18n: false, text: String(loc.cityId) });
     if (stateName) parts.push({ isI18n: false, text: stateName });
     else if (loc.stateId) parts.push({ isI18n: false, text: String(loc.stateId) });
+    // TC-016 (#219): agregar country que antes no se mostraba.
+    if (countryName) parts.push({ isI18n: false, text: countryName });
 
     this._cachedLocationParts = parts;
     return parts;

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
@@ -489,9 +489,23 @@
                                 <h6 class="mb-3">{{ 'provider-tour-management.modal.meetingPoint' | translate }}</h6>
                                 @for (loc of selectedBooking.tourDetails.locations; track loc.id) {
                                     <div class="mb-3">
-                                        <p class="fs-14 fw-medium text-dark mb-2">
-                                            <i class="isax isax-location5 text-primary me-2"></i>{{ loc.address }}
-                                        </p>
+                                        <!-- TC-016 (#219): nombre location + address + ciudad/estado/pais -->
+                                        @if (loc.location) {
+                                            <p class="fs-15 fw-semibold text-dark mb-1">
+                                                <i class="isax isax-location5 text-primary me-2"></i>{{ (loc.location | localizedName) || loc.location }}
+                                            </p>
+                                        }
+                                        @if (loc.address) {
+                                            <p class="fs-14 text-dark mb-1">
+                                                <i class="isax isax-map me-2 text-gray-6"></i>{{ loc.address }}
+                                            </p>
+                                        }
+                                        @if (loc.cityName || loc.stateName || loc.countryName) {
+                                            <p class="fs-13 text-gray-6 mb-2">
+                                                <i class="isax isax-global me-2"></i>
+                                                @if (loc.cityName) { {{ loc.cityName }} }@if (loc.cityName && (loc.stateName || loc.countryName)) {, }@if (loc.stateName) { {{ loc.stateName }} }@if (loc.stateName && loc.countryName) {, }@if (loc.countryName) { {{ loc.countryName }} }
+                                            </p>
+                                        }
                                         @if (loc.latitude && loc.longitude) {
                                             <google-map height="280px" width="100%"
                                                 [center]="{lat: loc.latitude, lng: loc.longitude}"

--- a/src/app/shared/dto/tour-admin.dto.ts
+++ b/src/app/shared/dto/tour-admin.dto.ts
@@ -69,6 +69,10 @@ export interface LocationDto {
   countryId: number;
   stateId: number;
   cityId: number;
+  // TC-016 (#219): backend expone nombres directos junto a los IDs.
+  countryName?: string;
+  stateName?: string;
+  cityName?: string;
   latitude?: number;
   longitude?: number;
 }

--- a/src/app/shared/dto/tour-response.dto.ts
+++ b/src/app/shared/dto/tour-response.dto.ts
@@ -100,6 +100,10 @@ interface Location {
   countryId: number;
   stateId: number;
   cityId: number;
+  // TC-016 (#219): backend expone nombres directos junto a los IDs.
+  countryName?: string;
+  stateName?: string;
+  cityName?: string;
   latitude: number;
   longitude: number;
 }


### PR DESCRIPTION
Luis 2026-08-06 en #219: en tour-detail y en el modal de detalle de reserva, el punto de encuentro solo mostraba la dirección textual. Falta país, ciudad, estado y el nombre del location (que ya vienen del backend post-PR api #224).

## Cambios

### \`tours-detail.component\` (cliente)
- \`getLocationDisplayParts()\`: usa \`loc.countryName/stateName/cityName\` del backend (fallback al catálogo público por compat). Agrega \`countryName\` que antes no aparecía.
- HTML: bajo el mapa, ahora renderiza en jerarquía: nombre del location (i18n), dirección textual, ciudad · estado · país (una línea concatenada).

### \`provider-tour-management.component\` (modal detalle reserva turista)
- Sección "Punto de encuentro" ya tenía mapa; ahora además muestra: nombre location, dirección, ciudad · estado · país.

### DTOs
- \`LocationDto\` y \`Location\` (interfaces del frontend): agregar campos opcionales \`countryName?\`, \`stateName?\`, \`cityName?\`.

## Depende de

PR api #224 (backend expone nombres en \`TourAddressResponse\`). Sin ese fix, los nombres aparecen null (fallback al catálogo público por retro-compatibilidad).

## Test plan

- [ ] Pipeline verde + deploy.
- [ ] \`/clients/tours-detail/{id}\` → mapa + debajo: nombre location, dirección, "Ciudad, Estado, País".
- [ ] Detalle reserva turista (\`/clients/my-profile?section=bookings\` → click en una reserva) → sección "Punto de encuentro" muestra los mismos datos.
- [ ] Regresión: si el location tiene solo address (sin ciudad/estado del catálogo viejo), sigue mostrando la dirección sin romper.

Parte (A) del TC-016. Parte (B) desglose viajeros vendrá en PR aparte.