### PR TITLE
feat(TC-016 #219 B): render desglose viajeros por ageType en modal reserva + floating cart

### DIFF
--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
@@ -322,7 +322,15 @@
                                 </div>
                                 <div class="col-lg-4">
                                     <h6 class="fs-14 text-gray-6">{{ 'provider-tour-management.modal.travelers' | translate }}</h6>
-                                    <p class="text-dark fs-16 fw-medium">{{ formatTravellers(selectedBooking.travellers) }}</p>
+                                    <p class="text-dark fs-16 fw-medium mb-1">{{ formatTravellers(selectedBooking.travellers) }}</p>
+                                    <!-- TC-016 (#219): desglose por ageType (ADULT/CHILD/INFANT) proveniente de shopping_cart_item_detail via SP. -->
+                                    @if (selectedBooking.travelerBreakdown?.length) {
+                                        <p class="fs-13 text-gray-6 mb-0">
+                                            @for (t of selectedBooking.travelerBreakdown; track t.ageType; let last = $last) {
+                                                <span>{{ t.quantity }} {{ 'configuration.ageType.' + t.ageType | translate }}</span>@if (!last) {<span>, </span>}
+                                            }
+                                        </p>
+                                    }
                                 </div>
                                 <div class="col-lg-4">
                                     <h6 class="fs-14 text-gray-6">{{ 'provider-tour-management.modal.totalPrice' | translate }}</h6>

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -64,6 +64,8 @@ export interface ProviderTourBooking {
   canRainCancel?: boolean;
   qrUrl?: string;
   totalTourists?: number;
+  /** TC-016 (#219): desglose de viajeros por ageType (ADULT/CHILD/INFANT). */
+  travelerBreakdown?: { ageType: string; quantity: number; unitPrice?: number; providerUnitPrice?: number }[];
   serviceResponsible?: any; // New field for reservation contact
   tourDetails?: any; // New field for public tour details
   // Payer info (for PROVIDER/ADMIN view)
@@ -629,6 +631,7 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
       customerPhone: reservation.payerPhone,
       travellers: `${reservation.totalTourists} ${reservation.totalTourists === 1 ? 'Turista' : 'Turistas'}`,
       totalTourists: reservation.totalTourists,
+      travelerBreakdown: reservation.travelerBreakdown,
       duration: `${reservation.slotTimeStart} - ${reservation.slotTimeEnd}`,
       // PROVIDER: sigue viendo el providerPrice como precio principal (TC-005 previo, PR #71).
       price: reservation.providerPrice != null ? `$${reservation.providerPrice.toFixed(2)}` : '',
@@ -693,6 +696,7 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
       customerPhone: reservation.payerPhone,
       travellers: `${reservation.totalTourists} ${reservation.totalTourists === 1 ? 'Turista' : 'Turistas'}`,
       totalTourists: reservation.totalTourists,
+      travelerBreakdown: reservation.travelerBreakdown,
       duration: `${reservation.slotTimeStart} - ${reservation.slotTimeEnd}`,
       // ADMIN/CLIENT: sigue viendo shoppingTotalPrice como precio principal.
       price: `$${(reservation.shoppingTotalPrice || 0).toFixed(2)}`,

--- a/src/app/shared/common/floating-cart/floating-cart.component.html
+++ b/src/app/shared/common/floating-cart/floating-cart.component.html
@@ -116,6 +116,13 @@
               {{ item.totalParticipants }} {{ 'cart.personSingularPlural' | translate }}
             </p>
 
+            <!-- TC-016 (#219): desglose por ageType leyendo item.participants (ya viene del backend en el carrito). -->
+            <p class="tour-card-breakdown fs-12 text-secondary mb-0 ms-4" *ngIf="item.participants?.length">
+              <ng-container *ngFor="let p of item.participants; let last = last">
+                {{ p.quantity }} {{ 'configuration.ageType.' + p.ageType | translate }}<span *ngIf="!last">, </span>
+              </ng-container>
+            </p>
+
             <!-- Precio -->
             <div class="tour-card-price">
               {{ formatPrice(item.totalPrice) }}

--- a/src/app/shared/models/reservation.model.ts
+++ b/src/app/shared/models/reservation.model.ts
@@ -73,6 +73,18 @@ export interface ClientReservation {
   providerName?: string;
   /** TC-005 refinamientos (#188): imagen principal del tour desde tour_gallery (primera por order_index). */
   tourImageUrl?: string;
+  /** TC-016 (#219): desglose de viajeros por ageType (ADULT/CHILD/INFANT). Puede ser [] para reservas historicas. */
+  travelerBreakdown?: TravelerBreakdown[];
+}
+
+/**
+ * TC-016 (#219): item del desglose de viajeros por ageType dentro de una reserva.
+ */
+export interface TravelerBreakdown {
+  ageType: string;
+  quantity: number;
+  unitPrice?: number;
+  providerUnitPrice?: number;
 }
 
 /**


### PR DESCRIPTION
## Contexto

TC-016 (#219) parte B — consume el nuevo campo `travelerBreakdown` que backend PR #225 (tourya-api) agregó a `ReservationDetailsResponse` (via SP `sp_get_provider_reservations` + `jsonb_agg` de `shopping_cart_item_detail`).

## Cambios

**DTOs:**
- \`ClientReservation.travelerBreakdown?: TravelerBreakdown[]\` (nueva interface exportada en \`reservation.model.ts\`).
- \`ProviderTourBooking.travelerBreakdown\` para propagar al modal.
- Ambos \`mapClientReservationToBooking*\` propagan \`reservation.travelerBreakdown\`.

**Templates:**
- \`provider-tour-management.html\` línea 323: bajo el \"N Turistas\", itera el breakdown como \"2 ADULTO, 1 NIÑO\" usando la key i18n existente \`configuration.ageType.{ADULT|CHILD|INFANT}\`.
- \`floating-cart.html\` línea 108: mismo patrón sobre \`item.participants\` (el DTO del carrito ya tenía el desglose local, esta era una gap de renderizado).

## Compatibilidad
- Sin el backend desplegado, el campo llega \`undefined\` → ambos bloques quedan ocultos por \`*ngIf\`/\`@if\`. Retrocompatible.

## Build
- \`ng build --configuration=production\` verde local ✅.

## Test plan
- [ ] Reserva con 2 ADULT + 1 CHILD → modal muestra \"3 Turistas\" y debajo \"2 ADULTO, 1 NIÑO\".
- [ ] Reserva solo ADULT → muestra solo \"2 ADULTO\" en línea de desglose.
- [ ] Reservas históricas sin \`shopping_cart_item_detail\` → línea de desglose oculta, sin cambios de layout.
- [ ] Floating cart: agregar tour individual con 2 ADULT + 1 INFANT → aparece desglose bajo participantes.
- [ ] Floating cart: tour tipo GRUPO → mantiene su render actual + desglose por ageType si aplica.