### PR TITLE
feat(TC-017 #220): flag HOTEL_PICKUP en editor + mensaje en detalle y modal reserva

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -328,6 +328,7 @@
       "itinerary": "Itinerary",
       "stopLabel": "Stop",
       "meetingPoint": "Meeting point",
+      "hotelPickup": "This tour picks up the customer at their hotel",
       "tourContactInfo": "Contact information (tour)",
       "reviewBtn": "Review",
       "alreadyReviewed": "Already reviewed",
@@ -642,8 +643,10 @@
         "options": {
           "meetingPoint": "Meeting Point",
           "endPoint": "End Point",
-          "pickUpPoint": "Pick Up Point"
+          "pickUpPoint": "Pick Up Point",
+          "hotelPickup": "Hotel Pickup"
         },
+        "hotelPickupHint": "This tour picks up the customer at their hotel. No physical tour location required.",
         "errors": {
           "required": "Address type is required"
         }
@@ -925,7 +928,8 @@
       "tourName": "Tour Name",
       "details": "Details",
       "selectTravelers": "Select travelers",
-      "meetingPoint": "Meeting Point"
+      "meetingPoint": "Meeting Point",
+      "hotelPickup": "We pick you up at your hotel"
     },
     "enquiry": {
       "title": "Enquire Us",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -329,6 +329,7 @@
       "itinerary": "Itinerario",
       "stopLabel": "Parada",
       "meetingPoint": "Punto de encuentro",
+      "hotelPickup": "Este tour recoge al cliente en su hotel",
       "tourContactInfo": "Información de contacto (tour)",
       "reviewBtn": "Reseñar",
       "alreadyReviewed": "Ya hice la reseña",
@@ -643,8 +644,10 @@
         "options": {
           "meetingPoint": "Punto de Encuentro",
           "endPoint": "Punto Final",
-          "pickUpPoint": "Punto de Recogida"
+          "pickUpPoint": "Punto de Recogida",
+          "hotelPickup": "Recogida en el hotel"
         },
+        "hotelPickupHint": "Este tour recoge al cliente en su hotel. No requiere ubicación física del tour.",
         "errors": {
           "required": "El tipo de dirección es requerido"
         }
@@ -926,7 +929,8 @@
       "tourName": "Nombre del tour",
       "details": "Detalle",
       "selectTravelers": "Seleccionar viajeros",
-      "meetingPoint": "Punto de encuentro"
+      "meetingPoint": "Punto de encuentro",
+      "hotelPickup": "Te recogemos en tu hotel"
     },
     "enquiry": {
       "title": "Contáctenos",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -328,6 +328,7 @@
       "itinerary": "Itinerário",
       "stopLabel": "Parada",
       "meetingPoint": "Ponto de encontro",
+      "hotelPickup": "Este tour busca o cliente no seu hotel",
       "tourContactInfo": "Informações de contato (passeio)",
       "reviewBtn": "Avaliar",
       "alreadyReviewed": "Já fiz a avaliação",
@@ -642,8 +643,10 @@
         "options": {
           "meetingPoint": "Ponto de Encontro",
           "endPoint": "Ponto Final",
-          "pickUpPoint": "Ponto de Coleta"
+          "pickUpPoint": "Ponto de Coleta",
+          "hotelPickup": "Coleta no hotel"
         },
+        "hotelPickupHint": "Este tour busca o cliente no seu hotel. Não requer localização física do tour.",
         "errors": {
           "required": "O tipo de endereço é obrigatório"
         }
@@ -926,7 +929,8 @@
       "tourName": "Nome do passeio",
       "details": "Detalhe",
       "selectTravelers": "Selecionar viajantes",
-      "meetingPoint": "Ponto de encontro"
+      "meetingPoint": "Ponto de encontro",
+      "hotelPickup": "Buscamos você no seu hotel"
     },
     "enquiry": {
       "title": "Contate-nos",

--- a/src/app/pages/clients/tours-detail/tours-detail.component.html
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.html
@@ -178,19 +178,28 @@
                         </div>
                         <!-- /Map -->
                         <!-- TC-016 (#219): mostrar tambien nombre location + pais + ciudad debajo del mapa, no solo la direccion textual. -->
+                        <!-- TC-017 (#220): si es HOTEL_PICKUP, mostrar mensaje en vez de ubicacion fisica. -->
                         <div class="mt-3" *ngIf="tour?.locations?.length">
                             <h6 class="fs-16 mb-2"><i class="isax isax-location me-1"></i>{{ 'tours-detail.booking.meetingPoint' | translate }}</h6>
                             <div class="mb-2" *ngFor="let loc of tour.locations">
-                                <p class="mb-1 fw-medium" *ngIf="loc.location">
-                                    <i class="isax isax-location5 text-primary me-2"></i>{{ (loc.location | localizedName) || loc.location }}
-                                </p>
-                                <p class="mb-1 text-gray-6" *ngIf="loc.address">
-                                    <i class="isax isax-map me-2"></i>{{ loc.address }}
-                                </p>
-                                <p class="mb-0 text-gray-6 fs-14" *ngIf="loc.cityName || loc.stateName || loc.countryName">
-                                    <i class="isax isax-global me-2"></i>
-                                    <ng-container *ngIf="loc.cityName">{{ loc.cityName }}</ng-container><ng-container *ngIf="loc.cityName && (loc.stateName || loc.countryName)">, </ng-container><ng-container *ngIf="loc.stateName">{{ loc.stateName }}</ng-container><ng-container *ngIf="loc.stateName && loc.countryName">, </ng-container><ng-container *ngIf="loc.countryName">{{ loc.countryName }}</ng-container>
-                                </p>
+                                <ng-container *ngIf="loc.addressType === 'Hotel Pickup'; else physicalLoc">
+                                    <div class="alert alert-info d-flex align-items-center mb-0" role="alert">
+                                        <i class="isax isax-building me-2 fs-18"></i>
+                                        <span class="fw-medium">{{ 'tours-detail.booking.hotelPickup' | translate }}</span>
+                                    </div>
+                                </ng-container>
+                                <ng-template #physicalLoc>
+                                    <p class="mb-1 fw-medium" *ngIf="loc.location">
+                                        <i class="isax isax-location5 text-primary me-2"></i>{{ (loc.location | localizedName) || loc.location }}
+                                    </p>
+                                    <p class="mb-1 text-gray-6" *ngIf="loc.address">
+                                        <i class="isax isax-map me-2"></i>{{ loc.address }}
+                                    </p>
+                                    <p class="mb-0 text-gray-6 fs-14" *ngIf="loc.cityName || loc.stateName || loc.countryName">
+                                        <i class="isax isax-global me-2"></i>
+                                        <ng-container *ngIf="loc.cityName">{{ loc.cityName }}</ng-container><ng-container *ngIf="loc.cityName && (loc.stateName || loc.countryName)">, </ng-container><ng-container *ngIf="loc.stateName">{{ loc.stateName }}</ng-container><ng-container *ngIf="loc.stateName && loc.countryName">, </ng-container><ng-container *ngIf="loc.countryName">{{ loc.countryName }}</ng-container>
+                                    </p>
+                                </ng-template>
                             </div>
                         </div>
                     </div>

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
@@ -497,29 +497,37 @@
                                 <h6 class="mb-3">{{ 'provider-tour-management.modal.meetingPoint' | translate }}</h6>
                                 @for (loc of selectedBooking.tourDetails.locations; track loc.id) {
                                     <div class="mb-3">
-                                        <!-- TC-016 (#219): nombre location + address + ciudad/estado/pais -->
-                                        @if (loc.location) {
-                                            <p class="fs-15 fw-semibold text-dark mb-1">
-                                                <i class="isax isax-location5 text-primary me-2"></i>{{ (loc.location | localizedName) || loc.location }}
-                                            </p>
-                                        }
-                                        @if (loc.address) {
-                                            <p class="fs-14 text-dark mb-1">
-                                                <i class="isax isax-map me-2 text-gray-6"></i>{{ loc.address }}
-                                            </p>
-                                        }
-                                        @if (loc.cityName || loc.stateName || loc.countryName) {
-                                            <p class="fs-13 text-gray-6 mb-2">
-                                                <i class="isax isax-global me-2"></i>
-                                                @if (loc.cityName) { {{ loc.cityName }} }@if (loc.cityName && (loc.stateName || loc.countryName)) {, }@if (loc.stateName) { {{ loc.stateName }} }@if (loc.stateName && loc.countryName) {, }@if (loc.countryName) { {{ loc.countryName }} }
-                                            </p>
-                                        }
-                                        @if (loc.latitude && loc.longitude) {
-                                            <google-map height="280px" width="100%"
-                                                [center]="{lat: loc.latitude, lng: loc.longitude}"
-                                                [zoom]="15" class="w-100 rounded">
-                                                <map-marker [position]="{lat: loc.latitude, lng: loc.longitude}"></map-marker>
-                                            </google-map>
+                                        <!-- TC-017 (#220): si es HOTEL_PICKUP, mensaje en vez de ubicacion fisica + mapa. -->
+                                        @if (loc.addressType === 'Hotel Pickup') {
+                                            <div class="alert alert-info d-flex align-items-center mb-0" role="alert">
+                                                <i class="isax isax-building me-2 fs-18"></i>
+                                                <span class="fw-medium">{{ 'provider-tour-management.modal.hotelPickup' | translate }}</span>
+                                            </div>
+                                        } @else {
+                                            <!-- TC-016 (#219): nombre location + address + ciudad/estado/pais -->
+                                            @if (loc.location) {
+                                                <p class="fs-15 fw-semibold text-dark mb-1">
+                                                    <i class="isax isax-location5 text-primary me-2"></i>{{ (loc.location | localizedName) || loc.location }}
+                                                </p>
+                                            }
+                                            @if (loc.address) {
+                                                <p class="fs-14 text-dark mb-1">
+                                                    <i class="isax isax-map me-2 text-gray-6"></i>{{ loc.address }}
+                                                </p>
+                                            }
+                                            @if (loc.cityName || loc.stateName || loc.countryName) {
+                                                <p class="fs-13 text-gray-6 mb-2">
+                                                    <i class="isax isax-global me-2"></i>
+                                                    @if (loc.cityName) { {{ loc.cityName }} }@if (loc.cityName && (loc.stateName || loc.countryName)) {, }@if (loc.stateName) { {{ loc.stateName }} }@if (loc.stateName && loc.countryName) {, }@if (loc.countryName) { {{ loc.countryName }} }
+                                                </p>
+                                            }
+                                            @if (loc.latitude && loc.longitude) {
+                                                <google-map height="280px" width="100%"
+                                                    [center]="{lat: loc.latitude, lng: loc.longitude}"
+                                                    [zoom]="15" class="w-100 rounded">
+                                                    <map-marker [position]="{lat: loc.latitude, lng: loc.longitude}"></map-marker>
+                                                </google-map>
+                                            }
                                         }
                                     </div>
                                 }

--- a/src/app/pages/providers/tours/add-tour/add-tour.component.html
+++ b/src/app/pages/providers/tours/add-tour/add-tour.component.html
@@ -273,11 +273,18 @@
                                                 <label class="form-label">{{ 'tour-form.fields.typeOfAddress.label' | translate }}</label>
 
                                                 <mat-select class="custom-mat-select select" placeholder="{{ 'tour-form.fields.typeOfAddress.placeholder' | translate }}"
-                                                    formControlName="typeOfAddress">
+                                                    formControlName="typeOfAddress"
+                                                    (valueChange)="onTypeOfAddressChange(i)">
                                                     <mat-option
                                                         [disabled]="typeOfAddressIsSelected(TypeOfAddress.MEETING_POINT, i)"
                                                         [value]="TypeOfAddress.MEETING_POINT">
                                                         {{ 'tour-form.fields.typeOfAddress.options.meetingPoint' | translate }}
+                                                    </mat-option>
+                                                    <!-- TC-017 (#220): recogida en el hotel del cliente (sin ubicacion fisica). -->
+                                                    <mat-option
+                                                        [disabled]="typeOfAddressIsSelected(TypeOfAddress.HOTEL_PICKUP, i)"
+                                                        [value]="TypeOfAddress.HOTEL_PICKUP">
+                                                        {{ 'tour-form.fields.typeOfAddress.options.hotelPickup' | translate }}
                                                     </mat-option>
                                                 </mat-select>
 
@@ -292,7 +299,17 @@
                                         </div>
 
 
-                                        <div class="col-xl-3 col-md-6">
+                                        <!-- TC-017 (#220): campos de ubicacion fisica ocultos cuando el tipo es HOTEL_PICKUP. -->
+                                        <ng-container *ngIf="isHotelPickup(i)">
+                                            <div class="col-md-12">
+                                                <div class="alert alert-info d-flex align-items-center mb-3" role="alert">
+                                                    <i class="isax isax-info-circle me-2"></i>
+                                                    <span>{{ 'tour-form.fields.typeOfAddress.hotelPickupHint' | translate }}</span>
+                                                </div>
+                                            </div>
+                                        </ng-container>
+
+                                        <div class="col-xl-3 col-md-6" *ngIf="!isHotelPickup(i)">
                                             <div class="mb-3">
                                                 <label class="form-label">{{ 'tour-form.fields.country.label' | translate }}</label>
                                                 <mat-select class="custom-mat-select select" placeholder="{{ 'tour-form.fields.country.placeholder' | translate }}"
@@ -311,7 +328,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="col-xl-3 col-md-6">
+                                        <div class="col-xl-3 col-md-6" *ngIf="!isHotelPickup(i)">
                                             <div class="mb-3">
                                                 <label class="form-label">{{ 'tour-form.fields.department.label' | translate }}</label>
                                                 <mat-select class="custom-mat-select select" placeholder="{{ 'tour-form.fields.department.placeholder' | translate }}"
@@ -329,7 +346,7 @@
                                                 </div>
                                             </div>
                                         </div>
-                                        <div class="col-xl-3 col-md-6">
+                                        <div class="col-xl-3 col-md-6" *ngIf="!isHotelPickup(i)">
                                             <div class="mb-3">
                                                 <div class="mb-3">
                                                     <label class="form-label">{{ 'tour-form.fields.city.label' | translate }}</label>
@@ -348,7 +365,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="col-md-12">
+                                        <div class="col-md-12" *ngIf="!isHotelPickup(i)">
                                             <div class="mb-3">
                                                 <label class="form-label">{{ 'tour-form.fields.location.label' | translate }}</label>
                                                 <input #addressInput type="text" formControlName="location"
@@ -367,7 +384,7 @@
                                             </div>
                                         </div>
 
-                                        <div class="col-md-12">
+                                        <div class="col-md-12" *ngIf="!isHotelPickup(i)">
                                             <div class="mb-3">
                                                 <label class="form-label">{{ 'tour-form.fields.address.label' | translate }}</label>
                                                 <textarea class="form-control" minlength="2" maxlength="50"
@@ -399,8 +416,10 @@
                                     </div>
                                 </ng-container>
 
+                                <!-- TC-017 (#220): oculto tambien cuando ya existe una location HOTEL_PICKUP
+                                     (no tiene sentido combinar ubicaciones fisicas con recogida en hotel). -->
                                 <div class="mt-3">
-                                    <a *ngIf="locations.length < 3" href="javascript:void(0);"
+                                    <a *ngIf="locations.length < 3 && !hasHotelPickupLocation()" href="javascript:void(0);"
                                         class="btn btn-primary btn-sm add-highlight" (click)="addLocation()">
                                         <i class="isax isax-add-circle me-1"></i>
                                         {{ 'tour-form.buttons.addNew' | translate }}

--- a/src/app/pages/providers/tours/add-tour/add-tour.component.ts
+++ b/src/app/pages/providers/tours/add-tour/add-tour.component.ts
@@ -599,6 +599,43 @@ export class AddTourComponent {
     this.locations.markAsDirty();
   }
 
+  // TC-017 (#220): HOTEL_PICKUP no tiene ubicacion fisica — el frontend limpia
+  // valores + validators de country/state/city/lat/long/address/location cuando
+  // el provider selecciona ese tipo, para que la validacion del form no lo bloquee.
+  isHotelPickup(index: number): boolean {
+    return this.locations.at(index)?.get('typeOfAddress')?.value === TypeOfAddress.HOTEL_PICKUP;
+  }
+
+  hasHotelPickupLocation(): boolean {
+    return this.locations.controls.some(l => l.get('typeOfAddress')?.value === TypeOfAddress.HOTEL_PICKUP);
+  }
+
+  onTypeOfAddressChange(index: number): void {
+    const loc = this.locations.at(index);
+    if (!loc) return;
+    const physicalFields = ['country', 'department', 'city', 'location', 'latitude', 'longitude', 'address'];
+    if (loc.get('typeOfAddress')?.value === TypeOfAddress.HOTEL_PICKUP) {
+      physicalFields.forEach(f => {
+        const ctrl = loc.get(f);
+        if (ctrl) {
+          ctrl.clearValidators();
+          ctrl.setValue(null, { emitEvent: false });
+          ctrl.updateValueAndValidity({ emitEvent: false });
+        }
+      });
+    } else {
+      // Restaurar validators cuando el provider cambia de HOTEL_PICKUP a otro tipo.
+      loc.get('country')?.setValidators([Validators.required]);
+      loc.get('department')?.setValidators([Validators.required]);
+      loc.get('city')?.setValidators([Validators.required]);
+      loc.get('location')?.setValidators([Validators.required]);
+      loc.get('latitude')?.setValidators([Validators.required, Validators.pattern("^-?([0-8]?[0-9]|90)(.[0-9]{1,10})$")]);
+      loc.get('longitude')?.setValidators([Validators.required, Validators.pattern("^-?(?:180(?:\\.0+)?|(?:1[0-7]\\d|\\d{1,2})(?:\\.\\d+)?)$")]);
+      loc.get('address')?.setValidators([Validators.required, Validators.minLength(3), Validators.maxLength(50)]);
+      physicalFields.forEach(f => loc.get(f)?.updateValueAndValidity({ emitEvent: false }));
+    }
+  }
+
   get mainAttractions(): FormArray {
     return this.tourForm.get("mainAttractions") as FormArray;
   }
@@ -867,14 +904,18 @@ export class AddTourComponent {
         address,
       } = location;
 
+      // TC-017 (#220): HOTEL_PICKUP no tiene ubicacion fisica — enviar null en country/state/city,
+      // 0 en lat/long (backend acepta null tras PR api #226).
+      const isHotelPickup = typeOfAddress === TypeOfAddress.HOTEL_PICKUP;
+
       return {
-        countryId: +country,
-        stateId: +department,
-        cityId: +city,
-        latitude: +latitude,
-        longitude: +longitude,
-        address,
-        location: this.i18nService.createI18nField(location.location),
+        countryId: isHotelPickup ? null : +country,
+        stateId: isHotelPickup ? null : +department,
+        cityId: isHotelPickup ? null : +city,
+        latitude: isHotelPickup ? 0 : +latitude,
+        longitude: isHotelPickup ? 0 : +longitude,
+        address: isHotelPickup ? null : address,
+        location: isHotelPickup ? null : this.i18nService.createI18nField(location.location),
         addressType: typeOfAddress,
       };
     });
@@ -1118,6 +1159,9 @@ export class AddTourComponent {
               longitude: location.longitude,
               address: location.address,
             });
+            // TC-017 (#220): en carga de tour existente, ajustar validators si es HOTEL_PICKUP
+            // para no bloquear el submit del provider al editar.
+            this.onTypeOfAddressChange(index);
           });
 
           this.tour?.mainAttractions?.map((mainAttraction, index) => {

--- a/src/app/shared/enums/type-of-address.enum.ts
+++ b/src/app/shared/enums/type-of-address.enum.ts
@@ -2,4 +2,6 @@ export enum TypeOfAddress {
   MEETING_POINT = "Meeting Point",
   END_POINT = "End Point",
   PICK_UP_POINT = "Pick-up Point",
+  // TC-017 (#220): recogida en el hotel del cliente. Sin ubicacion fisica del tour.
+  HOTEL_PICKUP = "Hotel Pickup",
 }


### PR DESCRIPTION
## Contexto

TC-017 (#220) — un tour puede recoger al cliente en su hotel (sin ubicación física del tour). Consume el nuevo valor \`HOTEL_PICKUP\` que backend PR #226 (tourya-api) agregó a \`AddressTypeEnum\` + relajo de \`@NotNull\` en country/state/city.

## Cambios frontend

**Enum:**
- \`type-of-address.enum.ts\`: agrega \`HOTEL_PICKUP = \"Hotel Pickup\"\`.

**Editor provider (add-tour):**
- Nueva opción \`Recogida en el hotel\` en el \`mat-select typeOfAddress\`.
- Cuando el provider la selecciona: se ocultan controles country/state/city/location/lat/long/address y se limpian sus validators (para que el submit no falle).
- Se muestra alert-info explicando \"Este tour recoge al cliente en su hotel. No requiere ubicación física del tour.\"
- Botón \"Agregar nuevo\" oculto cuando ya existe una location \`HOTEL_PICKUP\` (no tiene sentido combinar).
- Al editar tour existente con \`HOTEL_PICKUP\`, los validators se ajustan en el \`patchValue\`.
- Submit map: envía \`null\` en country/state/city/address/location, \`0\` en lat/long cuando aplica.

**Vistas de solo lectura:**
- \`tours-detail.component.html\`: si \`loc.addressType === 'Hotel Pickup'\` → muestra alert-info 🏨 \"Te recogemos en tu hotel\" en vez del bloque de ubicación física.
- \`provider-tour-management.component.html\` (modal reserva, sección Punto de encuentro): mismo mensaje + no renderiza mapa/dirección/nombre.

**i18n en 3 idiomas (es/en/pt):**
- \`tour-form.fields.typeOfAddress.options.hotelPickup\`
- \`tour-form.fields.typeOfAddress.hotelPickupHint\`
- \`tours-detail.booking.hotelPickup\`
- \`provider-tour-management.modal.hotelPickup\`

## Build
- \`ng build --configuration=production\` verde local ✅.

## Test plan
- [ ] Como PROVIDER: crear tour nuevo → seleccionar \"Recogida en el hotel\" en Tipo de Dirección → los campos país/estado/ciudad/ubicación/dirección desaparecen → aparece alert azul → botón \"Agregar nuevo\" desaparece → guardar tour → sin error.
- [ ] Editar el mismo tour → \"Recogida en el hotel\" aparece preseleccionada, campos ocultos, alert visible, guardar sin error.
- [ ] Cambiar de \"Recogida en el hotel\" a \"Punto de Encuentro\" → campos aparecen de nuevo con validators required → botón \"Agregar nuevo\" reaparece.
- [ ] Como CLIENT: entrar al detalle de un tour con \`HOTEL_PICKUP\` → sección \"Ubicación\" muestra el alert azul en vez del mapa/dirección.
- [ ] Como PROVIDER: modal detalle de reserva de un tour \`HOTEL_PICKUP\` → sección \"Punto de encuentro\" muestra alert azul.
- [ ] Tour con locations mixtas (MEETING_POINT + otro tipo, sin HOTEL_PICKUP) → mantiene render actual (retrocompatible).