### PR TITLE
feat(TC-018 #227 Bug B UI): modal deshabilita dias bajo alerta DIMAR RED

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1318,6 +1318,8 @@
   "tourSlotModal": {
     "title": "Select Schedule and Participants",
     "available": "Available:",
+    "blockedByMaritime": "Not available: active DIMAR alert for maritime conditions",
+    "blockedShort": "Blocked (DIMAR)",
     "availableSchedules": "Available Schedules",
     "selectSchedule": "Select your preferred schedule",
     "groupsAvailable": "groups available",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1319,6 +1319,8 @@
   "tourSlotModal": {
     "title": "Seleccionar Horario y Participantes",
     "available": "Disponibles:",
+    "blockedByMaritime": "No disponible: alerta DIMAR vigente por condiciones marítimas",
+    "blockedShort": "Bloqueado DIMAR",
     "availableSchedules": "Horarios Disponibles",
     "selectSchedule": "Selecciona el horario que prefieras",
     "groupsAvailable": "grupos disponibles",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1162,6 +1162,8 @@
   "tourSlotModal": {
     "title": "Selecionar Horário e Participantes",
     "available": "Disponível:",
+    "blockedByMaritime": "Não disponível: alerta DIMAR ativo por condições marítimas",
+    "blockedShort": "Bloqueado (DIMAR)",
     "availableSchedules": "Horários Disponíveis",
     "selectSchedule": "Selecione o horário da sua preferência",
     "groupsAvailable": "grupos disponíveis",

--- a/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.html
+++ b/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.html
@@ -43,14 +43,26 @@
         </div>
 
         <!-- Date Carousel -->
+        <!-- TC-018 (#227) Bug B: dias bajo alerta DIMAR RED aparecen con clase 'blocked' y tooltip. -->
         <div class="date-carousel">
           <owl-carousel-o [options]="customOptions">
             <ng-template *ngFor="let date of dates" carouselSlide>
-              <div class="date-item d-flex flex-column align-items-center justify-content-center" [ngClass]="{'selected': selectedDate === date}" (click)="selectDate(date)">
+              <div class="date-item d-flex flex-column align-items-center justify-content-center"
+                   [ngClass]="{'selected': selectedDate === date, 'blocked': isDayBlockedByMaritime(date)}"
+                   [style.opacity]="isDayBlockedByMaritime(date) ? 0.45 : 1"
+                   [style.cursor]="isDayBlockedByMaritime(date) ? 'not-allowed' : 'pointer'"
+                   [attr.title]="isDayBlockedByMaritime(date) ? ('tourSlotModal.blockedByMaritime' | translate) : null"
+                   (click)="selectDate(date)">
                 <span class="text text-center mb-1 m-0" style="line-height: 1;">{{date | date: 'dd/MM/yyyy'}}</span>
-                <span class="text-center w-100 m-0" 
-                      [ngClass]="{'text-danger font-weight-bold': hasCapacityError(date)}" 
+                <span class="text-center w-100 m-0"
+                      *ngIf="!isDayBlockedByMaritime(date)"
+                      [ngClass]="{'text-danger font-weight-bold': hasCapacityError(date)}"
                       style="font-size: 0.75rem; opacity: 0.85; line-height: 1; transition: color 0.3s;">{{ 'tourSlotModal.available' | translate }} {{ getDayAvailability(date) }}</span>
+                <span class="text-center w-100 m-0 text-danger"
+                      *ngIf="isDayBlockedByMaritime(date)"
+                      style="font-size: 0.7rem; line-height: 1;">
+                  <i class="isax isax-warning-2 me-1"></i>{{ 'tourSlotModal.blockedShort' | translate }}
+                </span>
               </div>
             </ng-template>
           </owl-carousel-o>

--- a/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.ts
+++ b/src/app/shared/common/tour-slot-selection-modal/tour-slot-selection-modal.component.ts
@@ -1218,7 +1218,25 @@ export class TourSlotSelectionModalComponent implements OnInit, AfterViewInit {
     return this.dateErrors.has(dayjs(date).format('YYYY-MM-DD'));
   }
 
+  /**
+   * TC-018 (#227) Bug B: true si el schedule del dia tiene el flag blockedByMaritimeReport.
+   * El backend lo calcula via EXISTS contra maritim_activity_report (flag=RED activo).
+   */
+  isDayBlockedByMaritime(date: Date): boolean {
+    if (!this.selectedTour?.schedules?.length) return false;
+    const dateStr = dayjs(date).format('YYYY-MM-DD');
+    const schedule = this.selectedTour.schedules.find(
+      s => dayjs(s.scheduleDate).format('YYYY-MM-DD') === dateStr
+    );
+    return schedule?.blockedByMaritimeReport === true;
+  }
+
   selectDate(date: Date) {
+    // TC-018 (#227) Bug B: silenciosamente no permitir seleccionar dias bajo alerta DIMAR RED.
+    // El HTML tambien pinta el dia como disabled — este guard es defensa.
+    if (this.isDayBlockedByMaritime(date)) {
+      return;
+    }
     if (!this.canSelectDate(date)) {
       const dateStr = dayjs(date).format('YYYY-MM-DD');
       this.dateErrors.add(dateStr);

--- a/src/app/shared/dto/search-tour-response.dto.ts
+++ b/src/app/shared/dto/search-tour-response.dto.ts
@@ -37,6 +37,8 @@ export interface ScheduleDto {
   isUnlimitedCapacity: boolean;
   status: string;
   availability?: number;
+  /** TC-018 (#227) Bug B: true si hay alerta DIMAR RED activa (subcat+ubic+rango fechas) para este dia. */
+  blockedByMaritimeReport?: boolean;
   config?: ConfigDto;
 }
 export interface TourDto {

--- a/src/app/shared/dto/tour-schedule.response.dto.ts
+++ b/src/app/shared/dto/tour-schedule.response.dto.ts
@@ -33,7 +33,9 @@ export interface TourScheduleConfigResponseDto {
 
   "status": string,
   "configId": number,
-  "config": TourScheduleConfigDto
+  "config": TourScheduleConfigDto,
+  /** TC-018 (#227) Bug B: true si hay alerta DIMAR RED activa para este dia. */
+  "blockedByMaritimeReport"?: boolean
 }
 export interface TourScheduleConfigDto {
   "id": number,


### PR DESCRIPTION
## Contexto

Bug B del TC-018 (#227) — UI del modal de selección de fecha/slot. Consume el flag \`blockedByMaritimeReport\` del backend PR #230 (que expuso el campo en \`sp_get_tour_schedule_json\` y agregó guard duro en \`ShoppingCartService.addItemToCart\`).

## Cambios

**DTOs:**
- \`ScheduleDto.blockedByMaritimeReport?: boolean\` (\`search-tour-response.dto.ts\` — la interface real que usa el componente).
- \`TourScheduleConfigResponseDto.blockedByMaritimeReport?: boolean\` (por consistencia).

**Componente TS:**
- Nuevo helper \`isDayBlockedByMaritime(date)\`: busca el schedule del día y lee el flag.
- \`selectDate\`: guard silencioso que retorna sin acción si el día está bloqueado (defense-in-depth — el HTML también lo pinta disabled).

**HTML:**
- Cada \`date-item\` del carousel:
  - Aplica clase \`'blocked'\` + \`opacity: 0.45\` + \`cursor: not-allowed\` + \`title\` tooltip cuando el día está bloqueado.
  - En vez del texto \"Disponibles: N\" muestra \"⚠ Bloqueado DIMAR\" en rojo.

**i18n en 3 idiomas (es/en/pt):**
- \`tourSlotModal.blockedByMaritime\` (tooltip largo)
- \`tourSlotModal.blockedShort\` (texto corto en la card del día)

## Build
- \`ng build --configuration=production\` verde local ✅.

## Test plan
- [ ] Backend ya desplegado (PR api #230). Como CLIENT abrir modal de selección de tour cuya subcategoría tenga reporte DIMAR RED activo en algún día del rango:
  - Los días afectados aparecen con **opacity reducida** + cursor not-allowed + tooltip "No disponible: alerta DIMAR vigente..." + texto rojo "⚠ Bloqueado DIMAR" en lugar de la disponibilidad.
  - Click en día bloqueado → no hace nada (no cambia selection).
- [ ] Días fuera del rango del reporte → mantienen render normal.
- [ ] Otro tour de otra subcategoría en misma ciudad y fecha → todos los días normales.
- [ ] Si el backend rechaza el add-to-cart (bypass del UI), el mensaje "Tour no disponible en la fecha X: alerta DIMAR RED..." debe aparecer.

## Estado TC-018
- Backend Bug A (hook fix) — PR api #229 ✅
- Backend Bug B (feature) — PR api #230 ✅
- **Frontend Bug B (UI)** — este PR ⏳