### PR TITLE
fix(TC-016 #219 B): render desglose viajeros en 4 vistas

### DIFF
--- a/src/app/pages/clients/tour-booking-confirmation/tour-booking-confirmation.component.html
+++ b/src/app/pages/clients/tour-booking-confirmation/tour-booking-confirmation.component.html
@@ -197,6 +197,12 @@
                       <div>
                         <small class="text-muted d-block">{{ 'tourBookingSuccess.details.travellers' | translate }}</small>
                         <span class="fw-medium">{{ currentReservation.travellers }}</span>
+                        <!-- TC-016 (#219): desglose por ageType usando priceBreakdown que ya viene del backend. -->
+                        <span class="d-block fs-13 text-gray-6" *ngIf="currentReservation.priceBreakdown?.length">
+                          <ng-container *ngFor="let p of currentReservation.priceBreakdown; let last = last">
+                            {{ p.quantity }} {{ ('tour-schedule.prices.ageType.' + (p.ageType?.name || p.ageType)) | translate }}<span *ngIf="!last">, </span>
+                          </ng-container>
+                        </span>
                       </div>
                     </div>
                   </div>

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
@@ -327,7 +327,7 @@
                                     @if (selectedBooking.travelerBreakdown?.length) {
                                         <p class="fs-13 text-gray-6 mb-0">
                                             @for (t of selectedBooking.travelerBreakdown; track t.ageType; let last = $last) {
-                                                <span>{{ t.quantity }} {{ 'configuration.ageType.' + t.ageType | translate }}</span>@if (!last) {<span>, </span>}
+                                                <span>{{ t.quantity }} {{ 'tour-schedule.prices.ageType.' + t.ageType | translate }}</span>@if (!last) {<span>, </span>}
                                             }
                                         </p>
                                     }

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -444,6 +444,9 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
       customerEmail: reservation.serviceResponsibleEmail || 'N/A',
       customerPhone: reservation.serviceResponsiblePhone || 'N/A',
       travellers: reservation.totalTourists != null ? `${reservation.totalTourists}` : 'N/A',
+      // TC-016 (#219): propagar tambien aqui — este mapper se usa cuando el modal se abre
+      // desde QR/detalle. Antes se olvido y el modal mostraba solo "Viajeros: 2" sin desglose.
+      travelerBreakdown: reservation.travelerBreakdown,
       duration: reservation.duration ? `${reservation.duration} días` : 'N/A',
       // TC-005: PROVIDER puro ve el neto que recibe (providerPrice del SP); ADMIN/BACKOFFICE/CLIENT ven el precio que paga el cliente.
       price: this.pickBookingPriceForRole(reservation),

--- a/src/app/shared/common/floating-cart/floating-cart.component.html
+++ b/src/app/shared/common/floating-cart/floating-cart.component.html
@@ -119,7 +119,7 @@
             <!-- TC-016 (#219): desglose por ageType leyendo item.participants (ya viene del backend en el carrito). -->
             <p class="tour-card-breakdown fs-12 text-secondary mb-0 ms-4" *ngIf="item.participants?.length">
               <ng-container *ngFor="let p of item.participants; let last = last">
-                {{ p.quantity }} {{ 'configuration.ageType.' + p.ageType | translate }}<span *ngIf="!last">, </span>
+                {{ p.quantity }} {{ 'tour-schedule.prices.ageType.' + p.ageType | translate }}<span *ngIf="!last">, </span>
               </ng-container>
             </p>
 


### PR DESCRIPTION
## Contexto

Luis reportó tras validar PR #99 (comentario en #219) que el desglose por ageType **se muestra mal** en 4 vistas:

1. **Carrito de compra** — literalmente muestra \`configuration.ageType.ADULT\` (i18n key sin traducir).
2. **\`/clients/tour-booking-confirmation\`** — no muestra el desglose, solo \"N personas\".
3. **Modal ADMIN** — solo \"Viajeros: 2\" sin desglose.
4. **Modal PROVIDER** — igual que ADMIN.

## Root causes (todos ortogonales)

### Bug 1 + 2 (i18n key path incorrecto)
Yo puse en PR #99 el path \`configuration.ageType.\` pero la key correcta es \`tour-schedule.prices.ageType.{ADULT|CHILD|INFANT}\`. El auditor previo describió mal el path y no verifiqué.

### Bug 3 (modal ADMIN/PROVIDER)
El componente \`provider-tour-management\` tiene 3 mappers distintos:
- \`mapProviderReservationToBooking\` (línea 615) ✅ propagaba \`travelerBreakdown\`.
- \`mapClientReservationToBooking\` (línea 679) ✅ propagaba.
- **\`mapReservationToBooking\` (línea 406)** ❌ **NO propagaba** — se me olvidó. Este mapper se usa cuando el modal se abre por flow QR/detalle (línea 272).

### Bug 4 (tour-booking-confirmation)
El HTML mostraba solo \`{{ currentReservation.travellers }}\` (string plano \"N personas\"). El DTO \`ReservationDto\` ya tenía \`priceBreakdown: Array<{ageType, quantity, ...}>\` populado por el backend — solo faltaba iterarlo debajo.

## Cambios

**4 archivos, +12/-2:**
- \`floating-cart.component.html\`: fix path i18n.
- \`provider-tour-management.component.html\`: fix path i18n.
- \`provider-tour-management.component.ts\` línea 446: propagar \`travelerBreakdown\` en el 3er mapper.
- \`tour-booking-confirmation.component.html\` línea 199: nuevo \`<span>\` con iteración de \`priceBreakdown\` debajo de \`travellers\`.

## Verificación (con reservas 327/328 en dev)

- BD dev confirma que ambas reservas tienen \`shopping_cart_item_detail\` (1 row cada una).
- SP \`sp_get_provider_reservations\` devuelve el desglose correcto: \`[{ageType: \"ADULT\", quantity: 2, ...}]\`.
- Path i18n \`tour-schedule.prices.ageType.ADULT\` = \"ADULTO\" ✅ existe en es.json línea 1030.

## Build
- \`ng build --configuration=production\` verde local ✅.

## Test plan
- [ ] Deploy → carrito flotante debe mostrar \"2 ADULTO\" (no \"configuration.ageType.ADULT\").
- [ ] Modal ADMIN de una reserva con detail → \"Viajeros: 2\" + debajo \"2 ADULTO\".
- [ ] Modal PROVIDER igual.
- [ ] Modal via QR (deep link) → mismo desglose visible.
- [ ] Confirmación de reserva (\`/clients/tour-booking-confirmation\`) → debajo de \"Viajeros\" muestra \"2 ADULTO, 1 NIÑO\" (o lo que corresponda).