### PR TITLE
refactor(TC-015 #218): refinamiento lista admin tours + quitar hero-image detalle

### DIFF
--- a/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.html
+++ b/src/app/pages/admin/tour-admin/tour-admin-detail/tour-admin-detail.component.html
@@ -1,20 +1,4 @@
-<!-- Breadcrumb -->
-<div class="breadcrumb-bar breadcrumb-bg-02 text-center">
-  <div class="container">
-    <div class="row">
-      <div class="col-md-12 col-12">
-        <h2 class="breadcrumb-title mb-2">Detalle del Tour - Administración</h2>
-        <nav aria-label="breadcrumb">
-          <ol class="breadcrumb justify-content-center mb-0">
-            <li class="breadcrumb-item"><a routerLink="/admin/dashboard"><i class="isax isax-home5"></i></a></li>
-            <li class="breadcrumb-item"><a routerLink="/admin/dashboard">Tours</a></li>
-            <li class="breadcrumb-item active" aria-current="page">Detalle</li>
-          </ol>
-        </nav>
-      </div>
-    </div>
-  </div>
-</div>
+<!-- TC-015 refinamiento (#218): removido el breadcrumb-bar con hero image ("Detalle del Tour - Administración"). -->
 
 <!-- Page Wrapper -->
 <div class="content" *ngIf="!loading && tour">

--- a/src/app/pages/admin/tour-admin/tour-admin-list/tour-admin-list.component.html
+++ b/src/app/pages/admin/tour-admin/tour-admin-list/tour-admin-list.component.html
@@ -57,13 +57,13 @@
           <div *ngIf="!loading && tours.length > 0" class="table-responsive">
             <table class="table table-hover mb-0">
               <thead>
+                <!-- TC-015 refinamiento (#218): Categoria/Duracion/Capacidad reemplazadas por Subcategoria/Tipo precio. -->
                 <tr>
                   <th>ID</th>
                   <th>Nombre</th>
                   <th>Proveedor</th>
-                  <th>Categoría</th>
-                  <th>Duración</th>
-                  <th>Capacidad</th>
+                  <th>Subcategoría</th>
+                  <th>Tipo precio</th>
                   <th>Estado</th>
                   <th class="text-center">Acciones</th>
                 </tr>
@@ -89,10 +89,12 @@
                     </div>
                   </td>
                   <td>
-                    <span class="badge bg-light text-dark">{{ getCategoryName(tour.tourCategoryId) }}</span>
+                    <span class="badge bg-light text-dark">{{ tour.subCategory || '—' }}</span>
                   </td>
-                  <td>{{ tour.duration }}</td>
-                  <td>{{ tour.maxPeople }} personas</td>
+                  <td>
+                    <span *ngIf="tour.priceType === 'grupo'" class="badge bg-info-transparent text-info">Grupo ({{ tour.maxPeople }})</span>
+                    <span *ngIf="tour.priceType !== 'grupo'" class="badge bg-secondary-transparent text-secondary">{{ tour.priceType || 'Individual' }}</span>
+                  </td>
                   <td>
                     <span class="badge" [ngClass]="getStatusBadgeClass(tour.status)">
                       {{ getStatusLabel(tour.status) }}

--- a/src/app/shared/dto/tour-admin.dto.ts
+++ b/src/app/shared/dto/tour-admin.dto.ts
@@ -13,6 +13,9 @@ export interface TourAdminDto {
   rating: number | null;
   status: TourStatus;
   tourCategoryId: number;
+  // TC-015 refinamiento (#218): columnas adicionales en la lista Gestion de Tours (admin).
+  subCategory?: string;
+  priceType?: string;
   // opcionalmente puede venir el objeto de categoría embebido
   tourCategory?: TourCategoryDto;
   provider: ProviderDto;


### PR DESCRIPTION
## Contexto

Luis en el último comentario de #218 pidió 2 refinamientos:

1. **En `/admin/tours`**: reemplazar columnas Categoría/Duración/Capacidad por Subcategoría + Tipo precio.
2. **En `/admin/tour-admin/detail/:id`**: quitar el breadcrumb-bar con hero image (\"Detalle del Tour - Administración\").

## Cambios (3 archivos, chico)

**\`tour-admin.dto.ts\`**: agrega \`subCategory?: string\` + \`priceType?: string\` a \`TourAdminDto\`. Backend \`TourResponse\` YA los devuelve (verificado — tiene ambos enums exportados).

**\`tour-admin-list.component.html\`**: reemplaza 3 columnas por 2:
- ❌ Categoría, Duración, Capacidad
- ✅ Subcategoría (badge gris con el enum), Tipo precio (\"Grupo (N)\" para grupo, \"Individual\" default)

**\`tour-admin-detail.component.html\`**: elimina bloque \`<div class=\"breadcrumb-bar breadcrumb-bg-02\">\` (líneas 1-17). Sin cambios de layout adicionales.

## Build
- \`ng build --configuration=production\` verde local ✅.

## Test plan
- [ ] Deploy → ir a \`/admin/tours\` como ADMIN → tabla ahora tiene columnas: ID, Nombre, Proveedor, **Subcategoría**, **Tipo precio**, Estado, Acciones.
- [ ] Tour con \`priceType='grupo'\` → columna muestra \"Grupo (N)\" con N=maxPeople.
- [ ] Tour con \`priceType='individual'\` → columna muestra \"Individual\".
- [ ] Tour sin subCategory → muestra \"—\".
- [ ] Ir a \`/admin/tour-admin/detail/71\` → el hero-bar con placeholder 1920x251 debe desaparecer, la página arranca directo con los botones de acción.

## Estado tras este PR

Con esto quedan todos los items reportados por Luis atendidos:
- TC-015 refinamiento ✅ (este PR)
- TC-016 refinamiento ✅ (mergeado antes, PR #102)
- TC-017 hotfix guard null ✅ (mergeado, PR #228) — esperando body 400 de Luis por si necesita otro fix
- TC-018 backend + frontend ✅ (mergeados)