### PR TITLE
fix(TC-020 #235): docType real en Wompi + boton Ver Reservas + refresh profile

### DIFF
--- a/src/app/pages/clients/cart-summary/cart-summary.component.ts
+++ b/src/app/pages/clients/cart-summary/cart-summary.component.ts
@@ -79,7 +79,10 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
     address2: '',
     city: '',
     state: '',
-    zipCode: ''
+    zipCode: '',
+    // TC-020 (#235 bug a): docType/docNumber para propagar a Wompi + backend.
+    documentType: '',
+    documentNumber: ''
   };
 
   // Hospedaje form
@@ -313,6 +316,10 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
             this.contactForm.lastName = profile.lastName || this.contactForm.lastName;
             this.contactForm.email = profile.email || this.contactForm.email;
             this.contactForm.phone = profile.phone || this.contactForm.phone;
+            // TC-020 (#235 bug a): propagar docType/docNumber del profile al contactForm
+            // para que se envie a Wompi + backend en vez de hardcodes CC/00000000/123456789.
+            this.contactForm.documentType = (profile as any).documentType || this.contactForm.documentType;
+            this.contactForm.documentNumber = (profile as any).documentNumber || this.contactForm.documentNumber;
 
             // Asignar campos adicionales si el backend los envía (dirección, info adicional)
             if ((profile as any).address) {
@@ -752,8 +759,11 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
           fullName: `${this.userForm.firstName} ${this.userForm.lastName}`.trim(),
           phoneNumber: this.userForm.phone.replace(/\D/g, ''), // Solo números
           phoneNumberPrefix: '+57',
-          legalId: '123456789', // TODO: Agregar campo en el formulario
-          legalIdType: 'CC'
+          // TC-020 (#235 bug a): usar docType/docNumber del profile del turista via
+          // contactForm (populado en loadUserProfile). Fallback a CC/00000000 si el
+          // profile no los tiene (perfiles pre-TC-009 con document_type NULL).
+          legalId: this.contactForm.documentNumber || '00000000',
+          legalIdType: this.contactForm.documentType || 'CC'
         },
         shippingAddress: shippingAddress
       };
@@ -1085,14 +1095,16 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
       }
       
       // 4. Preparar información del pagador
+      // TC-020 (#235 bug a): docType/docNumber del contactForm (populados desde profile).
+      // Fallback a CC/00000000 para perfiles legacy sin documento configurado.
       const payerInfo = {
         fullName: this.contactForm.firstName + ' ' + this.contactForm.lastName,
         firstName: this.contactForm.firstName,
         lastName: this.contactForm.lastName,
         email: this.contactForm.email,
         phone: this.contactForm.phone,
-        documentType: 'CC', // TODO: Obtener del formulario si está disponible
-        documentNumber: '00000000', // TODO: Obtener del formulario
+        documentType: this.contactForm.documentType || 'CC',
+        documentNumber: this.contactForm.documentNumber || '00000000',
         address1: this.contactForm.address1,
         city: this.contactForm.city,
         country: this.contactForm.country

--- a/src/app/pages/clients/my-profile/my-profile.component.ts
+++ b/src/app/pages/clients/my-profile/my-profile.component.ts
@@ -137,7 +137,10 @@ export class MyProfileComponent implements OnInit {
 
   loadProfile(): void {
     this.profileLoading = true;
-    this.touristService.getProfile().subscribe({
+    // TC-020 (#235 bug d): forceRefresh=true — sin esto el cache stale de
+    // TouristService (shareReplay(1)) devolvia la version anterior del profile
+    // y el documentType aparecia como N/A aunque el update lo hubiera guardado.
+    this.touristService.getProfile(true).subscribe({
       next: (data) => {
         this.profileData = data;
         this.profileLoading = false;

--- a/src/app/pages/clients/tour-booking-confirmation/tour-booking-confirmation.component.ts
+++ b/src/app/pages/clients/tour-booking-confirmation/tour-booking-confirmation.component.ts
@@ -408,9 +408,8 @@ export class TourBookingConfirmationComponent implements OnInit {
    * Navegar a mis reservas
    */
   goToMyReservations(): void {
-    // TODO: Implementar navegación a mis reservas cuando esté disponible
-    console.log('Navegating to my reservations...');
-    this.router.navigate(['/clients/list-tours']);
+    // TC-020 (#235 bug b): navegar a la tab "Mis reservas" del perfil.
+    this.router.navigate(['/clients/my-profile'], { queryParams: { section: 'bookings' } });
   }
 
   /**


### PR DESCRIPTION
## Contexto

Luis reportó 4 bugs en el flow de checkout / confirmación de reserva (issue #235). Este PR cierra **3 de los 4** (todos frontend). El bug restante (c) — timezone — va en PR backend aparte.

## Cambios

### Bug (a) — docType/docNumber hardcodeados en Wompi + backend payer
**Root cause:** \`cart-summary.component.ts\` tenía hardcodes en 2 lugares:
- L750-756 (webcheckout Wompi): \`legalId: '123456789', legalIdType: 'CC'\`
- L1094-1095 (payerInfo → backend): \`documentType: 'CC', documentNumber: '00000000'\`

**Fix:**
- Agregado \`documentType/documentNumber\` al \`contactForm\`.
- \`loadUserProfile()\` propaga \`profile.documentType/documentNumber\` al contactForm.
- Ambos hardcodes reemplazados por \`this.contactForm.documentType || 'CC'\` y \`documentNumber || '00000000'\`.
- Fallback a valores por defecto para perfiles pre-TC-009 (columna \`document_type\` NULL en \`tourist_profile\`).

### Bug (b) — Botón "Ver Mis Reservas" navegaba a search
**Root cause:** \`tour-booking-confirmation.goToMyReservations()\` L410-414 tenía TODO y navegaba a \`/clients/list-tours\`.

**Fix:** navega a \`/clients/my-profile?section=bookings\` (que \`my-profile.component\` ya escucha vía \`queryParamMap\`).

### Bug (d) — Perfil turista mostraba N/A en tipo documento
**Root cause:** \`my-profile.loadProfile()\` L140 llamaba \`getProfile()\` sin \`forceRefresh=true\`. El \`TouristService.getProfile()\` usa \`shareReplay(1)\` como cache — si el user acababa de guardar y volvía a la vista, veía el response previo (sin documentType actualizado).

**Fix:** \`getProfile(true)\` fuerza refetch cada vez que se entra al perfil.

## Build
- \`ng build --configuration=production\` verde local ✅.

## Test plan
- [ ] Deploy → como turista con \`documentType\` configurado en el perfil, ir al checkout de un tour. Verificar en Wompi que aparece el tipo/número real (no CC/123456789).
- [ ] Post-pago, en la confirmación, click en "Ver Mis Reservas" → debe ir a la pestaña Bookings del perfil.
- [ ] En \`/clients/my-profile?section=profile\` el tipo de documento debe mostrarse (no N/A) si el user lo tiene configurado.
- [ ] Editar profile + cambiar documento + guardar → recargar la vista → nuevo valor visible (no cache stale).
- [ ] Perfiles pre-TC-009 con \`document_type=NULL\`: Wompi recibe fallback CC/00000000 (comportamiento actual, retrocompatible). Al editar y guardar en el modal, se persiste.