### PR TITLE
feat(TC-021 #236): ocultar datos cliente al PROVIDER hasta 1 dia antes del tour

### DIFF
--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.html
@@ -383,7 +383,9 @@
 
 
                         <!-- ===== SOLO PROVIDER / ADMIN ===== -->
-                        @if (currentRole !== 'CLIENT') {
+                        <!-- TC-021 (#236): PROVIDER solo ve datos del cliente hasta 1 dia antes del scheduleDate.
+                             ADMIN/BACKOFFICE siempre ven (canSeeCustomerData retorna true si !== PROVIDER). -->
+                        @if (currentRole !== 'CLIENT' && canSeeCustomerData()) {
 
                             <!-- Reserva a nombre de -->
                             @if (selectedBooking.serviceResponsible) {
@@ -444,23 +446,27 @@
                         <!-- ===== TODOS LOS ROLES ===== -->
 
                         <!-- Información del Cliente -->
-                        <div class="upcoming-details mb-4">
-                            <h6 class="mb-3">{{ 'provider-tour-management.modal.customerInfo' | translate }}</h6>
-                            <div class="row gy-3">
-                                <div class="col-lg-4">
-                                    <h6 class="fs-14 text-gray-6">{{ 'provider-tour-management.modal.fields.name' | translate }}</h6>
-                                    <p class="text-dark fs-16 fw-medium">{{ selectedBooking.customerName }}</p>
-                                </div>
-                                <div class="col-lg-4">
-                                    <h6 class="fs-14 text-gray-6">{{ 'provider-tour-management.modal.fields.email' | translate }}</h6>
-                                    <p class="text-dark fs-16 fw-medium">{{ selectedBooking.customerEmail }}</p>
-                                </div>
-                                <div class="col-lg-4">
-                                    <h6 class="fs-14 text-gray-6">{{ 'provider-tour-management.modal.fields.phone' | translate }}</h6>
-                                    <p class="text-dark fs-16 fw-medium">{{ selectedBooking.customerPhone }}</p>
+                        <!-- TC-021 (#236): mismos datos que "Reserva a nombre de" — tambien se oculta al
+                             PROVIDER lejos del scheduleDate. CLIENT ve siempre (son sus propios datos). -->
+                        @if (canSeeCustomerData()) {
+                            <div class="upcoming-details mb-4">
+                                <h6 class="mb-3">{{ 'provider-tour-management.modal.customerInfo' | translate }}</h6>
+                                <div class="row gy-3">
+                                    <div class="col-lg-4">
+                                        <h6 class="fs-14 text-gray-6">{{ 'provider-tour-management.modal.fields.name' | translate }}</h6>
+                                        <p class="text-dark fs-16 fw-medium">{{ selectedBooking.customerName }}</p>
+                                    </div>
+                                    <div class="col-lg-4">
+                                        <h6 class="fs-14 text-gray-6">{{ 'provider-tour-management.modal.fields.email' | translate }}</h6>
+                                        <p class="text-dark fs-16 fw-medium">{{ selectedBooking.customerEmail }}</p>
+                                    </div>
+                                    <div class="col-lg-4">
+                                        <h6 class="fs-14 text-gray-6">{{ 'provider-tour-management.modal.fields.phone' | translate }}</h6>
+                                        <p class="text-dark fs-16 fw-medium">{{ selectedBooking.customerPhone }}</p>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
+                        }
 
                         <!-- Secciones ocultas para Proveedores -->
                         @if (currentRole !== 'PROVIDER') {

--- a/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
+++ b/src/app/pages/providers/provider-tour-management/provider-tour-management.component.ts
@@ -97,6 +97,25 @@ export class ProviderTourManagementComponent implements OnInit, OnDestroy, OnCha
   goToMaritimeReports(): void {
     this.router.navigate(['/admin/maritime-reports']);
   }
+
+  /**
+   * TC-021 (#236): PROVIDER solo puede ver datos personales del cliente hasta 1 dia
+   * antes del scheduleDate (para evitar contacto directo + negociacion fuera de la
+   * plataforma). ADMIN/BACKOFFICE/CLIENT ven siempre.
+   *
+   * Fail-closed si no hay rawCheckInDate — mejor ocultar por accidente que filtrar.
+   */
+  canSeeCustomerData(): boolean {
+    if (this.currentRole !== 'PROVIDER') return true;
+    if (!this.selectedBooking?.rawCheckInDate) return false;
+    const schedule = this.parseLocalDate(this.selectedBooking.rawCheckInDate);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    schedule.setHours(0, 0, 0, 0);
+    const diffMs = schedule.getTime() - today.getTime();
+    const diffDays = Math.floor(diffMs / 86_400_000);
+    return diffDays <= 1;
+  }
   
   // Variables de paginación y filtrado
   public pageSize = 10;


### PR DESCRIPTION
## Contexto

Luis pidió (issue #236) que el PROVIDER solo pueda ver datos personales del cliente (nombre, email, teléfono, documento) **hasta 1 día antes del scheduleDate**. Objetivo: evitar contacto directo con turista + negociación fuera de la plataforma.

## Cambios (2 archivos, +32/-16)

**`provider-tour-management.component.ts`**: helper nuevo
\`\`\`ts
canSeeCustomerData(): boolean {
  if (this.currentRole !== 'PROVIDER') return true;  // ADMIN, BACKOFFICE, CLIENT
  if (!this.selectedBooking?.rawCheckInDate) return false;  // fail-closed
  const schedule = this.parseLocalDate(this.selectedBooking.rawCheckInDate);
  const today = new Date();
  today.setHours(0,0,0,0); schedule.setHours(0,0,0,0);
  const diffDays = Math.floor((schedule.getTime() - today.getTime()) / 86_400_000);
  return diffDays <= 1;  // hoy, mañana, o después del tour
}
\`\`\`

**`provider-tour-management.component.html`**: 3 secciones envueltas
- L386: bloque outer `@if (currentRole !== 'CLIENT' && canSeeCustomerData())` — cubre "Reserva a nombre de" + "Información del pagador"
- L447: `@if (canSeeCustomerData())` — cubre "Información del Cliente"

## Reglas efectivas para PROVIDER

| Contexto | Visibilidad datos cliente |
|---|---|
| ≥ 2 días antes del scheduleDate | ❌ Oculto |
| 1 día antes | ✅ Visible |
| Mismo día del tour | ✅ Visible |
| Después del tour (historial) | ✅ Visible |

Para ADMIN/BACKOFFICE/CLIENT: sin restricción (siempre visibles).

## Backend defense-in-depth

Va en PR aparte (siguiente en la cola) — scrub `payerName/Email/Phone/Doc*` + `serviceResponsible*` en `ReservationService.getProviderReservations` cuando caller es PROVIDER + `diffDays > 1`. Así aunque un cliente bypass la UI llamando directo la API, no ve los datos.

## Build
- \`ng build --configuration=production\` verde local ✅.

## Test plan
- [ ] Como PROVIDER: abrir modal de reserva cuya scheduleDate es >= 2 días — NO ver "Reserva a nombre de", "Info del pagador", "Info del Cliente".
- [ ] Como PROVIDER: abrir modal de reserva cuya scheduleDate es HOY, MAÑANA o pasada — VER las 3 secciones.
- [ ] Como ADMIN o BACKOFFICE: siempre ver las 3 secciones.
- [ ] Como CLIENT: siempre ver "Información del Cliente".