### PR TITLE
feat(TC-017 #220 opcion B): siempre guardar campos i18n del tour en slot 'es'

### DIFF
--- a/src/app/pages/providers/tours/add-tour/add-tour.component.ts
+++ b/src/app/pages/providers/tours/add-tour/add-tour.component.ts
@@ -915,7 +915,7 @@ export class AddTourComponent {
         latitude: isHotelPickup ? 0 : +latitude,
         longitude: isHotelPickup ? 0 : +longitude,
         address: isHotelPickup ? null : address,
-        location: isHotelPickup ? null : this.i18nService.createI18nField(location.location),
+        location: isHotelPickup ? null : this.i18nService.createI18nFieldInSpanish(location.location),
         addressType: typeOfAddress,
       };
     });
@@ -958,8 +958,8 @@ export class AddTourComponent {
 
     const body = {
       id: this.tourId || undefined,
-      name: this.i18nService.createI18nField(name),
-      description: this.i18nService.createI18nField(description),
+      name: this.i18nService.createI18nFieldInSpanish(name),
+      description: this.i18nService.createI18nFieldInSpanish(description),
       tourCategoryId: +category,
       priceType: priceType === PriceType.GROUP ? 'grupo' : 'individual',
       durationEnum: Array.isArray(duration) ? duration[0] : duration,
@@ -973,33 +973,33 @@ export class AddTourComponent {
       locations: locationMap,
       mainAttractions: mainAttractions.map((attr: any) => ({
         id: attr.id,
-        description: this.i18nService.createI18nField(attr.description)
+        description: this.i18nService.createI18nFieldInSpanish(attr.description)
       })),
       includes: includes.map((inc: any) => ({
         id: inc.id,
-        description: this.i18nService.createI18nField(inc.description),
+        description: this.i18nService.createI18nFieldInSpanish(inc.description),
         type: inc.type
       })),
       excludes: excludes.map((exc: any) => ({
         id: exc.id,
-        description: this.i18nService.createI18nField(exc.description),
+        description: this.i18nService.createI18nFieldInSpanish(exc.description),
         type: exc.type
       })),
       faq: faq.map((f: any) => ({
         id: f.id,
-        question: this.i18nService.createI18nField(f.question),
-        answer: this.i18nService.createI18nField(f.answer)
+        question: this.i18nService.createI18nFieldInSpanish(f.question),
+        answer: this.i18nService.createI18nFieldInSpanish(f.answer)
       })),
       itineraries: itineraries.map((itin: any) => ({
         id: itin.id,
-        title: this.i18nService.createI18nField(itin.title),
+        title: this.i18nService.createI18nFieldInSpanish(itin.title),
         day: itin.day,
         time: itin.time,
-        description: this.i18nService.createI18nField(itin.description)
+        description: this.i18nService.createI18nFieldInSpanish(itin.description)
       })),
       cancellationPolicies: cancellationPolicies.map((policy: any) => ({
         id: policy.id,
-        observations: this.i18nService.createI18nField(policy.observations),
+        observations: this.i18nService.createI18nFieldInSpanish(policy.observations),
         allowsRainRefund: policy.allowsRainRefund,
         allowsRescheduling: policy.allowsRescheduling,
         cancellationPolicyType: policy.cancellationPolicyType

--- a/src/app/shared/services/i18n-field.service.ts
+++ b/src/app/shared/services/i18n-field.service.ts
@@ -87,7 +87,7 @@ export class I18nFieldService {
    */
   createI18nField(value: string, lang?: SupportedLanguage): I18nField {
     const targetLang = lang || this.getCurrentLanguage();
-    
+
     const field: I18nField = {
       es: '',
       en: '',
@@ -97,6 +97,20 @@ export class I18nFieldService {
     field[targetLang] = value || '';
 
     return field;
+  }
+
+  /**
+   * TC-017 (#220 opcion B): fuerza guardar el valor en el slot 'es' (español).
+   * Uso pensado para el editor de tour (add-tour) — el backend valida que
+   * TranslatedField.es no sea vacio (RNT/legal), asi que siempre guardamos alli
+   * sin importar el idioma del UI. Los slots 'en' y 'pt' quedan vacios y seran
+   * llenados por un agente IA en fase futura.
+   *
+   * @param value - El valor del input del usuario
+   * @returns I18nField con {es: value, en: '', pt: ''}
+   */
+  createI18nFieldInSpanish(value: string): I18nField {
+    return this.createI18nField(value, 'es');
   }
 
   /**


### PR DESCRIPTION
## Contexto

Luis eligió opción B en TC-017 (issue #220). Tras el diagnóstico del body 400:

\`\`\`json
{ \"errorCode\": 307, \"validationErrors\": [\"Spanish translation is required\"] }
\`\`\`

Con payload `name: {\"es\":\"\",\"en\":\"Mulita para 4 pasajeros\",\"pt\":\"\"}`.

**Scope adicional (Luis comentario 23:29 UTC):**

> "cuando un PROVIDER esté creando un tour, a pesar de que tenga configurado el idioma en Inglés o Portugués, siempre la información del Tour se creará en español 'es'. La información en 'en' y 'pt' será creada por un agente IA."

## Cambios (2 archivos, +26/-11)

**`i18n-field.service.ts`:** nuevo helper explícito
\`\`\`ts
createI18nFieldInSpanish(value: string): I18nField {
  return this.createI18nField(value, 'es');
}
\`\`\`

**`add-tour.component.ts`:** 11 usos de \`createI18nField(value)\` → \`createI18nFieldInSpanish(value)\`. Cubre: `name`, `description`, `locations[].location`, `mainAttractions[].description`, `includes[].description`, `excludes[].description`, `faq[].question/answer`, `itineraries[].title/description`, `cancellationPolicies[].observations`.

## Validación required

El input HTML de `name` ya tiene `Validators.required + minLength(3) + maxLength(50)` (línea 132-139 del `.ts`). Sin cambios adicionales — Angular ya bloquea el submit si `name` es vacío.

**Antes del fix**, el validator pasaba porque el user llenaba `name` en inglés (con el UI en `en`). `createI18nField(value)` usaba el idioma actual y ponía el valor en el slot `en`, dejando `es` vacío → backend rechazaba.

**Después del fix**, sin importar el idioma del UI, el valor se guarda en `es`.

## Trade-offs

- Los tours editados **pierden** los idiomas en/pt que tuvieran previamente (el submit sobrescribe con solo `es`). Aceptable según scope Luis — la IA rellenará en el futuro.
- Si el negocio necesita mantener multi-idioma antes de la IA, se puede agregar un helper `createI18nFieldPreserving(oldField, value)` que preserve los otros slots. Fuera de scope de este PR.

## Build
- \`ng build --configuration=production\` verde local ✅.

## Test plan
- [ ] Deploy → como PROVIDER, cambiar idioma UI a inglés/portugués.
- [ ] Editar un tour existente, cambiar el nombre → guardar → debe funcionar sin error 400.
- [ ] Verificar en BD que \`tour.name -> 'es'\` tiene el nuevo valor.
- [ ] Verificar que \`tour.name -> 'en'/'pt'\` quedan vacíos (esperado hasta que la IA rellene).
- [ ] Editor rechaza submit si el name está completamente vacío (existing behavior).