### PR TITLE
fix(TC-018 #227): rediseño columnas listado DIMAR + botones por flag + fix precarga subcategoría

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -2133,6 +2133,18 @@
       "irreversible": "This action cannot be undone.",
       "cancel_btn": "Cancel",
       "confirm_btn": "Yes, publish red flag"
+    },
+    "table": {
+      "subCategory": "Subcategory"
+    },
+    "actions": {
+      "view": "View",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "view_modal": {
+      "title": "View Report",
+      "close_btn": "Close"
     }
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -2134,6 +2134,18 @@
       "irreversible": "Esta acción no se puede deshacer.",
       "cancel_btn": "Cancelar",
       "confirm_btn": "Sí, publicar bandera roja"
+    },
+    "table": {
+      "subCategory": "Subcategoría"
+    },
+    "actions": {
+      "view": "Ver",
+      "edit": "Editar",
+      "delete": "Eliminar"
+    },
+    "view_modal": {
+      "title": "Ver Reporte",
+      "close_btn": "Cerrar"
     }
   }
 }

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -2134,6 +2134,18 @@
       "irreversible": "Esta ação não pode ser desfeita.",
       "cancel_btn": "Cancelar",
       "confirm_btn": "Sim, publicar bandeira vermelha"
+    },
+    "table": {
+      "subCategory": "Subcategoria"
+    },
+    "actions": {
+      "view": "Ver",
+      "edit": "Editar",
+      "delete": "Excluir"
+    },
+    "view_modal": {
+      "title": "Ver Relatório",
+      "close_btn": "Fechar"
     }
   }
 }

--- a/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.html
+++ b/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.html
@@ -98,20 +98,14 @@
               <td mat-cell *matCellDef="let report"> {{ report.countryName }} </td>
             </ng-container>
 
-            <!-- Department Column -->
-            <ng-container matColumnDef="department">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header> Department </th>
-              <td mat-cell *matCellDef="let report"> {{ report.stateName }} </td>
-            </ng-container>
-
             <!-- City Column -->
             <ng-container matColumnDef="city">
               <th mat-header-cell *matHeaderCellDef mat-sort-header> City </th>
               <td mat-cell *matCellDef="let report"> {{ report.cityName }} </td>
             </ng-container>
 
-            <!-- Tag Column -->
-            <ng-container matColumnDef="tag">
+            <!-- Flag Column -->
+            <ng-container matColumnDef="flag">
               <th mat-header-cell *matHeaderCellDef mat-sort-header> Flag </th>
               <td mat-cell *matCellDef="let report">
                 <span class="badge rounded-pill" [ngClass]="getBadgeClass(report.flag)">
@@ -120,14 +114,10 @@
               </td>
             </ng-container>
 
-            <!-- Flag Column -->
-            <ng-container matColumnDef="flag">
-              <th mat-header-cell *matHeaderCellDef mat-sort-header> Status </th>
-              <td mat-cell *matCellDef="let report">
-                <span class="badge rounded-pill" [ngClass]="getBadgeClass(report.flag)">
-                  {{ report.flag }}
-                </span>
-              </td>
+            <!-- TC-018 #227: Subcategory Column (nueva) -->
+            <ng-container matColumnDef="subCategory">
+              <th mat-header-cell *matHeaderCellDef> {{ 'maritime-reports.table.subCategory' | translate }} </th>
+              <td mat-cell *matCellDef="let report"> {{ report.subcategoryCode || '-' }} </td>
             </ng-container>
 
             <!-- Date Column -->
@@ -141,12 +131,22 @@
               <th mat-header-cell *matHeaderCellDef class="text-center"> Actions </th>
               <td mat-cell *matCellDef="let report" class="text-center">
                 <div class="d-flex justify-content-center gap-2">
-                  <button class="btn btn-icon btn-sm btn-outline-primary" (click)="openEditModal(report)" title="Edit">
-                    <i class="isax isax-edit-2"></i>
+                  <!-- TC-018 #227: Ver siempre visible. -->
+                  <button class="btn btn-icon btn-sm btn-outline-secondary" (click)="openViewModal(report)"
+                          [title]="'maritime-reports.actions.view' | translate">
+                    <i class="isax isax-eye"></i>
                   </button>
-                  <button class="btn btn-icon btn-sm btn-outline-danger" (click)="deleteReport(report.id!)" title="Delete">
-                    <i class="isax isax-trash"></i>
-                  </button>
+                  <!-- TC-018 #227: Editar/Eliminar solo si NO es RED (reportes RED son inmutables porque BE-23 ya cancelo reservas retroactivamente). -->
+                  <ng-container *ngIf="report.flag !== MaritimeFlagRed">
+                    <button class="btn btn-icon btn-sm btn-outline-primary" (click)="openEditModal(report)"
+                            [title]="'maritime-reports.actions.edit' | translate">
+                      <i class="isax isax-edit-2"></i>
+                    </button>
+                    <button class="btn btn-icon btn-sm btn-outline-danger" (click)="deleteReport(report)"
+                            [title]="'maritime-reports.actions.delete' | translate">
+                      <i class="isax isax-trash"></i>
+                    </button>
+                  </ng-container>
                 </div>
               </td>
             </ng-container>
@@ -192,8 +192,14 @@
       <div class="modal-content border-0 shadow-lg">
         <div class="modal-header">
           <h5 class="modal-title">
-            <i class="isax me-2 text-primary" [ngClass]="isEditMode ? 'isax-edit-2' : 'isax-add-circle'"></i>
-            {{ isEditMode ? 'Editar Reporte' : 'Crear Nuevo Reporte' }}
+            <i class="isax me-2 text-primary"
+               [ngClass]="isViewMode ? 'isax-eye' : (isEditMode ? 'isax-edit-2' : 'isax-add-circle')"></i>
+            <ng-container *ngIf="isViewMode; else editOrCreateTitle">
+              {{ 'maritime-reports.view_modal.title' | translate }}
+            </ng-container>
+            <ng-template #editOrCreateTitle>
+              {{ isEditMode ? 'Editar Reporte' : 'Crear Nuevo Reporte' }}
+            </ng-template>
           </h5>
           <button type="button" class="btn-close" (click)="closeModal()" aria-label="Close"></button>
         </div>
@@ -235,8 +241,11 @@
               <div class="col-md-6">
                 <div class="mb-3">
                   <label class="form-label">Subcategoría <span class="text-danger">*</span></label>
+                  <!-- TC-018 #227 fix: value=sub.code (string estable) para que
+                       patchValue con report.subcategoryCode precargue el select
+                       en modo Editar. El texto mostrado sigue localizado. -->
                   <mat-select class="custom-mat-select select" placeholder="Seleccione Subcategoría" formControlName="subCategory">
-                    <mat-option *ngFor="let sub of subCategories" [value]="sub.name">{{ sub.name | localizedName }}</mat-option>
+                    <mat-option *ngFor="let sub of subCategories" [value]="sub.code">{{ sub.name | localizedName }}</mat-option>
                   </mat-select>
                 </div>
               </div>
@@ -266,9 +275,10 @@
         </div>
         <div class="modal-footer border-0">
           <button type="button" class="btn btn-secondary" (click)="closeModal()">
-            Cancelar
+            {{ isViewMode ? ('maritime-reports.view_modal.close_btn' | translate) : 'Cancelar' }}
           </button>
-          <button type="submit" form="reportForm" class="btn btn-primary px-4" [disabled]="reportForm.invalid">
+          <!-- TC-018 #227: en modo Ver no hay boton de guardar (solo lectura). -->
+          <button *ngIf="!isViewMode" type="submit" form="reportForm" class="btn btn-primary px-4" [disabled]="reportForm.invalid">
             {{ isEditMode ? 'Actualizar' : 'Guardar' }} Reporte
           </button>
         </div>

--- a/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.ts
+++ b/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.ts
@@ -41,7 +41,9 @@ export class MaritimeActivityReportsComponent implements OnInit {
   // Data
   reports: MaritimeActivityReport[] = [];
   dataSource = new MatTableDataSource<MaritimeActivityReport>([]);
-  displayedColumns: string[] = ['id', 'country', 'department', 'city', 'tag', 'flag', 'reportDate', 'actions'];
+  // TC-018 #227: Rediseno columnas listado DIMAR.
+  // Se quitan Department y Status (duplicaba Flag). Se agrega subCategory.
+  displayedColumns: string[] = ['id', 'country', 'city', 'flag', 'subCategory', 'reportDate', 'actions'];
   
   // Dashboard Stats
   todayReport: MaritimeActivityReport | null = null;
@@ -55,8 +57,13 @@ export class MaritimeActivityReportsComponent implements OnInit {
   // Form (Modal Simulation)
   reportForm: FormGroup;
   isEditMode = false;
+  // TC-018 #227: modo lectura para "Ver reporte" (reusa el mismo modal).
+  isViewMode = false;
   selectedReportId: number | null = null;
   showFormModal = false;
+
+  // TC-018 #227: expuesto al template para condicionar botones por bandera.
+  readonly MaritimeFlagRed = MaritimeFlag.RED;
 
   countries: any[] = [];
   departments: any[] = [];
@@ -228,18 +235,53 @@ export class MaritimeActivityReportsComponent implements OnInit {
 
   openCreateModal(): void {
     this.isEditMode = false;
+    this.isViewMode = false;
     this.selectedReportId = null;
     this.reportForm.reset({ flag: MaritimeFlag.GREEN });
+    this.reportForm.enable();
     this.showFormModal = true;
   }
 
   openEditModal(report: MaritimeActivityReport): void {
+    // TC-018 #227: reportes con bandera RED son inmutables (ya cancelaron
+    // reservas retroactivamente vi BE-23). Silently no-op si algun caller
+    // los pasa por descuido.
+    if (report.flag === MaritimeFlag.RED) {
+      this.openViewModal(report);
+      return;
+    }
     this.isEditMode = true;
+    this.isViewMode = false;
     this.selectedReportId = report.id!;
-    
-    // Find category name by ID
+    this.hydrateFormFromReport(report);
+    this.reportForm.enable();
+    this.showFormModal = true;
+  }
+
+  // TC-018 #227: nuevo modo "Ver" (solo lectura). Reusa el mismo modal para
+  // evitar duplicar markup / bindings. El template oculta el boton Guardar
+  // cuando isViewMode === true, y deshabilitamos el form aqui.
+  openViewModal(report: MaritimeActivityReport): void {
+    this.isEditMode = false;
+    this.isViewMode = true;
+    this.selectedReportId = report.id!;
+    this.hydrateFormFromReport(report);
+    this.reportForm.disable();
+    this.showFormModal = true;
+  }
+
+  // TC-018 #227: extraida de openEditModal para reusar en openViewModal.
+  // Fix: la subcategoria del reporte viene como subcategoryCode (string),
+  // pero el <mat-option> antes usaba [value]="sub.name" (dict localizado).
+  // Ahora precargamos los subCategories del catalogo primero, luego pasamos
+  // el CODE al form (el mat-option ahora usa [value]="sub.code" tambien).
+  private hydrateFormFromReport(report: MaritimeActivityReport): void {
     const category = this.categories.find(c => c.id === report.businessCategoryId);
     const categoryName = category ? category.name : '';
+
+    // Cargar subcategorias antes del patch, para que el mat-select tenga
+    // opciones cuando se le asigne el valor.
+    this.subCategories = (category && category.subCategories) ? category.subCategories : [];
 
     this.reportForm.patchValue({
       country: report.countryName,
@@ -269,19 +311,14 @@ export class MaritimeActivityReportsComponent implements OnInit {
         });
       }
     }
-
-    if (categoryName) {
-      const selectedCategory = this.categories.find(c => c.name === categoryName);
-      if (selectedCategory && selectedCategory.subCategories) {
-        this.subCategories = selectedCategory.subCategories;
-      }
-    }
-
-    this.showFormModal = true;
   }
 
   closeModal(): void {
     this.showFormModal = false;
+    // Rehabilitar por si venia de modo Ver, asi el siguiente open* no
+    // arrastra un form deshabilitado.
+    this.reportForm.enable();
+    this.isViewMode = false;
   }
 
   attemptSave(): void {
@@ -309,14 +346,17 @@ export class MaritimeActivityReportsComponent implements OnInit {
     const deptObj = this.departments.find(d => d.name === reportData.department);
     const cityObj = this.cities.find(c => c.name === reportData.city);
     const categoryObj = this.categories.find(c => c.name === reportData.category);
-    const subCatObj = this.subCategories.find(s => s.name === reportData.subCategory);
+    // TC-018 #227: el mat-option de subcategoria ahora usa el CODE como value
+    // (string estable), no el name localizado (dict). Asi el patchValue del
+    // modo Editar precarga correctamente.
+    const subCatObj = this.subCategories.find(s => s.code === reportData.subCategory);
 
     const payload = {
       countryId: countryObj ? countryObj.id : null,
       stateId: deptObj ? deptObj.id : null,
       cityId: cityObj ? cityObj.id : null,
       businessCategoryId: categoryObj ? categoryObj.id : null,
-      subcategoryCode: subCatObj ? subCatObj.code : null,
+      subcategoryCode: subCatObj ? subCatObj.code : reportData.subCategory,
       flag: reportData.flag,
       reportStartDate: reportData.reportStartDate,
       reportEndDate: reportData.reportEndDate
@@ -341,9 +381,17 @@ export class MaritimeActivityReportsComponent implements OnInit {
     }
   }
 
-  deleteReport(id: number): void {
+  deleteReport(report: MaritimeActivityReport): void {
+    // TC-018 #227: reportes RED son inmutables (BE-23 ya cancelo reservas).
+    // Segunda linea de defensa por si el boton llega a mostrarse.
+    if (report.flag === MaritimeFlag.RED) {
+      return;
+    }
+    if (report.id == null) {
+      return;
+    }
     if (confirm('¿Estás seguro de eliminar este reporte?')) {
-      this.reportsService.delete(id).subscribe({
+      this.reportsService.delete(report.id).subscribe({
         next: () => this.loadReports(),
         error: (err) => console.error('Error deleting report', err)
       });


### PR DESCRIPTION
## Summary

Cierre de refinamientos frontend del TC-018 reportados por Luis en https://github.com/Touryapp/tourya-api/issues/227 (comentario 2026-08-11).

- **Listado (admin ADMIN + BACKOFFICE_OPERATION):** se quitan las columnas **Department** y **Status** (esta ultima duplicaba Flag). Se agrega la columna **Subcategoría**. Nuevo layout: `ID | País | Ciudad | Flag | Subcategoría | Date (Inicio y Fin) | Actions`.
- **Botones de accion:** ahora son **Ver + Editar + Eliminar**. Los reportes con `flag=RED` son inmutables (BE-23 ya cancelo reservas retroactivamente), asi que solo muestran **Ver**. Doble guarda en `openEditModal()` y `deleteReport()`.
- **Modal Ver:** reusa el modal del editor en modo solo-lectura (`reportForm.disable()`), oculta el boton Guardar, titulo/close via i18n.
- **Fix bug de precarga de subcategoria en Editar:** el `<mat-option>` usaba `[value]="sub.name"` (objeto dict localizado) mientras `patchValue()` recibia `subcategoryCode` (string) → mismatch → dropdown vacio. Ahora el option usa `[value]="sub.code"` (string estable), `persistReport()` busca por code, y `hydrateFormFromReport()` carga los `subCategories` del catalogo ANTES del patch para que el select tenga opciones cuando se le asigne el valor. Modo Crear sigue igual (subcategoria vacia hasta seleccionar categoria).
- **i18n (es/en/pt):** nuevas keys `maritime-reports.table.subCategory`, `maritime-reports.actions.{view,edit,delete}`, `maritime-reports.view_modal.{title,close_btn}`.

Aplica a la ruta `/admin/maritime-reports` y al embed en el dashboard admin (mismo componente).

## Test plan

- [ ] `npx ng build --configuration=production` en verde (validado local).
- [ ] Login como ADMIN / BACKOFFICE_OPERATION → `/admin/maritime-reports`.
- [ ] Verificar cabeceras del listado: `ID | Country | City | Flag | Subcategoría | Date | Actions`. Ya no aparecen Department ni Status duplicado.
- [ ] En una fila con `flag=GREEN` o `YELLOW` → aparecen 3 botones (ojo/lapiz/basura).
- [ ] En una fila con `flag=RED` → aparece solo el boton Ver.
- [ ] Click Ver en cualquier flag → abre modal con titulo "Ver Reporte" (o traduccion), campos deshabilitados, sin boton Guardar.
- [ ] Click Editar en GREEN/YELLOW → abre modal titulo "Editar Reporte" y **la subcategoria aparece precargada** con la del reporte (bug principal).
- [ ] Cambiar solo la subcategoria y guardar → se persiste correctamente (payload lleva `subcategoryCode` correcto).
- [ ] Crear reporte nuevo → subcategoria arranca vacia y se llena tras elegir categoria.
- [ ] Cambiar idioma (es/en/pt) → cabecera "Subcategoría/Subcategory/Subcategoria" y tooltips Ver/Editar/Eliminar traducen.

Fixes #227