### PR TITLE
fix(TC-008 #195): ADMIN mantiene su menú completo en todas las vistas admin

### DIFF
--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -10,7 +10,11 @@ import { AuthService } from '../../core/services/auth.service';
  * sidebar (o no lo dibujaba). Ahora aporta un sidebar navegacional persistente
  * en TODAS las vistas admin excepto `/admin/dashboard` (que tiene su propio
  * sidebar con toggles internos). Items del sidebar dependen del rol: ADMIN ve
- * 8, BACKOFFICE_OPERATION ve 3.</p>
+ * 8, BACKOFFICE_OPERATION (BO puro, sin ADMIN) ve 3.</p>
+ *
+ * <p><b>Regla de precedencia de roles</b>: si el usuario tiene ADMIN, gana ADMIN
+ * (aunque tambien tenga BACKOFFICE_OPERATION). Solo un BO puro (sin ADMIN) ve
+ * el sidebar reducido de 3 items. Ver `isAdmin` / `isBackofficeOnly` getters.</p>
  */
 @Component({
   selector: 'app-admin',
@@ -21,8 +25,6 @@ import { AuthService } from '../../core/services/auth.service';
 export class AdminComponent implements OnInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
 
-  isAdmin = false;
-  isBackofficeOperation = false;
   showShellSidebar = false;
 
   constructor(
@@ -30,9 +32,30 @@ export class AdminComponent implements OnInit, OnDestroy {
     private authService: AuthService
   ) {}
 
+  /**
+   * Getters (no fields) para que el sidebar refleje siempre el rol actual del
+   * usuario en localStorage. Si por alguna razon el token/rol cambia mientras
+   * AdminComponent sigue vivo (ej: refresh post-login-BO despues de haber
+   * entrado como ADMIN), la vista no queda pegada con el snapshot de ngOnInit.
+   */
+  get isAdmin(): boolean {
+    return this.authService.isAdmin();
+  }
+
+  get isBackofficeOperation(): boolean {
+    return this.authService.isBackofficeOperation();
+  }
+
+  /**
+   * BO "puro" = tiene BACKOFFICE_OPERATION pero NO ADMIN. Solo estos usuarios
+   * ven el sidebar reducido de 3 items. ADMIN + BO combinado sigue viendo el
+   * sidebar de 8 items (ADMIN gana). Ver JSDoc de clase.
+   */
+  get isBackofficeOnly(): boolean {
+    return this.isBackofficeOperation && !this.isAdmin;
+  }
+
   ngOnInit(): void {
-    this.isAdmin = this.authService.isAdmin();
-    this.isBackofficeOperation = this.authService.isBackofficeOperation();
     this.recomputeShellSidebar(this.router.url);
 
     this.router.events
@@ -51,13 +74,27 @@ export class AdminComponent implements OnInit, OnDestroy {
   /**
    * Sidebar visible en todas las rutas admin excepto /admin/dashboard (que ya
    * dibuja su propio sidebar con toggles). Evita mostrar dos sidebars.
+   *
+   * <p>Endurecido: normaliza trailing slash y query string antes de comparar,
+   * asi `/admin/`, `/admin/bookings-management/`, y `/admin/bookings-management?x=1`
+   * se comportan igual que sus equivalentes canonicos.</p>
    */
   private recomputeShellSidebar(url: string): void {
-    const path = (url || '').split('?')[0];
-    this.showShellSidebar = path.startsWith('/admin')
-      && !path.startsWith('/admin/dashboard')
-      && path !== '/admin'
-      && path !== '/admin/';
+    const path = this.normalizePath(url);
+    const isDashboard = path === '/admin/dashboard';
+    const isAdminRoot = path === '/admin';
+    this.showShellSidebar = path.startsWith('/admin/') && !isDashboard && !isAdminRoot;
+  }
+
+  private normalizePath(url: string): string {
+    if (!url) return '';
+    // Descarta query string y hash.
+    let path = url.split('?')[0].split('#')[0];
+    // Descarta trailing slash (excepto raiz).
+    if (path.length > 1 && path.endsWith('/')) {
+      path = path.slice(0, -1);
+    }
+    return path;
   }
 
   /** ADMIN va al dashboard con la seccion Solicitudes activa. */


### PR DESCRIPTION
## Summary

- Endurece el fix del shell sidebar del AdminComponent (PR #96 / commit 4891053) para cerrar el hilo TC-008 #195 abierto por Luis 2026-08-04.
- `isAdmin` / `isBackofficeOperation` migran de fields (snapshot en ngOnInit) a getters (siempre frescos desde AuthService). Elimina el riesgo de un snapshot pegado si el rol cambia post-init.
- Nuevo getter `isBackofficeOnly` documenta explícitamente la regla: ADMIN gana sobre BACKOFFICE_OPERATION cuando el usuario tiene ambos roles.
- `recomputeShellSidebar` normaliza el path (descarta query string, hash y trailing slash) antes de decidir si mostrar el shell.

## Contexto

Luis reportó en #195 que como ADMIN, al presionar "Reservas" o "Usuarios Backoffice", el menú del ADMIN desaparecía y sólo mostraba los 3 items del BO. Regresión introducida por PR #94 (sidebar BO dentro de `provider-tour-management`) y ya corregida en PR #96 trasladando el sidebar al shell AdminComponent. Este PR endurece esa fix contra edge cases (URLs con trailing slash / query / hash, roles combinados).

## Rutas cubiertas

**ADMIN** (`admin@gmail.com`) — ve shell sidebar de 8 items en todas las vistas admin excepto `/admin/dashboard` (que tiene su propio sidebar con toggles):
- `/admin/bookings-management` ✓
- `/admin/backoffice-users` ✓
- `/admin/maritime-reports` ✓
- `/admin/provider-payments` ✓
- `/admin/tour-admin` ✓

**BACKOFFICE_OPERATION puro** (`backofficeoperation3@yopmail.com`) — ve shell sidebar de 3 items (Reportes DIMAR, Órdenes de pago, Reservas) en las rutas accesibles (dashboard/tour-admin/backoffice-users bloqueadas por AdminGuard).

**ADMIN + BO combinado** — `isAdmin` retorna true → sidebar completo de 8 items. ADMIN gana.

## Test plan

- [x] `npx ng build --configuration=production` verde (0 errores TS estricto).
- [ ] Deploy dev.
- [ ] Login ADMIN → dashboard (sidebar propio 8 items). Click "Reservas" → `/admin/bookings-management` con shell sidebar 8 items visible.
- [ ] ADMIN click "Usuarios Backoffice" desde shell → `/admin/backoffice-users` con shell sidebar 8 items (no desaparece el menú).
- [ ] ADMIN click cada item del shell (Solicitudes, Gestión Tours, App config) → vuelve a `/admin/dashboard?section=X` con la sección correcta activada.
- [ ] Login BO → aterriza en `/admin/bookings-management` con shell sidebar 3 items.
- [ ] BO navega entre Reportes DIMAR / Órdenes de pago / Reservas → sidebar 3 items persiste.
- [ ] Verificar en el navegador que `/admin/bookings-management/` (con slash final) y `/admin/bookings-management?foo=bar` (con query) muestran el shell igual que el path canónico.

Cierra el hilo abierto de #195.