### PR TITLE
fix(TC-008 #195): elimina header duplicado en maritime-reports por sub-flujos

### DIFF
--- a/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.html
+++ b/src/app/pages/maritime-activity-reports/maritime-activity-reports.component.html
@@ -1,20 +1,10 @@
-<!-- Breadcrumb and Page Header -->
-  <div class="breadcrumb-bar shadow-sm mb-4" *ngIf="!embedMode">
-    <div class="container-fluid">
-      <div class="row align-items-center">
-        <div class="col-md-12 col-12">
-          <h2 class="breadcrumb-title text-center mb-2">Maritime Activity Reports</h2>
-          <nav aria-label="breadcrumb" class="page-breadcrumb">
-            <ol class="breadcrumb justify-content-center mb-0">
-              <li class="breadcrumb-item"><a [routerLink]="routes.home"><i class="isax isax-home-1"></i></a></li>
-              <li class="breadcrumb-item active" aria-current="page">DIMAR</li>
-              <li class="breadcrumb-item active" aria-current="page">Reports</li>
-            </ol>
-          </nav>
-        </div>
-      </div>
-    </div>
-  </div>
+<!-- TC-008 #195 refinamiento (2026-08-12): el shell AdminComponent (o el
+     dashboard cuando se usa en modo embed) ya provee el contexto de navegacion
+     via su sidebar activo. El breadcrumb-bar hardcodeado en ingles ("Maritime
+     Activity Reports") duplicaba ese contexto y aparecia como un header extra
+     mal formateado al entrar por sub-flujos (/admin/maritime-reports). Se
+     elimina del componente hijo — regla: el shell es responsable del titulo/
+     breadcrumb, el componente hijo solo pinta contenido. -->
 
 <div [ngClass]="embedMode ? '' : 'content section-padding'">
   <div [ngClass]="embedMode ? '' : 'container'">


### PR DESCRIPTION
## Contexto (Luis 2026-08-12T03:39 issue tourya-api#195)

Post-merge del fix TC-008 previo (b579e8f — ADMIN mantiene menu completo en todas las vistas admin), Luis validó ADMIN=8 items / BO=3 items, pero encontró un detalle final:

- ADMIN entrando a **Reporte de Actividades Maritimas directo desde el shell del dashboard** (toggle interno) -> se pinta bien, sin header extra.
- ADMIN entrando primero a **Reservas** o **Backoffice Users**, y desde ahí clickeando **Reportes DIMAR** en el sidebar del shell -> se pinta con un **header extra "Maritime Activity Reports"** arriba (hardcodeado en ingles, sin i18n).
- BACKOFFICE_OPERATION desde su menu de 3 items -> siempre pinta esa version con el header duplicado.

## Causa raiz

`maritime-activity-reports.component.html` renderiza su propio `breadcrumb-bar` con:

```html
<h2 class="breadcrumb-title text-center mb-2">Maritime Activity Reports</h2>
```

Gateado por `*ngIf="!embedMode"`. El dashboard (`dashboard.component.html` linea 189) usa `[embedMode]="true"` cuando embebe el componente, asi que el toggle interno no muestra el header — por eso Flow 1 funciona.

Pero cuando la ruta `/admin/maritime-reports` carga el componente standalone (Flows 2 y 3), `embedMode` toma su valor por defecto `false` y el breadcrumb-bar aparece. Y desde el fix TC-008 previo, el `AdminComponent` (shell) ya provee el contexto de navegacion via su sidebar activo en todas las rutas admin excepto `/admin/dashboard`, asi que ese header hardcodeado queda **duplicado** con el sidebar del shell y ademas mal formateado (en ingles, sin i18n).

## Fix

Elimina el bloque `breadcrumb-bar` del template del componente hijo. Regla: el **shell admin es responsable del titulo/breadcrumb** (via sidebar activo); el componente hijo solo pinta contenido. Se mantiene el `@Input() embedMode` porque sigue usandose para las clases `content section-padding` / `container` segun si el componente esta embebido en el dashboard o cargado standalone.

## Archivos tocados

- `src/app/pages/maritime-activity-reports/maritime-activity-reports.component.html` (-17 / +7).

## Verificacion

- [x] `npx ng build --configuration=production` verde (solo warnings pre-existentes de CommonJS).
- [ ] ADMIN -> `/admin/dashboard` -> toggle "Reporte Actividades Maritimas" -> OK (dashboard renderiza inline con `embedMode=true`, sin header extra, mantiene menu 8 items).
- [ ] ADMIN -> `/admin/bookings-management` -> shell sidebar -> "Reportes DIMAR" -> `/admin/maritime-reports` -> OK (sin breadcrumb-bar extra, sidebar shell activo con 8 items).
- [ ] ADMIN -> `/admin/backoffice-users` -> shell sidebar -> "Reportes DIMAR" -> OK (sin header extra).
- [ ] BO puro -> login -> shell sidebar (3 items) -> "Reportes DIMAR" -> OK (sin header extra).
- [ ] TC-018 #227 (columnas rediseñadas + botones RED-immutable) no roto.
- [ ] Modal Crear / Editar / Ver reporte funciona igual que antes.

## No mergear todavia

Franklin revisa y mergea.