### PR TITLE
feat(TC-017 #220): Hotel Pickup — mensaje en 4 vistas + i18n

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -26,6 +26,12 @@
       "tourSubmitted": "Tour submitted for review successfully"
     }
   },
+  "tour": {
+    "hotelPickup": {
+      "longMessage": "For this tour, our team will pick you up directly at your accommodation.",
+      "shortMessage": "We pick you up at your accommodation"
+    }
+  },
   "rejectionReasons": {
     "inappropriate": "Inappropriate content",
     "fake": "Fake or misleading information",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -31,6 +31,12 @@
     "fake": "Información falsa o engañosa",
     "spam": "Spam o contenido irrelevante"
   },
+  "tour": {
+    "hotelPickup": {
+      "longMessage": "Para disfrutar de este tour, nuestro equipo te recogerá directamente en tu alojamiento.",
+      "shortMessage": "Te recogemos en tu alojamiento"
+    }
+  },
   "home": {
     "title": "Reserve los Mejores Tours en San Andrés al Mejor Precio",
     "subtitle": "Disfruta de la isla con atención 24/7, compra segura y cancelaciones flexibles.",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -26,6 +26,12 @@
       "tourSubmitted": "Passeio enviado para revisão com sucesso"
     }
   },
+  "tour": {
+    "hotelPickup": {
+      "longMessage": "Para desfrutar deste tour, nossa equipe irá buscar você diretamente na sua acomodação.",
+      "shortMessage": "Buscamos você na sua acomodação"
+    }
+  },
   "rejectionReasons": {
     "inappropriate": "Conteúdo inapropriado",
     "fake": "Informação falsa ou enganosa",

--- a/src/app/pages/clients/cart-summary/cart-summary.component.html
+++ b/src/app/pages/clients/cart-summary/cart-summary.component.html
@@ -417,10 +417,17 @@
                                                 <i class="fas fa-clock me-1"></i>
                                                 {{ item.schedule.startTime }} - {{ item.schedule.endTime }}
                                             </p>
-                                            <p class="text-muted small mb-1" [title]="item.address.city + ', ' + item.address.state">
+                                            <!-- TC-017 (#220): Hotel Pickup no tiene direccion — mostrar mensaje corto. -->
+                                            <p class="text-muted small mb-1" *ngIf="isHotelPickupItem(item); else itemAddress">
                                                 <i class="fas fa-map-marker-alt me-1"></i>
-                                                {{ item.address.city.length > 15 ? (item.address.city | slice:0:15) + '...' : item.address.city }}, {{ item.address.state.length > 15 ? (item.address.state | slice:0:15) + '...' : item.address.state }}
+                                                {{ 'tour.hotelPickup.shortMessage' | translate }}
                                             </p>
+                                            <ng-template #itemAddress>
+                                                <p class="text-muted small mb-1" [title]="(item.address.city || '') + ', ' + (item.address.state || '')">
+                                                    <i class="fas fa-map-marker-alt me-1"></i>
+                                                    {{ (item.address.city || '').length > 15 ? ((item.address.city || '') | slice:0:15) + '...' : (item.address.city || '') }}, {{ (item.address.state || '').length > 15 ? ((item.address.state || '') | slice:0:15) + '...' : (item.address.state || '') }}
+                                                </p>
+                                            </ng-template>
                                             <!-- TC-006: para tours grupo mostramos la cantidad de grupos; para individual la cantidad de pax. -->
                                             <p class="text-muted small mb-1" *ngIf="item.tour?.priceType === 'grupo'">
                                                 <i class="fas fa-users me-1"></i>

--- a/src/app/pages/clients/cart-summary/cart-summary.component.ts
+++ b/src/app/pages/clients/cart-summary/cart-summary.component.ts
@@ -1395,6 +1395,21 @@ export class CartSummaryComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   /**
+   * TC-017 (#220): true si el tour es Hotel Pickup. El backend aun no expone address_type
+   * en la respuesta del carrito, asi que caemos al empty-check de geo como fallback.
+   * Cuando el backend lo exponga (address.addressType), la deteccion se vuelve exacta.
+   */
+  isHotelPickupItem(item: CartItem): boolean {
+    if (item?.address?.addressType === 'Hotel Pickup') {
+      return true;
+    }
+    const city = item?.address?.city || '';
+    const state = item?.address?.state || '';
+    const address = item?.address?.address || '';
+    return !city && !state && !address;
+  }
+
+  /**
    * Helper para obtener label de tipo de participante
    */
   getParticipantTypeLabel(ageType: string): string {

--- a/src/app/pages/clients/list-tours/tour-grid-view/tour-grid-view.component.html
+++ b/src/app/pages/clients/list-tours/tour-grid-view/tour-grid-view.component.html
@@ -53,7 +53,13 @@
                 </h5>
                 <p class="d-flex align-items-center mb-3 tour-card-location">
                     <i class="fa fa-map-marker-alt me-2"></i>
-                    {{ tour?.tour?.address?.city || 'N/A' }}, {{ tour?.tour?.address?.address || 'N/A' }}
+                    <!-- TC-017 (#220): sin datos de geo (Hotel Pickup) mostramos mensaje en vez de "N/A, N/A". -->
+                    <ng-container *ngIf="tour?.tour?.address?.city || tour?.tour?.address?.address; else hotelPickupShort">
+                        {{ tour?.tour?.address?.city || 'N/A' }}, {{ tour?.tour?.address?.address || 'N/A' }}
+                    </ng-container>
+                    <ng-template #hotelPickupShort>
+                        <span>{{ 'tour.hotelPickup.shortMessage' | translate }}</span>
+                    </ng-template>
                 </p>
                 <div class="mb-2">
                     <h6 class="d-flex align-items-center text-gray-6 fs-14 fw-normal">

--- a/src/app/pages/clients/list-tours/tour-list-view/tour-list-view.component.html
+++ b/src/app/pages/clients/list-tours/tour-list-view/tour-list-view.component.html
@@ -50,7 +50,13 @@
                                     'N/A' }}</a></h5>
                             <p class="fs-14 d-flex align-items-center">
                                 <i class="isax isax-location5 me-2"></i>
-                                {{ tour?.tour?.address?.city || 'N/A' }}, {{ tour?.tour?.address?.state || 'N/A' }}
+                                <!-- TC-017 (#220): sin datos de geo (Hotel Pickup) mostramos mensaje en vez de "N/A, N/A". -->
+                                <ng-container *ngIf="tour?.tour?.address?.city || tour?.tour?.address?.state; else hotelPickupShort">
+                                    {{ tour?.tour?.address?.city || 'N/A' }}, {{ tour?.tour?.address?.state || 'N/A' }}
+                                </ng-container>
+                                <ng-template #hotelPickupShort>
+                                    <span>{{ 'tour.hotelPickup.shortMessage' | translate }}</span>
+                                </ng-template>
                             </p>
                         </div>
                         <div class="d-flex align-items-center">

--- a/src/app/pages/clients/tour-booking-confirmation/tour-booking-confirmation.component.html
+++ b/src/app/pages/clients/tour-booking-confirmation/tour-booking-confirmation.component.html
@@ -332,21 +332,30 @@
                           <div class="mb-2">
                             <span class="badge bg-secondary">{{ location.addressType }}</span>
                           </div>
-                          
-                          <div class="row g-2 mb-1">
-                            <div class="col-sm-4 text-muted small fw-medium">{{ 'tourBookingSuccess.details.locationName' | translate }}:</div>
-                            <div class="col-sm-8 fw-medium">{{ (location.location | localizedName) || location.address }}</div>
-                          </div>
-                  
-                          <div class="row g-2 mb-1">
-                            <div class="col-sm-4 text-muted small fw-medium">{{ 'tourBookingSuccess.details.address' | translate }}:</div>
-                            <div class="col-sm-8 small">{{ location.address }}</div>
-                          </div>
-                  
-                          <div class="row g-2">
-                            <div class="col-sm-4 text-muted small fw-medium">{{ 'tourBookingSuccess.details.region' | translate }}:</div>
-                            <div class="col-sm-8 small">{{ getResolvedLocationString(location.countryId, location.stateId, location.cityId) }}</div>
-                          </div>
+
+                          <!-- TC-017 (#220): Hotel Pickup no tiene direccion fisica — mostrar mensaje largo. -->
+                          <ng-container *ngIf="location.addressType === 'Hotel Pickup'; else physicalLocationInfo">
+                            <div class="alert alert-info d-flex align-items-center mb-0" role="alert">
+                              <i class="isax isax-building me-2 fs-18"></i>
+                              <span class="fw-medium">{{ 'tour.hotelPickup.longMessage' | translate }}</span>
+                            </div>
+                          </ng-container>
+                          <ng-template #physicalLocationInfo>
+                            <div class="row g-2 mb-1">
+                              <div class="col-sm-4 text-muted small fw-medium">{{ 'tourBookingSuccess.details.locationName' | translate }}:</div>
+                              <div class="col-sm-8 fw-medium">{{ (location.location | localizedName) || location.address }}</div>
+                            </div>
+
+                            <div class="row g-2 mb-1">
+                              <div class="col-sm-4 text-muted small fw-medium">{{ 'tourBookingSuccess.details.address' | translate }}:</div>
+                              <div class="col-sm-8 small">{{ location.address }}</div>
+                            </div>
+
+                            <div class="row g-2">
+                              <div class="col-sm-4 text-muted small fw-medium">{{ 'tourBookingSuccess.details.region' | translate }}:</div>
+                              <div class="col-sm-8 small">{{ getResolvedLocationString(location.countryId, location.stateId, location.cityId) }}</div>
+                            </div>
+                          </ng-template>
                         </div>
                       </li>
                     </ul>

--- a/src/app/pages/clients/tours-detail/tours-detail.component.html
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.html
@@ -178,14 +178,14 @@
                         </div>
                         <!-- /Map -->
                         <!-- TC-016 (#219): mostrar tambien nombre location + pais + ciudad debajo del mapa, no solo la direccion textual. -->
-                        <!-- TC-017 (#220): si es HOTEL_PICKUP, mostrar mensaje en vez de ubicacion fisica. -->
+                        <!-- TC-017 (#220): si es HOTEL_PICKUP, mostrar mensaje largo en vez de ubicacion fisica. -->
                         <div class="mt-3" *ngIf="tour?.locations?.length">
                             <h6 class="fs-16 mb-2"><i class="isax isax-location me-1"></i>{{ 'tours-detail.booking.meetingPoint' | translate }}</h6>
                             <div class="mb-2" *ngFor="let loc of tour.locations">
                                 <ng-container *ngIf="loc.addressType === 'Hotel Pickup'; else physicalLoc">
                                     <div class="alert alert-info d-flex align-items-center mb-0" role="alert">
                                         <i class="isax isax-building me-2 fs-18"></i>
-                                        <span class="fw-medium">{{ 'tours-detail.booking.hotelPickup' | translate }}</span>
+                                        <span class="fw-medium">{{ 'tour.hotelPickup.longMessage' | translate }}</span>
                                     </div>
                                 </ng-container>
                                 <ng-template #physicalLoc>

--- a/src/app/shared/dto/cart.dto.ts
+++ b/src/app/shared/dto/cart.dto.ts
@@ -38,6 +38,9 @@ export interface CartItem {
     state: string;
     country: string;
     address: string;
+    // TC-017 (#220): opcional para detectar Hotel Pickup en el UI. Si backend expone address_type
+    // en la respuesta del carrito, viene poblado; si no, la deteccion cae al empty-check en el template.
+    addressType?: string;
   };
   gallery: {
     imageUrl: string;

--- a/src/app/shared/services/cart.service.ts
+++ b/src/app/shared/services/cart.service.ts
@@ -901,11 +901,13 @@ export class CartService {
         })),
         totalPrice: item.totalPrice, // ✅ API: item.totalPrice
         totalParticipants: item.details.reduce((sum: number, detail: any) => sum + detail.quantity, 0), // ✅ Calculado
+        // TC-017 (#220): sin fallbacks fake — Hotel Pickup deja geo vacia y la UI muestra el mensaje corto.
         address: {
-          city: item.city || 'Cartagena',
-          state: item.department || item.state || 'Bolívar',
-          country: item.country || 'Colombia',
-          address: item.meetingPoint || 'Plaza de la Aduana, Centro Histórico'
+          city: item.city || '',
+          state: item.department || item.state || '',
+          country: item.country || '',
+          address: item.meetingPoint || '',
+          addressType: item.addressType || undefined
         },
         // Usar imagen del tour si viene en la respuesta
         gallery: item.tourImageUrl ? [


### PR DESCRIPTION
## Contexto
TC-017 (#220 en tourya-api). Luis validó el save de tours Hotel Pickup. Este PR ataca el scope UI: cuando el tour es Hotel Pickup no hay ubicación física, así que reemplazamos el mapa + dirección por un mensaje.

## Cambios por vista

- **tours-detail** (`clients/tours-detail`): la condición Hotel Pickup ya existía y el mapa ya estaba oculto porque `mapCenter` sólo se setea con lat/lng. Actualizado el texto al mensaje largo (`tour.hotelPickup.longMessage`).
- **tour-booking-confirmation** (`clients/tour-booking-confirmation`): nueva rama `@if` cuando `location.addressType === 'Hotel Pickup'` — muestra mensaje largo y oculta locationName/address/region. El backend `ReservationResponse.locations` ya expone `addressType` vía `TourAddressResponse`.
- **tour-list-view + tour-grid-view** (`clients/list-tours`): antes mostraban `"N/A, N/A"` cuando city/state venían null (caso Hotel Pickup). Ahora en ese caso muestra el mensaje corto (`tour.hotelPickup.shortMessage`).
- **cart-summary** (`clients/cart-summary`): nuevo helper `isHotelPickupItem(item)` y template condicional para mensaje corto. Se quitaron los fallbacks fake `'Cartagena'`/`'Bolívar'`/`'Colombia'`/`'Plaza de la Aduana...'` de `cart.service.ts:mapApiResponseToCartItems` que enmascaraban Hotel Pickup como si fuera Cartagena. Ahora null cae a empty string, y el helper detecta Hotel Pickup por: `addressType === 'Hotel Pickup'` (si el backend lo expone en el futuro) o por city+state+address todos vacíos.
- `CartItem.address.addressType?: string` — nuevo campo opcional para propagar el flag si backend lo agrega en `ShoppingCartItemResponse`.

## i18n
Nueva sección central `tour.hotelPickup` con ES/EN/PT:
- `longMessage` — para tour-details y tour-booking-confirmation.
- `shortMessage` — para list-tours cards y cart-summary.

## Test plan
- [ ] Meeting Point tour: sigue mostrando mapa + dirección normal en tours-detail; ciudad/estado normales en list-tours y cart-summary; datos de dirección en tour-booking-confirmation.
- [ ] Hotel Pickup tour (creado post save de #220):
  - tours-detail: sin mapa, muestra mensaje largo en la sección de ubicación.
  - tour-booking-confirmation: badge "Hotel Pickup" + mensaje largo (sin locationName/address/region).
  - list-tours (grid y list): mensaje corto en la línea de ubicación de la card.
  - cart-summary: mensaje corto en la línea del ítem del carrito.
- [ ] Verificar los 3 idiomas ES/EN/PT.
- [ ] `npx ng build --configuration=production` verde (ya validado en local).

## Notas
- Fallbacks fake removidos en `cart.service.ts` son un fix de corrección — dejaban tours Hotel Pickup como "Cartagena, Bolívar" en el carrito.
- Backend no expone `address_type` en el response del search endpoint ni del carrito. La detección Hotel Pickup en list-tours y cart-summary usa el fallback "geo vacía" (aceptado por Franklin según el brief). Si backend luego lo expone, el código ya lo consume vía `addressType?`.