### PR TITLE
fix(TC-017 #220): oculta mapa Hotel Pickup real + i18n priceType grupo/individual

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -30,6 +30,10 @@
     "hotelPickup": {
       "longMessage": "For this tour, our team will pick you up directly at your accommodation.",
       "shortMessage": "We pick you up at your accommodation"
+    },
+    "priceType": {
+      "individual": "Individual",
+      "group": "Group"
     }
   },
   "rejectionReasons": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -35,6 +35,10 @@
     "hotelPickup": {
       "longMessage": "Para disfrutar de este tour, nuestro equipo te recogerá directamente en tu alojamiento.",
       "shortMessage": "Te recogemos en tu alojamiento"
+    },
+    "priceType": {
+      "individual": "Individual",
+      "group": "Grupo"
     }
   },
   "home": {

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -30,6 +30,10 @@
     "hotelPickup": {
       "longMessage": "Para desfrutar deste tour, nossa equipe irá buscar você diretamente na sua acomodação.",
       "shortMessage": "Buscamos você na sua acomodação"
+    },
+    "priceType": {
+      "individual": "Individual",
+      "group": "Grupo"
     }
   },
   "rejectionReasons": {

--- a/src/app/pages/clients/list-tours/tour-grid-view/tour-grid-view.component.ts
+++ b/src/app/pages/clients/list-tours/tour-grid-view/tour-grid-view.component.ts
@@ -92,16 +92,19 @@ export class TourGridViewComponent implements OnChanges {
     }
   }
 
+  // TC-017 (#220): backend puede enviar 'grupo'/'individual' (minusc) o 'GROUP'/'INDIVIDUAL' (mayus).
+  // Se normaliza y se usa la key i18n tour.priceType.* con formato "Grupo (N)" donde N = maxPeople.
   getPriceTypeLabel(tour: any): string {
     const priceType = tour?.priceType;
     if (!priceType) return '';
     const upper = priceType.toUpperCase();
     if (upper === 'PRIVATE' || upper === 'PER_PERSON' || upper === 'INDIVIDUAL') {
-      return this.translate.instant('toursList.priceType.person');
+      return this.translate.instant('tour.priceType.individual');
     }
-    if (upper === 'GROUP' || upper === 'PER_GROUP') {
-      const amount = tour?.maxCapacity || 0;
-      return this.translate.instant('toursList.priceType.group', { amount: amount });
+    if (upper === 'GROUP' || upper === 'GRUPO' || upper === 'PER_GROUP') {
+      const amount = tour?.maxPeople || 0;
+      const label = this.translate.instant('tour.priceType.group');
+      return `${label} (${amount})`;
     }
     return priceType;
   }

--- a/src/app/pages/clients/tours-detail/tours-detail.component.html
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.html
@@ -170,11 +170,12 @@
                     <div class="bg-light-200 card-bg-light mb-4" id="location">
                         <h5 class="fs-18 mb-3">{{ 'tours-detail.sections.location' | translate }}</h5>
                         <!-- Map -->
-                        <div>
+                        <!-- TC-017 (#220): ocultar mapa cuando todas las ubicaciones son Hotel Pickup, aun si el backend envia coords por defecto. -->
+                        <div *ngIf="!isHotelPickup">
                             <google-map *ngIf="mapCenter" height="400px" width="100%" [center]="mapCenter" [zoom]="mapZoom" class="tour-detail-map w-100">
                                 <map-marker [position]="mapCenter"></map-marker>
                             </google-map>
-                            
+
                         </div>
                         <!-- /Map -->
                         <!-- TC-016 (#219): mostrar tambien nombre location + pais + ciudad debajo del mapa, no solo la direccion textual. -->

--- a/src/app/pages/clients/tours-detail/tours-detail.component.ts
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.ts
@@ -278,17 +278,21 @@ export class ToursDetailComponent implements OnInit, OnDestroy, AfterViewChecked
             // Marcar que necesitamos refrescar lightgallery después del render
             this.needRefresh = true;
           }
-          // set map center from first location when available
-          const loc = this.tour?.locations && this.tour.locations.length ? this.tour.locations[0] : undefined;
-  
-          if (loc && loc.latitude !== undefined && loc.longitude !== undefined) {
+          // set map center from first PHYSICAL location (skip Hotel Pickup) when available.
+          // TC-017 (#220): antes usaba locations[0] sin filtrar, y si backend enviaba coords por defecto
+          // para Hotel Pickup el mapa se pintaba con la ubicacion equivocada.
+          const physicalLoc = this.tour?.locations?.find(
+            l => l?.addressType !== 'Hotel Pickup' && l?.latitude !== undefined && l?.longitude !== undefined
+          );
+
+          if (physicalLoc) {
           // subscribe to cart items to control floating cart visibility
           this.cartService.cartItems$
             .pipe(takeUntil(this.destroy$))
             .subscribe((items) => {
               this.isCartVisible = !!(items && items.length > 0);
             });
-            this.mapCenter = { lat: loc.latitude, lng: loc.longitude };
+            this.mapCenter = { lat: physicalLoc.latitude, lng: physicalLoc.longitude };
             this.mapZoom = 15;
           }
           // load public locations catalog (city/state names) once tour is loaded
@@ -561,18 +565,31 @@ export class ToursDetailComponent implements OnInit, OnDestroy, AfterViewChecked
   }
 
   /**
+   * TC-017 (#220): true cuando todas las ubicaciones del tour son "Hotel Pickup" (o no hay ninguna fisica).
+   * Sirve para ocultar el <google-map> aun cuando el backend devuelva coords por defecto (ej. ciudad).
+   */
+  get isHotelPickup(): boolean {
+    const locs = this.tour?.locations;
+    if (!locs || locs.length === 0) return false;
+    return locs.every(l => l?.addressType === 'Hotel Pickup');
+  }
+
+  /**
    * Helper to map priceType to human-readable labels.
+   * TC-017 (#220): backend devuelve valores en minusculas ('grupo' / 'individual'),
+   * normalizamos a mayusculas antes de comparar. Formato para grupo: "Grupo (N)" donde N = maxPeople.
    */
   getPriceTypeLabel(): string {
-    if (!this.tour) return '';
-    if (this.tour.priceType === PriceType.INDIVIDUAL) {
-      return this.translate.instant('tours-detail.booking.perPerson');
-    } else if (this.tour.priceType === PriceType.GROUP) {
-      const upTo = this.translate.instant('tours-detail.booking.upTo');
-      const persons = this.translate.instant('tours-detail.booking.persons').toLowerCase();
-      return `${this.translate.instant('tours-detail.booking.group')} (${upTo} ${this.tour.maxPeople || 0} ${persons})`;
+    if (!this.tour?.priceType) return '';
+    const upper = this.tour.priceType.toUpperCase();
+    if (upper === 'GROUP' || upper === 'GRUPO' || upper === 'PER_GROUP') {
+      const label = this.translate.instant('tour.priceType.group');
+      return `${label} (${this.tour.maxPeople || 0})`;
     }
-    return this.tour.priceType || '';
+    if (upper === 'INDIVIDUAL' || upper === 'PRIVATE' || upper === 'PER_PERSON') {
+      return this.translate.instant('tour.priceType.individual');
+    }
+    return this.tour.priceType;
   }
 
   getImage(i: number): string {


### PR DESCRIPTION
## Summary
Feedback de Luis (2026-08-12) sobre PR #111 mergeado hoy. Tres items:

**Item 1 (bug del fix anterior):** `tours-detail` seguia mostrando el mapa cuando el tour es Hotel Pickup. Root cause: el guard era `*ngIf="mapCenter"`, pero si el backend devuelve coords por defecto (ej. la ciudad) para un Hotel Pickup, `mapCenter` se llena y el mapa se pinta. Fix:
- Nuevo getter `isHotelPickup` (true si TODAS las locations son 'Hotel Pickup').
- `<div *ngIf="!isHotelPickup">` envuelve el mapa (usa `*ngIf`, no CSS, para no instanciar el componente Google Maps).
- Adicional defensivo: `mapCenter` se calcula desde el primer location **fisico con coords**, ignorando Hotel Pickup, en vez de `locations[0]` a ciegas.

**Item 2 (i18n priceType en tour-details):** Label salia siempre en el string crudo (`'grupo'` / `'individual'`) sin traducirse. Root cause: `getPriceTypeLabel()` comparaba `this.tour.priceType === PriceType.INDIVIDUAL` (`'INDIVIDUAL'` mayus), pero el backend devuelve minusculas (`'individual'` / `'grupo'`), asi que caia al fallback `return this.tour.priceType`. Fix: normalizar a mayusculas y aceptar variantes (`GRUPO`, `GROUP`, `PER_GROUP` / `INDIVIDUAL`, `PRIVATE`, `PER_PERSON`). Formato para grupo: **"Grupo (N)"** con N = `tour.maxPeople` (per pedido de Luis).

**Item 3 (i18n priceType en list-tours grid cards):** Mismo bug de mayus/minus (`'grupo'` no matcheaba `'GROUP'`). Ademas usaba `tour?.maxCapacity` que **no existe** en `TourDto` (el campo real es `maxPeople`), asi que N siempre era 0. Corregido y unificado con tour-details.

**i18n:** nuevas keys `tour.priceType.individual` y `tour.priceType.group` en `public/i18n/{es,en,pt}.json`. NO se modifica `tour.hotelPickup.*` del PR #111.

## Archivos tocados
- `src/app/pages/clients/tours-detail/tours-detail.component.ts` (getter `isHotelPickup`, refactor `getPriceTypeLabel`, mapCenter defensivo)
- `src/app/pages/clients/tours-detail/tours-detail.component.html` (guard `!isHotelPickup` en div del mapa)
- `src/app/pages/clients/list-tours/tour-grid-view/tour-grid-view.component.ts` (fix `maxCapacity` -> `maxPeople`, agregar `GRUPO` uppercase, nuevas keys)
- `public/i18n/{es,en,pt}.json` (nuevas keys `tour.priceType.individual` y `tour.priceType.group`)

## Test plan (verificacion end-to-end)
- [ ] `tours-detail` con tour Hotel Pickup -> mapa NO se ve, mensaje largo Hotel Pickup si.
- [ ] `tours-detail` con tour Meeting Point (physical) -> mapa SI se ve, centrado en la location.
- [ ] `tours-detail` con priceType `grupo` -> label muestra "Grupo (N)" en ES, "Group (N)" en EN, "Grupo (N)" en PT.
- [ ] `tours-detail` con priceType `individual` -> label muestra "Individual" en los 3 idiomas.
- [ ] `list-tours` grid con tour `grupo` -> card muestra "Grupo (N)" traducido.
- [ ] `list-tours` grid con tour `individual` -> card muestra "Individual" traducido.
- [ ] Cambiar idioma UI ES/EN/PT -> todos los labels de arriba cambian correctamente.
- [ ] Mensaje Hotel Pickup del PR #111 sigue funcionando en las otras 3 vistas (confirmation, list-tours, cart-summary).

## Build
- `npx ng build --configuration=production` -> exit 0 (verde).

## Nota
- List-view (no cards) actualmente NO muestra priceType. No se agrega en este PR (Luis dijo "cards", que es la grid view). Si se requiere en list-view, seria un follow-up con la misma logica.