### PR TITLE
feat(TC-017 #220): sort precio asc/desc + boton volver en tour-details

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "back": "Back"
+  },
   "shared": {
     "available": "Available",
     "notAvailable": "Not available",
@@ -1320,8 +1323,8 @@
     "sortBy": "Sort By : ",
     "sortByShort": "Sort By",
     "recommended": "Recommended",
-    "priceLowToHigh": "Price: low to high",
-    "priceHighToLow": "Price: high to low",
+    "priceLowToHigh": "Price low to high",
+    "priceHighToLow": "Price high to low",
     "newest": "Newest",
     "ratings": "Ratings",
     "reset": "Reset",

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "back": "Volver"
+  },
   "shared": {
     "available": "Disponible",
     "notAvailable": "No disponible",
@@ -1321,8 +1324,8 @@
     "sortBy": "Ordenar por : ",
     "sortByShort": "Ordenar por",
     "recommended": "Recomendado",
-    "priceLowToHigh": "Precio: Menor a Mayor",
-    "priceHighToLow": "Precio: Mayor a Menor",
+    "priceLowToHigh": "Precio de menor a mayor",
+    "priceHighToLow": "Precio de mayor a menor",
     "newest": "Más recientes",
     "ratings": "Calificaciones",
     "reset": "Restablecer",

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "back": "Voltar"
+  },
   "shared": {
     "available": "Disponível",
     "notAvailable": "Não disponível",
@@ -1161,8 +1164,8 @@
     "sortBy": "Classificar por: ",
     "sortByShort": "Classificar por",
     "recommended": "Recomendados",
-    "priceLowToHigh": "Preço: Menor para Maior",
-    "priceHighToLow": "Preço: Maior para Menor",
+    "priceLowToHigh": "Preço do menor ao maior",
+    "priceHighToLow": "Preço do maior ao menor",
     "newest": "Mais recentes",
     "ratings": "Classificações",
     "reset": "Limpar",

--- a/src/app/pages/clients/list-tours/list-tours.component.html
+++ b/src/app/pages/clients/list-tours/list-tours.component.html
@@ -375,57 +375,36 @@
                     <div class="d-flex align-items-center justify-content-between flex-wrap">
                         <h6 class="mb-3">{{ tours.length }} {{ 'filters.toursFound' | translate }}</h6>
                         <div class="d-flex align-items-center flex-wrap">
-                            <div class="list-item d-flex align-items-center mb-3">
-                                <a href="javascript:void(0);" class="list-icon me-2"
-                                    [ngClass]="{ active: viewMode === 'grid' }" (click)="setViewMode('grid')">
-                                    <i class="isax isax-grid-1"></i>
-                                </a>
-                                <a href="javascript:void(0);" class="list-icon me-2"
-                                    [ngClass]="{ active: viewMode === 'list' }" (click)="setViewMode('list')">
-                                    <i class="isax isax-firstline"></i>
-                                </a>
-                            </div>
+                            <!-- TC-017 (#220): quitados los toggles grid/list a pedido de Luis. viewMode default = 'grid'. -->
                             <div class="dropdown mb-3">
                                 <a href="javascript:void(0);" class="dropdown-toggle py-2" data-bs-toggle="dropdown"
                                     aria-expanded="false">
-                                    <span class="fw-medium text-gray-9">{{ 'toursList.sortBy' | translate }}</span>{{ 'toursList.recommended' | translate }}
+                                    <span class="fw-medium text-gray-9">{{ 'toursList.sortBy' | translate }}</span>{{ getSortOptionLabel() | translate }}
                                 </a>
                                 <div class="dropdown-menu dropdown-sm">
                                     <form>
                                         <h6 class="fw-medium fs-16 mb-3">{{ 'toursList.sortByShort' | translate }}</h6>
+                                        <!-- TC-017 (#220): sort en cliente sobre this.tours. Radios para asegurar exclusividad. -->
                                         <div class="form-check d-flex align-items-center ps-0 mb-2">
-                                            <input class="form-check-input ms-0 mt-0" name="recommend" type="checkbox"
-                                                id="recommend1" checked>
-                                            <label class="form-check-label ms-2" for="recommend1">{{ 'toursList.recommended' | translate }}</label>
+                                            <input class="form-check-input ms-0 mt-0" name="sortOption" type="radio"
+                                                id="sort_recommended" value="recommended"
+                                                [checked]="sortOption === 'recommended'"
+                                                (change)="onSortOptionChange('recommended')">
+                                            <label class="form-check-label ms-2" for="sort_recommended">{{ 'toursList.recommended' | translate }}</label>
                                         </div>
                                         <div class="form-check d-flex align-items-center ps-0 mb-2">
-                                            <input class="form-check-input ms-0 mt-0" name="recommend" type="checkbox"
-                                                id="recommend2">
-                                            <label class="form-check-label ms-2" for="recommend2">{{ 'toursList.priceLowToHigh' | translate }}</label>
-                                        </div>
-                                        <div class="form-check d-flex align-items-center ps-0 mb-2">
-                                            <input class="form-check-input ms-0 mt-0" name="recommend" type="checkbox"
-                                                id="recommend3">
-                                            <label class="form-check-label ms-2" for="recommend3">{{ 'toursList.priceHighToLow' | translate }}</label>
-                                        </div>
-                                        <div class="form-check d-flex align-items-center ps-0 mb-2">
-                                            <input class="form-check-input ms-0 mt-0" name="recommend" type="checkbox"
-                                                id="recommend4">
-                                            <label class="form-check-label ms-2" for="recommend4">{{ 'toursList.newest' | translate }}</label>
-                                        </div>
-                                        <div class="form-check d-flex align-items-center ps-0 mb-2">
-                                            <input class="form-check-input ms-0 mt-0" name="recommend" type="checkbox"
-                                                id="recommend5">
-                                            <label class="form-check-label ms-2" for="recommend5">{{ 'toursList.ratings' | translate }}</label>
+                                            <input class="form-check-input ms-0 mt-0" name="sortOption" type="radio"
+                                                id="sort_price_asc" value="price_asc"
+                                                [checked]="sortOption === 'price_asc'"
+                                                (change)="onSortOptionChange('price_asc')">
+                                            <label class="form-check-label ms-2" for="sort_price_asc">{{ 'toursList.priceLowToHigh' | translate }}</label>
                                         </div>
                                         <div class="form-check d-flex align-items-center ps-0 mb-0">
-                                            <input class="form-check-input ms-0 mt-0" name="recommend" type="checkbox"
-                                                id="recommend6">
-                                            <label class="form-check-label ms-2" for="recommend6">{{ 'toursList.reviews' | translate }}</label>
-                                        </div>
-                                        <div class="d-flex align-items-center justify-content-end border-top pt-3 mt-3">
-                                            <a href="javascript:void(0);" class="btn btn-light btn-sm me-2">{{ 'toursList.reset' | translate }}</a>
-                                            <button type="submit" class="btn btn-primary btn-sm">{{ 'toursList.apply' | translate }}</button>
+                                            <input class="form-check-input ms-0 mt-0" name="sortOption" type="radio"
+                                                id="sort_price_desc" value="price_desc"
+                                                [checked]="sortOption === 'price_desc'"
+                                                (change)="onSortOptionChange('price_desc')">
+                                            <label class="form-check-label ms-2" for="sort_price_desc">{{ 'toursList.priceHighToLow' | translate }}</label>
                                         </div>
                                     </form>
                                 </div>

--- a/src/app/pages/clients/list-tours/list-tours.component.ts
+++ b/src/app/pages/clients/list-tours/list-tours.component.ts
@@ -240,6 +240,10 @@ export class ListToursComponent implements OnInit, OnDestroy {
   public wishlistIds: number[] = [];
   public favoriteStates: boolean[] = [];
 
+  // TC-017 (#220): sort en cliente sobre la pagina actual (recommended = orden del backend).
+  public sortOption: 'recommended' | 'price_asc' | 'price_desc' = 'recommended';
+  private originalTours: TourScheduleResponseDto[] = [];
+
   constructor(
     private fb: FormBuilder,
     private route: ActivatedRoute,
@@ -676,6 +680,44 @@ export class ListToursComponent implements OnInit, OnDestroy {
     this.viewMode = mode;
   }
 
+  // TC-017 (#220): sort dropdown handlers.
+  // Ordenamos sobre la pagina actual (client-side). 'recommended' devuelve el orden del backend.
+  onSortOptionChange(option: 'recommended' | 'price_asc' | 'price_desc'): void {
+    this.sortOption = option;
+    this.tours = this.applySort(this.originalTours);
+    this.updateFavoriteStates();
+  }
+
+  getSortOptionLabel(): string {
+    switch (this.sortOption) {
+      case 'price_asc':
+        return 'toursList.priceLowToHigh';
+      case 'price_desc':
+        return 'toursList.priceHighToLow';
+      case 'recommended':
+      default:
+        return 'toursList.recommended';
+    }
+  }
+
+  private applySort(source: TourScheduleResponseDto[]): TourScheduleResponseDto[] {
+    if (!source || source.length === 0) return [];
+    const arr = [...source];
+    if (this.sortOption === 'price_asc') {
+      arr.sort((a, b) => this.getPriceForSort(a) - this.getPriceForSort(b));
+    } else if (this.sortOption === 'price_desc') {
+      arr.sort((a, b) => this.getPriceForSort(b) - this.getPriceForSort(a));
+    }
+    return arr;
+  }
+
+  private getPriceForSort(item: TourScheduleResponseDto): number {
+    const price = item?.tour?.priceFrom;
+    if (price === null || price === undefined) return Number.MAX_SAFE_INTEGER;
+    const num = typeof price === 'number' ? price : Number(price);
+    return isNaN(num) ? Number.MAX_SAFE_INTEGER : num;
+  }
+
   // Event handlers for tour-list-view component
   onToggleFavorite(index: number): void {
     this.toggleClass(index);
@@ -909,7 +951,8 @@ export class ListToursComponent implements OnInit, OnDestroy {
         console.log("Respuesta completa de searchTours:", response);
 
         if (response && response.content) {
-          this.tours = response.content || [];
+          this.originalTours = response.content || [];
+          this.tours = this.applySort(this.originalTours);
           this.totalItems = response.totalElements || 0;
           this.totalPages = response.totalPages || 0;
           this.currentPage = response.number + 1;

--- a/src/app/pages/clients/tours-detail/tours-detail.component.html
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.html
@@ -1,6 +1,12 @@
     <!-- Page Wrapper -->
     <div class="content" *ngIf="tour">
         <div class="container" >
+            <!-- TC-017 (#220): boton "Volver" para regresar al listado. -->
+            <div class="mb-3">
+                <button type="button" class="btn btn-outline-primary btn-sm d-inline-flex align-items-center" (click)="goBack()">
+                    <i class="fa-solid fa-chevron-left me-2"></i>{{ 'common.back' | translate }}
+                </button>
+            </div>
             <!-- Breadcrumb Navigation -->
             <nav aria-label="breadcrumb" class="mb-3">
                 <ol class="breadcrumb justify-content-center mb-0" style="--bs-breadcrumb-item-active-color: #000; --bs-breadcrumb-divider-color: #000;">

--- a/src/app/pages/clients/tours-detail/tours-detail.component.ts
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, OnDestroy, AfterViewChecked } from '@angular/core';
+import { Location } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
 // usando @angular/google-maps para mapa nativo
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
@@ -168,8 +169,22 @@ export class ToursDetailComponent implements OnInit, OnDestroy, AfterViewChecked
     private reviewsService: ReviewsService,
     private touristService: TouristService,
     private snackBar: MatSnackBar,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private location: Location
   ) {}
+
+  /**
+   * TC-017 (#220): boton "Volver" en el detalle del tour.
+   * Usa history.back cuando hay historial; cae al listado si el usuario
+   * abrio la URL directo (sin history previa) o si es el primer entry.
+   */
+  public goBack(): void {
+    if (window.history.length > 1) {
+      this.location.back();
+    } else {
+      this.router.navigate([routes.listTours]);
+    }
+  }
 
   // Reviews data
   reviews: ProviderReview[] = [];


### PR DESCRIPTION
## Summary
Refinamientos UI/UX pedidos por Luis en TC-017 #220 (comentario 2026-08-12) tras validar el mapa Hotel Pickup + i18n priceType.

- **Item 1 — Ordenamiento por precio en list-tours**: dropdown de orden ahora ofrece dos opciones explicitas y separadas: `Precio de menor a mayor` y `Precio de mayor a menor`, junto con `Recomendado`. Se convirtieron los checkboxes en radios (exclusion mutua). El sort corre client-side sobre la pagina actual usando `tour.tour.priceFrom`; `Recomendado` deja el orden original del backend. El toggle del dropdown refleja la opcion activa.
- **Item 2 — Botones extras al lado del selector**: se quitaron los toggles grid/list que quedaron obsoletos (viewMode default = `grid`).
- **Item 3 — Boton Volver en tour-details**: nuevo boton arriba del breadcrumb que usa `Location.back()` cuando hay history; fallback a `/clients/list-tours` si el usuario abrio la URL directo.

## i18n
- Actualiza `toursList.priceLowToHigh` y `toursList.priceHighToLow` en `es/en/pt.json` al wording exacto pedido por Luis.
- Agrega `common.back` en `es/en/pt.json` ("Volver" / "Back" / "Voltar").

## Archivos tocados
- `public/i18n/{es,en,pt}.json`
- `src/app/pages/clients/list-tours/list-tours.component.{html,ts}`
- `src/app/pages/clients/tours-detail/tours-detail.component.{html,ts}`

## Test plan
- [ ] `npx ng build --configuration=production` verde (ya validado localmente).
- [ ] `/clients/list-tours`: abrir el dropdown "Ordenar por", verificar 3 opciones (Recomendado / Precio menor-mayor / Precio mayor-menor).
- [ ] Seleccionar "Precio de menor a mayor" -> tours mas baratos primero; "Precio de mayor a menor" -> tours mas caros primero; "Recomendado" -> orden original del backend.
- [ ] Verificar que ya no aparecen los iconos grid/list al lado del selector.
- [ ] `/clients/tours-detail/{id}` desde el listado: hay boton "Volver" arriba, hace back al listado.
- [ ] Abrir `/clients/tours-detail/{id}` directo (URL fresca) -> boton "Volver" cae al listado.
- [ ] Cambiar idioma UI ES/EN/PT y confirmar que los 3 labels nuevos cambian.
- [ ] Regresiones: mensaje Hotel Pickup, i18n priceType, mapa oculto en Hotel Pickup siguen funcionando.