### PR TITLE
fix(TC-017 #220): quitar opcion Recomendado + default vacio en selector orden

### DIFF
--- a/src/app/pages/clients/list-tours/list-tours.component.html
+++ b/src/app/pages/clients/list-tours/list-tours.component.html
@@ -384,14 +384,8 @@
                                 <div class="dropdown-menu dropdown-sm">
                                     <form>
                                         <h6 class="fw-medium fs-16 mb-3">{{ 'toursList.sortByShort' | translate }}</h6>
-                                        <!-- TC-017 (#220): sort en cliente sobre this.tours. Radios para asegurar exclusividad. -->
-                                        <div class="form-check d-flex align-items-center ps-0 mb-2">
-                                            <input class="form-check-input ms-0 mt-0" name="sortOption" type="radio"
-                                                id="sort_recommended" value="recommended"
-                                                [checked]="sortOption === 'recommended'"
-                                                (change)="onSortOptionChange('recommended')">
-                                            <label class="form-check-label ms-2" for="sort_recommended">{{ 'toursList.recommended' | translate }}</label>
-                                        </div>
+                                        <!-- TC-017 (#220): sort en cliente sobre this.tours. Radios para asegurar exclusividad.
+                                             Sin default seleccionado: si el usuario no elige, la lista respeta el orden del backend. -->
                                         <div class="form-check d-flex align-items-center ps-0 mb-2">
                                             <input class="form-check-input ms-0 mt-0" name="sortOption" type="radio"
                                                 id="sort_price_asc" value="price_asc"

--- a/src/app/pages/clients/list-tours/list-tours.component.ts
+++ b/src/app/pages/clients/list-tours/list-tours.component.ts
@@ -240,8 +240,10 @@ export class ListToursComponent implements OnInit, OnDestroy {
   public wishlistIds: number[] = [];
   public favoriteStates: boolean[] = [];
 
-  // TC-017 (#220): sort en cliente sobre la pagina actual (recommended = orden del backend).
-  public sortOption: 'recommended' | 'price_asc' | 'price_desc' = 'recommended';
+  // TC-017 (#220): sort en cliente sobre la pagina actual.
+  // Default '' = sin ordenar (respeta el orden que trae el backend). Luis 13-ago pidio quitar
+  // la opcion "Recomendado" — el estado no-seleccionado ya expresa lo mismo sin ambiguedad.
+  public sortOption: '' | 'price_asc' | 'price_desc' = '';
   private originalTours: TourScheduleResponseDto[] = [];
 
   constructor(
@@ -680,9 +682,9 @@ export class ListToursComponent implements OnInit, OnDestroy {
     this.viewMode = mode;
   }
 
-  // TC-017 (#220): sort dropdown handlers.
-  // Ordenamos sobre la pagina actual (client-side). 'recommended' devuelve el orden del backend.
-  onSortOptionChange(option: 'recommended' | 'price_asc' | 'price_desc'): void {
+  // TC-017 (#220): sort dropdown handlers. Ordenamos sobre la pagina actual (client-side).
+  // Estado '' = sin ordenar (respeta orden del backend).
+  onSortOptionChange(option: '' | 'price_asc' | 'price_desc'): void {
     this.sortOption = option;
     this.tours = this.applySort(this.originalTours);
     this.updateFavoriteStates();
@@ -694,9 +696,8 @@ export class ListToursComponent implements OnInit, OnDestroy {
         return 'toursList.priceLowToHigh';
       case 'price_desc':
         return 'toursList.priceHighToLow';
-      case 'recommended':
       default:
-        return 'toursList.recommended';
+        return '';
     }
   }
 


### PR DESCRIPTION
## Feedback Luis (2026-08-13T12:07 en #220)

> \"funciono correctamente. Lo ultimo es quitar la opción de ordenar 'Recomendado'. por default la consulta no se debe ordenar por alguna opción por default. el selector de ordenar debe tener las siguientes opciones:
> 1. debe estar vacío (indica que la consulta no se ordena)
> 2. Precio: de menor a mayor.
> 3. Precio: de mayor a menor.\"

## Cambios (2 archivos, +7/-10)

**`list-tours.component.ts`:**
- Tipo \`sortOption: '' | 'price_asc' | 'price_desc'\` (era \`'recommended' | ...\`).
- Default \`= ''\` (era \`= 'recommended'\`).
- \`getSortOptionLabel()\` retorna \`''\` cuando no hay sort — el toggle del dropdown solo muestra \"Ordenar por\" sin label extra.
- \`applySort\` sin cambios — ya devolvia el array intacto cuando \`sortOption\` no era \`price_asc\`/\`price_desc\`.

**`list-tours.component.html`:**
- Eliminado el bloque \`<div class=\"form-check\">\` del radio \"Recomendado\".
- Los 2 radios restantes (\`price_asc\`, \`price_desc\`) ya no tienen ninguno checked por default.

## Estado esperado tras deploy

1. Dropdown \"Ordenar por\" abre con 2 opciones: \"Precio de menor a mayor\" y \"Precio de mayor a menor\" — sin default.
2. Si el usuario no clickea nada, la lista respeta el orden del backend (paginado).
3. Al elegir una de las 2, aplica sort client-side sobre la pagina actual.

Key i18n \`toursList.recommended\` queda huerfana pero se deja para no romper otras referencias eventuales — se puede limpiar en un cleanup posterior si nadie mas la usa.

## Test plan
- [ ] Deploy → abrir \`/list-tours\`. Dropdown \"Ordenar por\" abre con solo 2 radios, ninguno seleccionado.
- [ ] Sin elegir nada → orden del backend.
- [ ] Elegir \"Precio menor a mayor\" → tours ordenados asc por priceFrom.
- [ ] Elegir \"Precio mayor a menor\" → tours ordenados desc.
- [ ] Cambiar idioma UI ES/EN/PT → labels traducidos.

Build production verde local.