### PR TITLE
feat(TC-022 #253): flujo devolucion creditos UI

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -246,7 +246,18 @@
       "providerPayments": "Payment Orders",
       "bookings": "Bookings",
       "backofficeUsers": "Backoffice Users",
+      "credits": "Credits",
       "appConfig": "System Configuration"
+    },
+    "menu": {
+      "credits": "Credits"
+    },
+    "credits": {
+      "title": "Credit Management",
+      "subtitle": "Total credits",
+      "colTourist": "Tourist",
+      "colReserved": "Reserved",
+      "colAvailable": "Available"
     }
   },
   "provider-tour-management": {
@@ -1607,6 +1618,7 @@
     "colCreationDate": "Creation Date",
     "colExpirationDate": "Expiration date",
     "colStatus": "Status",
+    "colActions": "Actions",
     "noCreditsFound": "No credits found",
     "selectedCount": "Selected",
     "totalSelected": "Total",
@@ -1623,6 +1635,33 @@
       "applied": "Applied",
       "consumed": "Consumed",
       "expired": "Expired"
+    }
+  },
+  "credit": {
+    "status": {
+      "refundRequested": "Refund requested",
+      "refunded": "Refunded"
+    },
+    "actions": {
+      "requestRefund": "Request refund",
+      "uploadProof": "Upload proof",
+      "viewProof": "View proof"
+    },
+    "confirm": {
+      "requestRefund": "Are you sure you want to request the cash refund of this credit? Once approved by Tourya, you will receive the amount in your bank account."
+    },
+    "toast": {
+      "refundRequested": "Request sent"
+    },
+    "upload": {
+      "helper": "Upload the refund proof (JPG/PNG image or PDF, max 5MB) for the tourist.",
+      "fileLabel": "Proof file",
+      "constraints": "Allowed formats: JPG, PNG, PDF. Max size: 5MB.",
+      "submit": "Upload",
+      "success": "Proof uploaded successfully",
+      "errorType": "File type not allowed. Use JPG, PNG or PDF.",
+      "errorSize": "File exceeds the 5MB maximum size.",
+      "noPreview": "No preview (PDF file)"
     }
   },
   "bookingTours": {

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -247,7 +247,18 @@
       "providerPayments": "Órdenes de pago",
       "bookings": "Reservas",
       "backofficeUsers": "Usuarios Backoffice",
+      "credits": "Créditos",
       "appConfig": "Configuración del sistema"
+    },
+    "menu": {
+      "credits": "Créditos"
+    },
+    "credits": {
+      "title": "Gestión de Créditos",
+      "subtitle": "Total de créditos",
+      "colTourist": "Turista",
+      "colReserved": "Reservado",
+      "colAvailable": "Disponible"
     }
   },
   "provider-tour-management": {
@@ -1608,6 +1619,7 @@
     "colCreationDate": "Fecha de creación",
     "colExpirationDate": "Fecha de expiración",
     "colStatus": "Estado",
+    "colActions": "Acciones",
     "noCreditsFound": "No se encontraron créditos",
     "selectedCount": "Seleccionados",
     "totalSelected": "Total",
@@ -1624,6 +1636,33 @@
       "applied": "Aplicado",
       "consumed": "Consumido",
       "expired": "Expirado"
+    }
+  },
+  "credit": {
+    "status": {
+      "refundRequested": "Solicitud de devolución",
+      "refunded": "Dinero devuelto"
+    },
+    "actions": {
+      "requestRefund": "Solicitar devolución",
+      "uploadProof": "Subir comprobante",
+      "viewProof": "Ver comprobante"
+    },
+    "confirm": {
+      "requestRefund": "¿Estás seguro que deseas solicitar la devolución en efectivo de este crédito? Una vez aprobado por Tourya, recibirás el monto en tu cuenta bancaria."
+    },
+    "toast": {
+      "refundRequested": "Solicitud enviada"
+    },
+    "upload": {
+      "helper": "Sube el comprobante (imagen JPG/PNG o PDF, máx 5MB) de la devolución realizada al turista.",
+      "fileLabel": "Archivo de comprobante",
+      "constraints": "Formatos permitidos: JPG, PNG, PDF. Tamaño máximo: 5MB.",
+      "submit": "Subir",
+      "success": "Comprobante subido correctamente",
+      "errorType": "Tipo de archivo no permitido. Usa JPG, PNG o PDF.",
+      "errorSize": "El archivo excede el tamaño máximo de 5MB.",
+      "noPreview": "Sin previsualización (archivo PDF)"
     }
   },
   "bookingTours": {

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -246,7 +246,18 @@
       "providerPayments": "Ordens de Pagamento",
       "bookings": "Reservas",
       "backofficeUsers": "Usuários Backoffice",
+      "credits": "Créditos",
       "appConfig": "Configuração do sistema"
+    },
+    "menu": {
+      "credits": "Créditos"
+    },
+    "credits": {
+      "title": "Gestão de Créditos",
+      "subtitle": "Total de créditos",
+      "colTourist": "Turista",
+      "colReserved": "Reservado",
+      "colAvailable": "Disponível"
     }
   },
   "provider-tour-management": {
@@ -1608,6 +1619,7 @@
     "colCreationDate": "Data de criação",
     "colExpirationDate": "Data de validade",
     "colStatus": "Status",
+    "colActions": "Ações",
     "noCreditsFound": "Nenhum crédito encontrado",
     "selectedCount": "Selecionados",
     "totalSelected": "Total",
@@ -1624,6 +1636,33 @@
       "applied": "Aplicado",
       "consumed": "Consumido",
       "expired": "Expirado"
+    }
+  },
+  "credit": {
+    "status": {
+      "refundRequested": "Solicitação de devolução",
+      "refunded": "Dinheiro devolvido"
+    },
+    "actions": {
+      "requestRefund": "Solicitar devolução",
+      "uploadProof": "Enviar comprovante",
+      "viewProof": "Ver comprovante"
+    },
+    "confirm": {
+      "requestRefund": "Tem certeza de que deseja solicitar a devolução em dinheiro deste crédito? Uma vez aprovado pela Tourya, você receberá o valor em sua conta bancária."
+    },
+    "toast": {
+      "refundRequested": "Solicitação enviada"
+    },
+    "upload": {
+      "helper": "Envie o comprovante (imagem JPG/PNG ou PDF, máx 5MB) da devolução ao turista.",
+      "fileLabel": "Arquivo do comprovante",
+      "constraints": "Formatos permitidos: JPG, PNG, PDF. Tamanho máximo: 5MB.",
+      "submit": "Enviar",
+      "success": "Comprovante enviado com sucesso",
+      "errorType": "Tipo de arquivo não permitido. Use JPG, PNG ou PDF.",
+      "errorSize": "O arquivo excede o tamanho máximo de 5MB.",
+      "noPreview": "Sem prévia (arquivo PDF)"
     }
   },
   "bookingTours": {

--- a/src/app/pages/admin/admin-credits/admin-credits.component.html
+++ b/src/app/pages/admin/admin-credits/admin-credits.component.html
@@ -1,0 +1,226 @@
+<!-- TC-022: Admin/Backoffice - Gestion de creditos y devoluciones -->
+<div class="admin-credits">
+
+    <!-- Header -->
+    <div class="card mb-4">
+        <div class="card-body">
+            <div class="d-flex justify-content-between align-items-center flex-wrap row-gap-3">
+                <div>
+                    <h5 class="mb-1">{{ 'admin.credits.title' | translate }}</h5>
+                    <p class="fs-14 text-gray-6 mb-0">
+                        {{ 'admin.credits.subtitle' | translate }}:
+                        <span class="fw-semibold text-dark">{{ totalElements }}</span>
+                    </p>
+                </div>
+                <div class="d-flex align-items-center flex-wrap gap-2">
+                    <label for="statusFilter" class="fs-14 fw-medium mb-0">
+                        {{ 'clientCredits.statusLabel' | translate }}
+                    </label>
+                    <select
+                        id="statusFilter"
+                        class="form-select form-select-sm w-auto"
+                        [ngModel]="selectedStatus"
+                        (ngModelChange)="onStatusChange($event)">
+                        @for (status of statusOptions; track status) {
+                            <option [value]="status">{{ getStatusOptionLabel(status) }}</option>
+                        }
+                    </select>
+                </div>
+            </div>
+        </div>
+    </div>
+    <!-- /Header -->
+
+    <!-- Credits Table -->
+    <div class="card">
+        <div class="card-body p-0">
+            <div class="custom-datatable-filter table-responsive">
+                @if (loading) {
+                    <div class="text-center py-5">
+                        <div class="spinner-border text-primary" role="status">
+                            <span class="visually-hidden">{{ 'cartSummary.loading' | translate }}</span>
+                        </div>
+                        <p class="mt-2 text-muted">{{ 'cartSummary.loading' | translate }}</p>
+                    </div>
+                } @else if (errorMessage) {
+                    <div class="alert alert-danger m-3">{{ errorMessage }}</div>
+                } @else {
+                    <table class="table datatable align-middle">
+                        <thead class="thead-light">
+                            <tr>
+                                <th>{{ 'clientCredits.colId' | translate }}</th>
+                                <th>{{ 'admin.credits.colTourist' | translate }}</th>
+                                <th>{{ 'clientCredits.colValue' | translate }}</th>
+                                <th>{{ 'admin.credits.colReserved' | translate }}</th>
+                                <th>{{ 'admin.credits.colAvailable' | translate }}</th>
+                                <th>{{ 'clientCredits.colStatus' | translate }}</th>
+                                <th>{{ 'clientCredits.colCreationDate' | translate }}</th>
+                                <th>{{ 'clientCredits.colActions' | translate }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @for (credit of credits; track credit.id) {
+                                <tr>
+                                    <td>#{{ credit.id }}</td>
+                                    <td>
+                                        <div class="fw-medium">{{ credit.touristName || '-' }}</div>
+                                        <div class="fs-12 text-muted">{{ credit.touristEmail || '' }}</div>
+                                    </td>
+                                    <td class="fw-semibold">{{ credit.amount | currency:'COP':'symbol':'1.0-0' }}</td>
+                                    <td>{{ (credit.reservedAmount ?? 0) | currency:'COP':'symbol':'1.0-0' }}</td>
+                                    <td class="text-success fw-medium">
+                                        {{ (credit.amount - (credit.reservedAmount ?? 0)) | currency:'COP':'symbol':'1.0-0' }}
+                                    </td>
+                                    <td>
+                                        <span class="badge rounded-pill d-inline-flex align-items-center fs-10"
+                                              [ngClass]="getStatusClass(credit.status)">
+                                            <i class="fa-solid fa-circle fs-5 me-1"></i>
+                                            {{ getStatusLabel(credit.status) }}
+                                        </span>
+                                    </td>
+                                    <td>{{ credit.creationDate | date:'dd/MM/yyyy' }}</td>
+                                    <td>
+                                        @if (credit.status.toUpperCase() === 'REFUND_REQUESTED') {
+                                            <button
+                                                class="btn btn-sm btn-primary d-inline-flex align-items-center"
+                                                (click)="openUploadModal(credit)"
+                                                [attr.title]="'credit.actions.uploadProof' | translate">
+                                                <i class="isax isax-document-upload me-1"></i>
+                                                {{ 'credit.actions.uploadProof' | translate }}
+                                            </button>
+                                        } @else if (credit.status.toUpperCase() === 'REFUNDED' && credit.refundProofUrl) {
+                                            <a [href]="credit.refundProofUrl" target="_blank" rel="noopener"
+                                               class="btn btn-sm btn-outline-primary d-inline-flex align-items-center">
+                                                <i class="isax isax-document-text me-1"></i>
+                                                {{ 'credit.actions.viewProof' | translate }}
+                                            </a>
+                                        } @else {
+                                            <span class="text-muted fs-12">-</span>
+                                        }
+                                    </td>
+                                </tr>
+                            }
+                            @if (credits.length === 0) {
+                                <tr>
+                                    <td colspan="8" class="text-center py-5">
+                                        <div class="text-muted">
+                                            <i class="isax isax-box fs-1 mb-3 d-block"></i>
+                                            <h5>{{ 'clientCredits.noCreditsFound' | translate }}</h5>
+                                        </div>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                }
+            </div>
+
+            <!-- Pagination -->
+            @if (!loading && totalPages > 1) {
+                <nav class="pagination-nav p-3 border-top">
+                    <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+                        <span class="fs-12 text-muted">
+                            {{ pageStart }} - {{ pageEnd }} / {{ totalElements }}
+                        </span>
+                        <ul class="pagination mb-0">
+                            <li class="page-item" [class.disabled]="page === 0">
+                                <button class="page-link" (click)="onPageChange(page - 1)" [disabled]="page === 0">
+                                    <i class="fa-solid fa-chevron-left"></i>
+                                </button>
+                            </li>
+                            <li class="page-item active">
+                                <span class="page-link">{{ displayPage }} / {{ totalPages }}</span>
+                            </li>
+                            <li class="page-item" [class.disabled]="page >= totalPages - 1">
+                                <button class="page-link" (click)="onPageChange(page + 1)" [disabled]="page >= totalPages - 1">
+                                    <i class="fa-solid fa-chevron-right"></i>
+                                </button>
+                            </li>
+                        </ul>
+                    </div>
+                </nav>
+            }
+        </div>
+    </div>
+
+</div>
+
+<!-- Upload Refund Proof Modal -->
+@if (showUploadModal && uploadTarget) {
+    <div class="modal fade show d-block" tabindex="-1" role="dialog" style="background: rgba(0,0,0,0.5);">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">
+                        {{ 'credit.actions.uploadProof' | translate }} - #{{ uploadTarget.id }}
+                    </h5>
+                    <button type="button" class="btn-close" (click)="closeUploadModal()" [disabled]="uploadInFlight"></button>
+                </div>
+                <div class="modal-body">
+                    <p class="fs-14 text-muted mb-3">
+                        {{ 'credit.upload.helper' | translate }}
+                    </p>
+
+                    <div class="mb-3">
+                        <label class="form-label fw-medium">
+                            {{ 'admin.credits.colTourist' | translate }}
+                        </label>
+                        <div>{{ uploadTarget.touristName }} <span class="text-muted">({{ uploadTarget.touristEmail }})</span></div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label fw-medium">
+                            {{ 'clientCredits.colValue' | translate }}
+                        </label>
+                        <div class="fw-semibold text-success">
+                            {{ uploadTarget.amount | currency:'COP':'symbol':'1.0-0' }}
+                        </div>
+                    </div>
+
+                    <div class="mb-3">
+                        <label for="proofFile" class="form-label fw-medium">
+                            {{ 'credit.upload.fileLabel' | translate }}
+                        </label>
+                        <input
+                            id="proofFile"
+                            type="file"
+                            class="form-control"
+                            accept="image/jpeg,image/png,application/pdf"
+                            (change)="onFileSelected($event)"
+                            [disabled]="uploadInFlight">
+                        <div class="form-text">{{ 'credit.upload.constraints' | translate }}</div>
+                    </div>
+
+                    @if (selectedFile) {
+                        <div class="border rounded p-2">
+                            <div class="fs-12 text-muted mb-1">
+                                {{ selectedFile.name }} ({{ (selectedFile.size / 1024) | number:'1.0-0' }} KB)
+                            </div>
+                            @if (previewUrl) {
+                                <img [src]="previewUrl" alt="preview" class="img-fluid" style="max-height: 240px;">
+                            } @else {
+                                <div class="d-flex align-items-center text-muted">
+                                    <i class="isax isax-document-1 fs-3 me-2"></i>
+                                    <span>{{ 'credit.upload.noPreview' | translate }}</span>
+                                </div>
+                            }
+                        </div>
+                    }
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" (click)="closeUploadModal()" [disabled]="uploadInFlight">
+                        {{ 'shared.cancel' | translate }}
+                    </button>
+                    <button type="button" class="btn btn-primary d-inline-flex align-items-center"
+                            [disabled]="!selectedFile || uploadInFlight"
+                            (click)="submitUpload()">
+                        @if (uploadInFlight) {
+                            <span class="spinner-border spinner-border-sm me-1"></span>
+                        }
+                        {{ 'credit.upload.submit' | translate }}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+}

--- a/src/app/pages/admin/admin-credits/admin-credits.component.scss
+++ b/src/app/pages/admin/admin-credits/admin-credits.component.scss
@@ -1,0 +1,14 @@
+.admin-credits {
+    .table-responsive {
+        max-height: 600px;
+        overflow-y: auto;
+    }
+
+    .fs-10 {
+        font-size: 10px !important;
+    }
+}
+
+.modal.show.d-block {
+    z-index: 1055;
+}

--- a/src/app/pages/admin/admin-credits/admin-credits.component.ts
+++ b/src/app/pages/admin/admin-credits/admin-credits.component.ts
@@ -1,0 +1,266 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Subject, takeUntil } from 'rxjs';
+import Swal from 'sweetalert2';
+
+import { SharedModule } from '../../../shared/shared-module';
+import { CreditService } from '../../../shared/services/credit.service';
+import { AdminCreditsPageResponse, ClientCredit } from '../../../shared/models/credit.model';
+
+type AdminCreditStatus =
+  | 'ALL'
+  | 'CREATED'
+  | 'REFUND_REQUESTED'
+  | 'REFUNDED'
+  | 'CANCELED'
+  | 'EXPIRED'
+  | 'DELETED';
+
+/**
+ * TC-022: pantalla admin/backoffice para gestion del listado global de creditos
+ * de todos los turistas. Permite filtrar por status, paginar server-side, y
+ * cerrar el ciclo de devolucion subiendo un comprobante (imagen o PDF) para los
+ * creditos en status REFUND_REQUESTED.
+ *
+ * <p>Guardada por {@link import('../../../core/guards/backoffice.guard').BackofficeGuard},
+ * cubre ADMIN y BACKOFFICE_OPERATION. No expone datos del turista en la vista
+ * cliente (garantizado por el backend, que solo devuelve nombre/email en el
+ * endpoint /admin/credits).</p>
+ */
+@Component({
+  selector: 'app-admin-credits',
+  standalone: true,
+  imports: [CommonModule, FormsModule, SharedModule, TranslateModule],
+  templateUrl: './admin-credits.component.html',
+  styleUrls: ['./admin-credits.component.scss']
+})
+export class AdminCreditsComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+
+  // Datos y estado UI
+  public credits: ClientCredit[] = [];
+  public loading = false;
+  public errorMessage = '';
+
+  // Paginacion server-side (Spring Data: page es 0-based).
+  public page = 0;
+  public size = 10;
+  public totalElements = 0;
+  public totalPages = 0;
+
+  // Filtro
+  public selectedStatus: AdminCreditStatus = 'ALL';
+  public readonly statusOptions: AdminCreditStatus[] = [
+    'ALL',
+    'CREATED',
+    'REFUND_REQUESTED',
+    'REFUNDED',
+    'CANCELED',
+    'EXPIRED',
+    'DELETED'
+  ];
+
+  // Modal de subida de comprobante
+  public showUploadModal = false;
+  public uploadTarget: ClientCredit | null = null;
+  public selectedFile: File | null = null;
+  public previewUrl: string | null = null;
+  public uploadInFlight = false;
+
+  private readonly allowedMimeTypes = ['image/jpeg', 'image/png', 'application/pdf'];
+  private readonly maxFileSizeBytes = 5 * 1024 * 1024; // 5MB
+
+  constructor(
+    private creditService: CreditService,
+    private snackBar: MatSnackBar,
+    private translate: TranslateService
+  ) {}
+
+  ngOnInit(): void {
+    this.loadCredits();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+    this.revokePreview();
+  }
+
+  public loadCredits(): void {
+    this.loading = true;
+    this.errorMessage = '';
+    const statusParam = this.selectedStatus === 'ALL' ? undefined : this.selectedStatus;
+
+    this.creditService
+      .getAdminCredits(this.page, this.size, statusParam)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (response: AdminCreditsPageResponse) => {
+          this.credits = response.content || [];
+          this.totalElements = response.totalElements;
+          this.totalPages = response.totalPages;
+          this.loading = false;
+        },
+        error: (err) => {
+          console.error('Error loading admin credits', err);
+          this.errorMessage =
+            err?.error?.message || this.translate.instant('shared.messages.error');
+          this.loading = false;
+        }
+      });
+  }
+
+  public onStatusChange(status: AdminCreditStatus): void {
+    this.selectedStatus = status;
+    this.page = 0;
+    this.loadCredits();
+  }
+
+  public onPageChange(newPage: number): void {
+    if (newPage < 0 || newPage >= this.totalPages) return;
+    this.page = newPage;
+    this.loadCredits();
+  }
+
+  public getStatusClass(status: string): string {
+    switch (status?.toUpperCase()) {
+      case 'CREATED':
+        return 'bg-success-subtle text-success';
+      case 'REFUND_REQUESTED':
+        return 'bg-warning-subtle text-warning';
+      case 'REFUNDED':
+        return 'bg-primary-subtle text-primary';
+      case 'CANCELED':
+      case 'DELETED':
+        return 'bg-secondary-subtle text-secondary';
+      case 'EXPIRED':
+        return 'bg-danger-subtle text-danger';
+      default:
+        return 'bg-secondary-subtle text-secondary';
+    }
+  }
+
+  public getStatusLabel(status: string): string {
+    switch (status?.toUpperCase()) {
+      case 'CREATED':
+        return this.translate.instant('clientCredits.statuses.created');
+      case 'REFUND_REQUESTED':
+        return this.translate.instant('credit.status.refundRequested');
+      case 'REFUNDED':
+        return this.translate.instant('credit.status.refunded');
+      case 'CANCELED':
+        return this.translate.instant('clientCredits.statuses.canceled');
+      case 'EXPIRED':
+        return this.translate.instant('clientCredits.statuses.expired');
+      case 'DELETED':
+        return this.translate.instant('clientCredits.statuses.eliminated');
+      default:
+        return status;
+    }
+  }
+
+  public getStatusOptionLabel(status: AdminCreditStatus): string {
+    if (status === 'ALL') return this.translate.instant('clientCredits.allStatuses');
+    return this.getStatusLabel(status);
+  }
+
+  // ==== Modal comprobante ====
+  public openUploadModal(credit: ClientCredit): void {
+    this.uploadTarget = credit;
+    this.selectedFile = null;
+    this.revokePreview();
+    this.showUploadModal = true;
+  }
+
+  public closeUploadModal(): void {
+    this.showUploadModal = false;
+    this.uploadTarget = null;
+    this.selectedFile = null;
+    this.revokePreview();
+  }
+
+  public onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input?.files?.[0];
+    if (!file) return;
+
+    if (!this.allowedMimeTypes.includes(file.type)) {
+      this.snackBar.open(
+        this.translate.instant('credit.upload.errorType'),
+        'Ok',
+        { duration: 3000 }
+      );
+      input.value = '';
+      return;
+    }
+    if (file.size > this.maxFileSizeBytes) {
+      this.snackBar.open(
+        this.translate.instant('credit.upload.errorSize'),
+        'Ok',
+        { duration: 3000 }
+      );
+      input.value = '';
+      return;
+    }
+
+    this.selectedFile = file;
+    this.revokePreview();
+    if (file.type.startsWith('image/')) {
+      this.previewUrl = URL.createObjectURL(file);
+    } else {
+      // PDF: solo mostramos el nombre; no generamos preview grafico.
+      this.previewUrl = null;
+    }
+  }
+
+  public submitUpload(): void {
+    if (!this.uploadTarget || !this.selectedFile || this.uploadInFlight) return;
+    const target = this.uploadTarget;
+    this.uploadInFlight = true;
+
+    this.creditService.uploadRefundProof(target.id, this.selectedFile).subscribe({
+      next: () => {
+        this.uploadInFlight = false;
+        this.snackBar.open(
+          this.translate.instant('credit.upload.success'),
+          'Ok',
+          { duration: 3000 }
+        );
+        this.closeUploadModal();
+        this.loadCredits();
+      },
+      error: (err) => {
+        this.uploadInFlight = false;
+        const backendMsg = err?.error?.message || err?.error?.error || '';
+        Swal.fire({
+          icon: 'error',
+          title: this.translate.instant('shared.messages.error'),
+          text: backendMsg || this.translate.instant('shared.messages.error')
+        });
+      }
+    });
+  }
+
+  private revokePreview(): void {
+    if (this.previewUrl) {
+      URL.revokeObjectURL(this.previewUrl);
+      this.previewUrl = null;
+    }
+  }
+
+  // Helpers de paginacion (numeros 1-based para la UI).
+  public get displayPage(): number {
+    return this.page + 1;
+  }
+
+  public get pageStart(): number {
+    return this.credits.length === 0 ? 0 : this.page * this.size + 1;
+  }
+
+  public get pageEnd(): number {
+    return this.page * this.size + this.credits.length;
+  }
+}

--- a/src/app/pages/admin/admin-routing.module.ts
+++ b/src/app/pages/admin/admin-routing.module.ts
@@ -52,6 +52,12 @@ const routes: Routes = [
         path: 'backoffice-users',
         canActivate: [AdminGuard],
         loadComponent: () => import('./backoffice-users/backoffice-users.component').then(m => m.BackofficeUsersComponent)
+      },
+      // TC-022: gestion de creditos y devoluciones. Expuesto a ADMIN + BACKOFFICE_OPERATION.
+      {
+        path: 'credits',
+        canActivate: [BackofficeGuard],
+        loadComponent: () => import('./admin-credits/admin-credits.component').then(m => m.AdminCreditsComponent)
       }
     ]
   }

--- a/src/app/pages/admin/admin.component.html
+++ b/src/app/pages/admin/admin.component.html
@@ -46,6 +46,12 @@
                   <i class="isax isax-calendar-tick me-2"></i>{{ 'admin.sidebar.bookings' | translate }}
                 </a>
               </li>
+              <!-- TC-022: gestion de creditos (ADMIN + BACKOFFICE_OPERATION). -->
+              <li>
+                <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToCredits()">
+                  <i class="isax isax-money-recive me-2"></i>{{ 'admin.sidebar.credits' | translate }}
+                </a>
+              </li>
 
               <ng-container *ngIf="isAdmin">
                 <li>

--- a/src/app/pages/admin/admin.component.ts
+++ b/src/app/pages/admin/admin.component.ts
@@ -122,6 +122,11 @@ export class AdminComponent implements OnInit, OnDestroy {
     this.router.navigate(['/admin/bookings-management']);
   }
 
+  /** TC-022: gestion de creditos y devoluciones (BackofficeGuard). */
+  goToCredits(): void {
+    this.router.navigate(['/admin/credits']);
+  }
+
   /** Usuarios Backoffice (AdminGuard). */
   goToBackofficeUsers(): void {
     this.router.navigate(['/admin/backoffice-users']);

--- a/src/app/pages/clients/client-credits/client-credits.component.html
+++ b/src/app/pages/clients/client-credits/client-credits.component.html
@@ -1,6 +1,6 @@
 <!-- Credits Management -->
 <div class="provider-tour-management" [ngClass]="{'p-0': mode === 'payment'}">
-    
+
     <!-- Header (Hidden in payment mode) -->
     <div class="card booking-header mb-4" *ngIf="mode === 'profile'">
         <div class="card-body header-content d-flex align-items-center justify-content-between flex-wrap">
@@ -17,17 +17,20 @@
         <div class="card-body p-0">
             <div class="list-header d-flex align-items-center justify-content-between flex-wrap p-3" *ngIf="mode === 'profile'">
                 <h6 class="mb-0">{{ 'clientCredits.creditsList' | translate }}</h6>
-                
+
                 <!-- Status Filter -->
                 <div class="d-flex align-items-center">
                     <span class="fs-14 text-gray-9 fw-medium me-2">{{ 'clientCredits.statusLabel' | translate }}</span>
-                    <select 
-                        class="form-select form-select-sm w-auto" 
+                    <select
+                        class="form-select form-select-sm w-auto"
                         (change)="onStatusChange($event)"
                         [value]="selectedStatus">
                         <option value="">{{ 'clientCredits.allStatuses' | translate }}</option>
                         <option value="CREATED">{{ 'clientCredits.statuses.created' | translate }}</option>
+                        <option value="REFUND_REQUESTED">{{ 'credit.status.refundRequested' | translate }}</option>
+                        <option value="REFUNDED">{{ 'credit.status.refunded' | translate }}</option>
                         <option value="CANCELED">{{ 'clientCredits.statuses.canceled' | translate }}</option>
+                        <option value="EXPIRED">{{ 'clientCredits.statuses.expired' | translate }}</option>
                         <option value="DELETED">{{ 'clientCredits.statuses.eliminated' | translate }}</option>
                     </select>
                 </div>
@@ -50,6 +53,7 @@
                             <th>{{ 'clientCredits.colCreationDate' | translate }}</th>
                             <th *ngIf="mode === 'profile'">{{ 'clientCredits.colExpirationDate' | translate }}</th>
                             <th>{{ 'clientCredits.colStatus' | translate }}</th>
+                            <th *ngIf="mode === 'profile'">{{ 'clientCredits.colActions' | translate }}</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -66,16 +70,44 @@
                                 <td>{{ credit.creationDate | date:'dd/MM/yyyy' }}</td>
                                 <td *ngIf="mode === 'profile'">{{ credit.expirationDate | date:'dd/MM/yyyy' }}</td>
                                 <td>
-                                    <span class="badge rounded-pill d-inline-flex align-items-center fs-10" 
+                                    <span class="badge rounded-pill d-inline-flex align-items-center fs-10"
                                           [ngClass]="getStatusClass(credit.status)">
-                                        <i class="fa-solid fa-circle fs-5 me-1"></i>{{ 'clientCredits.statuses.' + credit.status.toLowerCase() | translate }}
+                                        <i class="fa-solid fa-circle fs-5 me-1"></i>
+                                        @if (credit.status.toUpperCase() === 'REFUND_REQUESTED' || credit.status.toUpperCase() === 'REFUNDED') {
+                                            {{ 'credit.status.' + getStatusI18nKey(credit.status) | translate }}
+                                        } @else {
+                                            {{ 'clientCredits.statuses.' + credit.status.toLowerCase() | translate }}
+                                        }
                                     </span>
+                                </td>
+                                <td *ngIf="mode === 'profile'">
+                                    @if (canRequestRefund(credit)) {
+                                        <button
+                                            class="btn btn-sm btn-outline-primary d-inline-flex align-items-center"
+                                            [disabled]="refundingCreditId === credit.id"
+                                            (click)="onRequestRefund(credit)">
+                                            @if (refundingCreditId === credit.id) {
+                                                <span class="spinner-border spinner-border-sm me-1"></span>
+                                            } @else {
+                                                <i class="isax isax-money-recive me-1"></i>
+                                            }
+                                            {{ 'credit.actions.requestRefund' | translate }}
+                                        </button>
+                                    } @else if (credit.status.toUpperCase() === 'REFUNDED' && credit.refundProofUrl) {
+                                        <a [href]="credit.refundProofUrl" target="_blank" rel="noopener"
+                                           class="btn btn-sm btn-outline-primary d-inline-flex align-items-center">
+                                            <i class="isax isax-document-text me-1"></i>
+                                            {{ 'credit.actions.viewProof' | translate }}
+                                        </a>
+                                    } @else {
+                                        <span class="text-muted fs-12">-</span>
+                                    }
                                 </td>
                             </tr>
                         }
                         @if (tableData.length === 0 && !isLoading) {
                             <tr>
-                                <td [attr.colspan]="mode === 'payment' ? 6 : 6" class="text-center py-5">
+                                <td [attr.colspan]="mode === 'payment' ? 6 : 7" class="text-center py-5">
                                     <div class="text-muted">
                                         <i class="isax isax-box fs-1 mb-3 d-block"></i>
                                         <h5>{{ 'clientCredits.noCreditsFound' | translate }}</h5>
@@ -85,7 +117,7 @@
                         }
                         @if (isLoading) {
                             <tr>
-                                <td [attr.colspan]="mode === 'payment' ? 6 : 6" class="text-center py-5">
+                                <td [attr.colspan]="mode === 'payment' ? 6 : 7" class="text-center py-5">
                                     <div class="spinner-border text-primary" role="status">
                                         <span class="visually-hidden">{{ 'cartSummary.loading' | translate }}</span>
                                     </div>
@@ -116,7 +148,7 @@
                         </button>
                     </div>
                 </div>
-                
+
                 <!-- Error Message -->
                 <div *ngIf="isExceedingMax" class="text-danger fs-12 mt-2">
                     <i class="fas fa-exclamation-triangle me-1"></i>

--- a/src/app/pages/clients/client-credits/client-credits.component.ts
+++ b/src/app/pages/clients/client-credits/client-credits.component.ts
@@ -1,7 +1,9 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { CreditService } from '../../../shared/services/credit.service';
 import { ClientCredit } from '../../../shared/models/credit.model';
-import { Sort } from '@angular/material/sort';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { TranslateService } from '@ngx-translate/core';
+import Swal from 'sweetalert2';
 
 @Component({
   selector: 'app-client-credits',
@@ -38,7 +40,14 @@ export class ClientCreditsComponent implements OnInit {
   // Filtro de estado
   public selectedStatus: string = '';
 
-  constructor(private creditService: CreditService) {}
+  // TC-022: id del credito cuya solicitud de devolucion esta procesando (loading local del boton).
+  public refundingCreditId: number | null = null;
+
+  constructor(
+    private creditService: CreditService,
+    private snackBar: MatSnackBar,
+    private translate: TranslateService
+  ) {}
 
   ngOnInit(): void {
     if (this.mode === 'profile') {
@@ -56,7 +65,7 @@ export class ClientCreditsComponent implements OnInit {
 
   private loadCredits(): void {
     this.isLoading = true;
-    
+
     // Pasar el status solo si no es vacío ('')
     const statusParam = this.selectedStatus ? this.selectedStatus : undefined;
 
@@ -78,6 +87,10 @@ export class ClientCreditsComponent implements OnInit {
     switch (status.toUpperCase()) {
       case 'CREATED':
         return 'bg-success-subtle text-success';
+      case 'REFUND_REQUESTED':
+        return 'bg-warning-subtle text-warning';
+      case 'REFUNDED':
+        return 'bg-primary-subtle text-primary';
       case 'USED':
       case 'APPLIED':
       case 'CONSUMED':
@@ -87,6 +100,73 @@ export class ClientCreditsComponent implements OnInit {
       default:
         return 'bg-warning-subtle text-warning';
     }
+  }
+
+  /**
+   * TC-022: la clave i18n `credit.status.*` sigue camelCase, mientras que la
+   * clave existente `clientCredits.statuses.*` es lowercase. Este helper devuelve
+   * el fragmento en camelCase (REFUND_REQUESTED -> refundRequested).
+   */
+  public getStatusI18nKey(status: string): string {
+    switch (status.toUpperCase()) {
+      case 'REFUND_REQUESTED':
+        return 'refundRequested';
+      case 'REFUNDED':
+        return 'refunded';
+      default:
+        return status.toLowerCase();
+    }
+  }
+
+  /**
+   * TC-022: un credito puede solicitar devolucion si esta CREATED y todavia tiene
+   * monto libre (no todo esta reservado). Si el backend no expone reservedAmount
+   * (opcional en el modelo), se asume 0 (todo el monto disponible).
+   */
+  public canRequestRefund(credit: ClientCredit): boolean {
+    const reserved = credit.reservedAmount ?? 0;
+    return credit.status?.toUpperCase() === 'CREATED' && credit.amount - reserved > 0;
+  }
+
+  /**
+   * TC-022: flujo turista solicita devolucion. Confirm SweetAlert2 -> POST
+   * /credits/{id}/request-refund -> toast + refresh en success, alert con mensaje
+   * del backend en error.
+   */
+  public onRequestRefund(credit: ClientCredit): void {
+    Swal.fire({
+      title: this.translate.instant('credit.actions.requestRefund'),
+      text: this.translate.instant('credit.confirm.requestRefund'),
+      icon: 'question',
+      showCancelButton: true,
+      confirmButtonText: this.translate.instant('credit.actions.requestRefund'),
+      cancelButtonText: this.translate.instant('shared.cancel'),
+      confirmButtonColor: '#3085d6'
+    }).then((result) => {
+      if (!result.isConfirmed) return;
+
+      this.refundingCreditId = credit.id;
+      this.creditService.requestRefund(credit.id).subscribe({
+        next: () => {
+          this.refundingCreditId = null;
+          this.snackBar.open(
+            this.translate.instant('credit.toast.refundRequested'),
+            'Ok',
+            { duration: 3000 }
+          );
+          this.loadCredits();
+        },
+        error: (err) => {
+          this.refundingCreditId = null;
+          const backendMsg = err?.error?.message || err?.error?.error || '';
+          Swal.fire({
+            icon: 'error',
+            title: this.translate.instant('shared.messages.error'),
+            text: backendMsg || this.translate.instant('shared.messages.error')
+          });
+        }
+      });
+    });
   }
 
   // Lógica de selección

--- a/src/app/shared/models/credit.model.ts
+++ b/src/app/shared/models/credit.model.ts
@@ -2,7 +2,48 @@ export interface ClientCredit {
   id: number;
   reservationId: number;
   amount: number;
+  /**
+   * TC-022: monto ya reservado del credito (usado en reservas activas).
+   * Solo disponible cuando el backend lo expone; opcional para compatibilidad.
+   */
+  reservedAmount?: number;
   creationDate: string;
   expirationDate: string;
   status: string;
+  /**
+   * TC-022: fecha en que el turista solicito devolucion (status REFUND_REQUESTED).
+   */
+  refundRequestedAt?: string;
+  /**
+   * TC-022: fecha en que ADMIN/BACKOFFICE marco como devuelto (status REFUNDED).
+   */
+  refundedAt?: string;
+  /**
+   * TC-022: URL del comprobante subido por ADMIN/BACKOFFICE al devolver el dinero.
+   */
+  refundProofUrl?: string;
+  /**
+   * TC-022: nombre del turista (solo en respuestas del endpoint /admin/credits).
+   */
+  touristName?: string;
+  /**
+   * TC-022: email del turista (solo en respuestas del endpoint /admin/credits).
+   */
+  touristEmail?: string;
+}
+
+/**
+ * TC-022: respuesta paginada del endpoint GET /admin/credits usado por
+ * ADMIN/BACKOFFICE_OPERATION para el listado global de creditos.
+ */
+export interface AdminCreditsPageResponse {
+  content: ClientCredit[];
+  totalElements: number;
+  totalPages: number;
+  number: number;
+  size: number;
+  first: boolean;
+  last: boolean;
+  numberOfElements: number;
+  empty: boolean;
 }

--- a/src/app/shared/services/credit.service.ts
+++ b/src/app/shared/services/credit.service.ts
@@ -1,8 +1,8 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
-import { ClientCredit } from '../models/credit.model';
+import { AdminCreditsPageResponse, ClientCredit } from '../models/credit.model';
 
 @Injectable({
   providedIn: 'root'
@@ -14,7 +14,7 @@ export class CreditService {
 
   /**
    * Obtiene la lista de créditos del cliente
-   * @param status Estado opcional para filtrar los créditos (CREATED, CANCELED, DELETED)
+   * @param status Estado opcional para filtrar los créditos (CREATED, CANCELED, DELETED, REFUND_REQUESTED, REFUNDED, EXPIRED)
    * @returns Observable con el arreglo de créditos
    */
   getCredits(status?: string): Observable<ClientCredit[]> {
@@ -30,5 +30,40 @@ export class CreditService {
    */
   reserveCredits(payload: { shoppingCartItemId: number; amountToReserve: number; creditIds: number[] }): Observable<any> {
     return this.http.post(`${this.apiUrl}/credits/reserve`, payload);
+  }
+
+  /**
+   * TC-022: turista solicita devolución en efectivo de un crédito en status CREATED.
+   * Transiciona CREATED -> REFUND_REQUESTED.
+   */
+  requestRefund(creditId: number): Observable<ClientCredit> {
+    return this.http.post<ClientCredit>(`${this.apiUrl}/credits/${creditId}/request-refund`, {});
+  }
+
+  /**
+   * TC-022: ADMIN/BACKOFFICE_OPERATION obtiene el listado global paginado de créditos
+   * con datos del turista. Filtrable por status.
+   */
+  getAdminCredits(page: number, size: number, status?: string): Observable<AdminCreditsPageResponse> {
+    let params = new HttpParams()
+      .set('page', page.toString())
+      .set('size', size.toString());
+    if (status) {
+      params = params.set('status', status);
+    }
+    return this.http.get<AdminCreditsPageResponse>(`${this.apiUrl}/admin/credits`, { params });
+  }
+
+  /**
+   * TC-022: ADMIN/BACKOFFICE_OPERATION sube el comprobante (imagen o PDF) de la
+   * devolución efectuada. Transiciona REFUND_REQUESTED -> REFUNDED.
+   */
+  uploadRefundProof(creditId: number, file: File): Observable<ClientCredit> {
+    const formData = new FormData();
+    formData.append('proof', file);
+    return this.http.post<ClientCredit>(
+      `${this.apiUrl}/admin/credits/${creditId}/upload-refund-proof`,
+      formData
+    );
   }
 }


### PR DESCRIPTION
## Summary
Frontend UI para el flujo de devolucion en efectivo de creditos (TC-022, issue #253 tourya-api). Complementa el backend paralelo en `feature/tc022-credit-refund-flow`.

### Frente 1 - Turista (`/clients/my-profile?section=credits`)
- Boton **Solicitar devolucion** en creditos `CREATED` con saldo libre (`amount - reservedAmount > 0`).
- Confirm SweetAlert2 -> `POST /credits/{id}/request-refund` -> toast success + refresh.
- Chip amarillo **Solicitud de devolucion** para `REFUND_REQUESTED`.
- Chip azul **Dinero devuelto** + link **Ver comprobante** (`refundProofUrl`, target=`_blank`) para `REFUNDED`.
- Nuevas opciones en el filtro por estado (REFUND_REQUESTED, REFUNDED, EXPIRED).

### Frente 2 - Admin/Backoffice (`/admin/credits`)
- Nuevo `AdminCreditsComponent` (standalone) protegido por `BackofficeGuard` (ADMIN + BACKOFFICE_OPERATION).
- Sidebar del shell admin actualizado con item **Creditos** para ambos roles.
- Tabla listado global paginada server-side (`GET /admin/credits?page&size&status`): ID, Turista (nombre+email), Monto, Reservado, Disponible, Estado, Fecha, Acciones.
- Filtro por status (ALL/CREATED/REFUND_REQUESTED/REFUNDED/CANCELED/EXPIRED/DELETED).
- Boton **Subir comprobante** solo en `REFUND_REQUESTED` -> modal con file picker (JPG/PNG/PDF max 5MB) + preview imagen + `POST /admin/credits/{id}/upload-refund-proof` (multipart `proof`).
- Link **Ver comprobante** en `REFUNDED`.

### Shared
- `CreditService`: nuevos metodos `requestRefund`, `getAdminCredits`, `uploadRefundProof`.
- `ClientCredit` model: campos opcionales `reservedAmount`, `refundRequestedAt`, `refundedAt`, `refundProofUrl`, `touristName`, `touristEmail` + tipo `AdminCreditsPageResponse`.
- i18n en/es/pt: nuevo namespace `credit.*` (status/actions/confirm/toast/upload), `admin.credits.*`, `admin.sidebar.credits`, `clientCredits.colActions`.

## Data safety
- El turista solo ve sus propios creditos (backend garantiza).
- Nombre/email de otros turistas solo se exponen en la vista `/admin/credits` (endpoint admin), nunca en la vista turista.

## Test plan
- [ ] `npx ng build --configuration=production` verde (OK localmente).
- [ ] Login turista con credito `CREATED` en `/clients/my-profile?section=credits`: aparece boton, confirm dispara request, credito pasa a `REFUND_REQUESTED`.
- [ ] Login ADMIN en `/admin/credits`: listado carga con datos del turista, filtro por status funciona, paginacion adelante/atras.
- [ ] Login BACKOFFICE_OPERATION: mismo comportamiento, ve el item **Creditos** en sidebar.
- [ ] Subir comprobante (imagen y PDF): credito pasa a `REFUNDED`, link **Ver comprobante** abre GCS URL en nueva pestana.
- [ ] Reintentar upload con archivo invalido (>5MB / tipo no permitido): snackBar de error, no llama al backend.
- [ ] Verificar que credito `REFUND_REQUESTED` no aparece como usable en el checkout (mantener flujo existente).

## Notas
- Backend paralelo trabajando en `Touryapp/tourya-api` rama `feature/tc022-credit-refund-flow`. Coordinar merge (backend primero).