### PR TITLE
fix(TC-022 #253): agregar item Créditos al sidebar del dashboard admin

### DIFF
--- a/src/app/pages/admin/dashboard/dashboard.component.html
+++ b/src/app/pages/admin/dashboard/dashboard.component.html
@@ -55,6 +55,13 @@
             <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToBookingsManagement()"><i
                 class="isax isax-calendar-tick"></i> Reservas</a>
           </li>
+          <!-- TC-022 #253 fix: link al panel de créditos (ADMIN + BACKOFFICE_OPERATION).
+               El item vivía solo en el shell admin.component.html; faltaba acá en el sidebar
+               propio del dashboard. -->
+          <li>
+            <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToCredits()"><i
+                class="isax isax-money-recive"></i> {{ 'admin.sidebar.credits' | translate }}</a>
+          </li>
           <li>
             <a class="d-flex align-items-center" style="cursor: pointer;" (click)="goToBackofficeUsers()"><i
                 class="isax isax-people"></i> {{ 'backofficeUsers.sidebarLink' | translate }}</a>

--- a/src/app/pages/admin/dashboard/dashboard.component.ts
+++ b/src/app/pages/admin/dashboard/dashboard.component.ts
@@ -50,6 +50,13 @@ export class DashboardComponent implements OnInit {
     this.router.navigate(['/admin/backoffice-users']);
   }
 
+  /** TC-022 #253 fix: navega a la vista de gestión de créditos (ADMIN + BACKOFFICE_OPERATION).
+   * El item se había agregado al shell admin.component.html pero no a este sidebar del dashboard
+   * — Luis reportó que no le aparecía en /admin/dashboard aunque estaba en el resto de vistas admin. */
+  goToCredits(): void {
+    this.router.navigate(['/admin/credits']);
+  }
+
   ngOnInit(): void {
     this.cargarSolicitudes();
     this.showGalleryFiles();


### PR DESCRIPTION
## Root cause

Luis reportó (issue #253) que el item "Créditos" no le aparecía a ADMIN ni BACKOFFICE_OPERATION en /admin/dashboard. Después de verificar (curl al chunk del deploy Cloud Run) que el código sí estaba desplegado, revisé la arquitectura del sidebar y encontré:

- El PR #115 agregó el `<li>` Créditos al **shell** `admin.component.html`.
- Pero según TC-008, **`/admin/dashboard` tiene su propio sidebar con toggles internos** (`dashboard.component.html`) — NO usa el sidebar del shell.
- Ese sidebar propio del dashboard **NO tenía el item Créditos** ni el método `goToCredits()`.

## Cambios (2 archivos)

- `dashboard.component.html`: agregar `<li>` Créditos entre "Reservas" y "Usuarios Backoffice" con icono `isax-money-recive` y key i18n `admin.sidebar.credits`.
- `dashboard.component.ts`: agregar método `goToCredits()` que navega a `/admin/credits`.

## Verificación previa a deploy

- Como ADMIN entrando a `/admin/dashboard` → debe aparecer "Créditos" en el sidebar entre Reservas y Usuarios Backoffice.
- Como BACKOFFICE_OPERATION entrando a `/admin/dashboard` → mismo item visible.
- Click en "Créditos" → navega a `/admin/credits` (que ya funciona desde el shell — PR #115).

Build production verde local.