### PR TITLE
feat(MO-43b): assetlinks.json para autoVerify de deep-links Android

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -26,6 +26,17 @@ http {
       expires -1;
     }
 
+    # MO-43b: Digital Asset Links para autoVerify de deep-links Android.
+    # Google descarga https://dev.tourya.co/.well-known/assetlinks.json para verificar
+    # que el owner del dominio autoriza al package_name Android con el SHA-256 dado.
+    # Por default nginx no sirve rutas con dot leading — hay que exponer esta location
+    # explicita antes del pattern general de .json (que da expires 1y — incorrecto aca).
+    location = /.well-known/assetlinks.json {
+      try_files $uri =404;
+      default_type application/json;
+      add_header Cache-Control "public, max-age=3600";
+    }
+
     # TC-008 (#195): assets estaticos deben devolver 404 real cuando no existen,
     # no el index.html (que rompe `import()` dinamico de Angular con
     # "Failed to fetch dynamically imported module").

--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.tourya.mobile",
+      "sha256_cert_fingerprints": [
+        "FD:39:C5:75:FF:A4:7D:0D:B3:94:E1:66:D6:96:1A:B4:44:1A:D5:9D:11:C9:B3:E3:1E:A8:D8:34:A4:A7:66:B3"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Sprint 4a mobile

Publica el Digital Asset Links en https://dev.tourya.co/.well-known/assetlinks.json para que Android verifique el link entre el dominio y el package `com.tourya.mobile`. Cuando alguien comparte un tour por WhatsApp (patrón MO-43), Android abre la app **directo sin chooser** en lugar de mostrar "Abrir con Chrome o Tourya".

## Cambios

- **`public/.well-known/assetlinks.json`** — array con package_name + SHA-256 del debug keystore MAUI local. Angular 19 con `\"input\": \"public\"` en angular.json ya copia la carpeta al output automáticamente (verificado con build production).

- **`nginx.conf`** — nueva location `= /.well-known/assetlinks.json` **antes** del pattern general de `.json`:
  - Necesaria porque nginx por default no sirve rutas con dot leading.
  - Fuerza `Content-Type: application/json` (Google exige este content-type para validar).
  - `Cache-Control public, max-age=3600` en vez del `expires 1y` del pattern general (correcto — el archivo puede cambiar cuando agreguemos SHA-256 de release).

## Verificación post-deploy

```bash
curl -H "Accept: application/json" https://dev.tourya.co/.well-known/assetlinks.json
# → 200 + application/json + JSON válido
```

Con el device conectado por adb:
```bash
adb shell pm verify-app-links --re-verify com.tourya.mobile
adb shell pm get-app-links com.tourya.mobile
# → "verified" para dev.tourya.co
```

## Sprint 4b — cancelado

Google Pay via Wompi resultó no viable — Wompi Colombia no lo ofrece y no hay SDK Android. Reporte técnico completo en el issue del sprint. Se posterga hasta que Wompi lo agregue o se decida cambio de proveedor.

## Deuda futura

Cuando la app se publique en Play Store, agregar al array `sha256_cert_fingerprints` el fingerprint del release keystore (o del Play App Signing). Google acepta múltiples fingerprints simultáneamente — no rompe el debug.