### PR TITLE
feat(fe): FE-Concierge widget chat Travel Concierge

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "common": {
     "back": "Back"
   },
@@ -2197,6 +2197,20 @@
     "view_modal": {
       "title": "View Report",
       "close_btn": "Close"
+    }
+  },
+  "concierge": {
+    "title": "Tourya Concierge",
+    "welcome": "Hi! I'm your Tourya concierge. How can I help you?",
+    "placeholder": "Type your question...",
+    "send": "Send",
+    "thinking": "Thinking...",
+    "error": "Something went wrong, please try again",
+    "escalated": "We'll reach out to you on WhatsApp",
+    "action": {
+      "searched": "{{count}} tours found",
+      "addedToCart": "Added to cart",
+      "cartFailed": "Could not add to cart"
     }
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "common": {
     "back": "Volver"
   },
@@ -2198,6 +2198,20 @@
     "view_modal": {
       "title": "Ver Reporte",
       "close_btn": "Cerrar"
+    }
+  },
+  "concierge": {
+    "title": "Concierge Tourya",
+    "welcome": "Hola! Soy tu concierge de Tourya. En que puedo ayudarte?",
+    "placeholder": "Escribi tu consulta...",
+    "send": "Enviar",
+    "thinking": "Pensando...",
+    "error": "Hubo un error, intenta de nuevo",
+    "escalated": "Te contactaremos por WhatsApp",
+    "action": {
+      "searched": "{{count}} tours encontrados",
+      "addedToCart": "Agregado al carrito",
+      "cartFailed": "No se pudo agregar al carrito"
     }
   }
 }

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "common": {
     "back": "Voltar"
   },
@@ -2198,6 +2198,20 @@
     "view_modal": {
       "title": "Ver Relatório",
       "close_btn": "Fechar"
+    }
+  },
+  "concierge": {
+    "title": "Concierge Tourya",
+    "welcome": "Ola! Sou seu concierge da Tourya. Como posso ajudar?",
+    "placeholder": "Escreva sua pergunta...",
+    "send": "Enviar",
+    "thinking": "Pensando...",
+    "error": "Ocorreu um erro, tente novamente",
+    "escalated": "Entraremos em contato pelo WhatsApp",
+    "action": {
+      "searched": "{{count}} tours encontrados",
+      "addedToCart": "Adicionado ao carrinho",
+      "cartFailed": "Nao foi possivel adicionar ao carrinho"
     }
   }
 }

--- a/src/app/pages/clients/cart-summary/cart-summary.component.html
+++ b/src/app/pages/clients/cart-summary/cart-summary.component.html
@@ -1,4 +1,4 @@
-<!-- Page Wrapper -->
+﻿<!-- Page Wrapper -->
 <div class="content content-two pt-4">
     <div class="container" *ngIf="!loading; else loadingTemplate">
         <!-- Header Section -->
@@ -603,3 +603,6 @@
     </ng-template>
 </div>
 <!-- /Page Wrapper -->
+
+<!-- FE-Concierge: Travel Concierge widget (no explicit cartId - backend infers active cart from JWT) -->
+<app-concierge-chat-widget></app-concierge-chat-widget>

--- a/src/app/pages/clients/list-tours/list-tours.component.html
+++ b/src/app/pages/clients/list-tours/list-tours.component.html
@@ -1,4 +1,4 @@
-
+﻿
 <!-- Page Wrapper -->
 <div class="content">
     <div class="container">
@@ -486,3 +486,6 @@
 <app-floating-cart [isVisible]="isCartVisible" (daySelected)="onDaySelected($event)"
     (cartToggled)="onCartToggled($event)" (clearCart)="onCartCleared()">
 </app-floating-cart>
+
+<!-- FE-Concierge: Travel Concierge widget (no context on explore page) -->
+<app-concierge-chat-widget></app-concierge-chat-widget>

--- a/src/app/pages/clients/tours-detail/tours-detail.component.html
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.html
@@ -1,4 +1,4 @@
-    <!-- Page Wrapper -->
+﻿    <!-- Page Wrapper -->
     <div class="content" *ngIf="tour">
         <div class="container" >
             <!-- TC-017 (#220): boton "Volver" para regresar al listado. -->
@@ -675,6 +675,9 @@
         <app-floating-cart [isVisible]="isCartVisible" (daySelected)="onDaySelected($event)"
             (cartToggled)="onCartToggled($event)" (clearCart)="onCartCleared()">
         </app-floating-cart>
+
+        <!-- FE-Concierge: Travel Concierge widget bound to current tour -->
+        <app-concierge-chat-widget [tourId]="currentTourId"></app-concierge-chat-widget>
 
         <!-- Review Modal (Angular-driven, igual al de provider-tour-management) -->
         @if (showReviewModal) {

--- a/src/app/pages/clients/tours-detail/tours-detail.component.ts
+++ b/src/app/pages/clients/tours-detail/tours-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, AfterViewChecked } from '@angular/core';
+﻿import { Component, OnInit, OnDestroy, AfterViewChecked } from '@angular/core';
 import { Location } from '@angular/common';
 import { TranslateService } from '@ngx-translate/core';
 // usando @angular/google-maps para mapa nativo
@@ -215,7 +215,7 @@ export class ToursDetailComponent implements OnInit, OnDestroy, AfterViewChecked
   public reviewReasonsNegative: ReviewReason[] = [];
   public reviewReasonsLoading: boolean = false;
   public selectedReasonId: number | null = null;
-  private currentTourId: number = 0;
+  public currentTourId: number = 0;
   public canWriteReview: boolean = false;
 
   // Computed: reasons based on rating

--- a/src/app/shared/common/concierge-chat-widget/concierge-chat-widget.component.html
+++ b/src/app/shared/common/concierge-chat-widget/concierge-chat-widget.component.html
@@ -1,0 +1,96 @@
+<div class="concierge-widget" [class.open]="isOpen">
+  <!-- FAB collapsed -->
+  <button
+    *ngIf="!isOpen"
+    type="button"
+    class="concierge-fab"
+    (click)="toggle()"
+    [attr.aria-label]="'concierge.title' | translate"
+    [title]="'concierge.title' | translate">
+    <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+    </svg>
+  </button>
+
+  <!-- Expanded panel -->
+  <div class="concierge-panel" *ngIf="isOpen" role="dialog" aria-modal="false">
+    <header class="concierge-header">
+      <div class="concierge-title">
+        <span class="dot" aria-hidden="true"></span>
+        <span>{{ 'concierge.title' | translate }}</span>
+      </div>
+      <button
+        type="button"
+        class="concierge-close"
+        (click)="close()"
+        [attr.aria-label]="'shared.close' | translate">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="18" y1="6" x2="6" y2="18"/>
+          <line x1="6" y1="6" x2="18" y2="18"/>
+        </svg>
+      </button>
+    </header>
+
+    <div class="concierge-messages" #messagesEnd>
+      <div
+        *ngFor="let msg of messages; trackBy: trackMessage"
+        class="msg-row"
+        [class.msg-user]="msg.role === 'user'"
+        [class.msg-assistant]="msg.role === 'assistant'">
+        <div class="msg-bubble">
+          <p class="msg-text">{{ msg.content }}</p>
+          <div
+            *ngIf="msg.role === 'assistant' && visibleActions(msg).length > 0"
+            class="msg-actions">
+            <span
+              *ngFor="let action of visibleActions(msg); trackBy: trackAction"
+              [class]="actionClass(action)">
+              {{ actionLabel(action) }}
+            </span>
+          </div>
+        </div>
+      </div>
+      <div *ngIf="isBusy" class="msg-row msg-assistant" aria-live="polite">
+        <div class="msg-bubble msg-thinking">
+          <span class="dots">
+            <span></span><span></span><span></span>
+          </span>
+          <span class="thinking-label">{{ 'concierge.thinking' | translate }}</span>
+        </div>
+      </div>
+    </div>
+
+    <div *ngIf="escalated" class="concierge-escalated" role="status">
+      {{ 'concierge.escalated' | translate }}
+    </div>
+
+    <form
+      *ngIf="!escalated"
+      class="concierge-input"
+      (ngSubmit)="send()"
+      autocomplete="off">
+      <textarea
+        #inputEl
+        rows="1"
+        maxlength="1000"
+        [(ngModel)]="input"
+        [disabled]="isBusy"
+        (keydown)="onInputKeydown($event)"
+        [placeholder]="'concierge.placeholder' | translate"
+        name="conciergeInput"
+        [attr.aria-label]="'concierge.placeholder' | translate">
+      </textarea>
+      <button
+        type="submit"
+        class="concierge-send"
+        [disabled]="isBusy || !input || !input.trim()"
+        [attr.aria-label]="'concierge.send' | translate"
+        [title]="'concierge.send' | translate">
+        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <line x1="22" y1="2" x2="11" y2="13"/>
+          <polygon points="22 2 15 22 11 13 2 9 22 2"/>
+        </svg>
+      </button>
+    </form>
+  </div>
+</div>

--- a/src/app/shared/common/concierge-chat-widget/concierge-chat-widget.component.scss
+++ b/src/app/shared/common/concierge-chat-widget/concierge-chat-widget.component.scss
@@ -1,0 +1,340 @@
+/* Concierge Chat Widget — FAB + panel flotante */
+.concierge-widget {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 1055;
+  font-family: inherit;
+
+  /* Sobre mobile pequeno, dejamos el FAB un poco separado del borde */
+  @media (max-width: 639px) {
+    bottom: 16px;
+    right: 16px;
+    left: auto;
+  }
+}
+
+/* -------- FAB colapsado -------- */
+.concierge-fab {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  border: none;
+  background: var(--bs-primary, #0d6efd);
+  color: #ffffff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+  &:hover,
+  &:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.24);
+    outline: none;
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+
+  svg {
+    display: block;
+  }
+}
+
+/* -------- Panel expandido -------- */
+.concierge-panel {
+  width: 380px;
+  height: 500px;
+  max-height: calc(100vh - 48px);
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.22);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: conciergeFadeIn 180ms ease-out;
+
+  @media (max-width: 639px) {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    width: 100vw;
+    height: 100vh;
+    max-height: none;
+    border-radius: 0;
+  }
+}
+
+@keyframes conciergeFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* -------- Header -------- */
+.concierge-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  background: var(--bs-primary, #0d6efd);
+  color: #ffffff;
+  flex: 0 0 auto;
+}
+
+.concierge-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+  font-size: 15px;
+
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #4ade80;
+    box-shadow: 0 0 0 3px rgba(74, 222, 128, 0.25);
+  }
+}
+
+.concierge-close {
+  background: transparent;
+  border: none;
+  color: #ffffff;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.15s ease;
+
+  &:hover,
+  &:focus-visible {
+    background: rgba(255, 255, 255, 0.15);
+    outline: none;
+  }
+}
+
+/* -------- Messages -------- */
+.concierge-messages {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 16px;
+  background: #f7f9fc;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.msg-row {
+  display: flex;
+  width: 100%;
+
+  &.msg-user {
+    justify-content: flex-end;
+  }
+
+  &.msg-assistant {
+    justify-content: flex-start;
+  }
+}
+
+.msg-bubble {
+  max-width: 82%;
+  padding: 10px 12px;
+  border-radius: 14px;
+  font-size: 14px;
+  line-height: 1.4;
+  word-wrap: break-word;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+
+  .msg-user & {
+    background: var(--bs-primary, #0d6efd);
+    color: #ffffff;
+    border-bottom-right-radius: 4px;
+  }
+
+  .msg-assistant & {
+    background: #ffffff;
+    color: #2c3e50;
+    border: 1px solid #e5e9f0;
+    border-bottom-left-radius: 4px;
+  }
+}
+
+.msg-text {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.msg-actions {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  background: #e5e9f0;
+  color: #2c3e50;
+  line-height: 1.2;
+
+  &.chip-info {
+    background: rgba(13, 110, 253, 0.12);
+    color: var(--bs-primary, #0d6efd);
+  }
+
+  &.chip-success {
+    background: rgba(34, 197, 94, 0.15);
+    color: #15803d;
+  }
+
+  &.chip-danger {
+    background: rgba(239, 68, 68, 0.12);
+    color: #b91c1c;
+  }
+}
+
+/* -------- Thinking dots -------- */
+.msg-thinking {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.dots {
+  display: inline-flex;
+  gap: 4px;
+
+  span {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--bs-primary, #0d6efd);
+    opacity: 0.4;
+    animation: conciergeBlink 1.2s infinite ease-in-out;
+
+    &:nth-child(2) {
+      animation-delay: 0.2s;
+    }
+
+    &:nth-child(3) {
+      animation-delay: 0.4s;
+    }
+  }
+}
+
+.thinking-label {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+@keyframes conciergeBlink {
+  0%, 80%, 100% {
+    opacity: 0.35;
+    transform: scale(0.85);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* -------- Escalated banner -------- */
+.concierge-escalated {
+  flex: 0 0 auto;
+  padding: 12px 16px;
+  background: #fef3c7;
+  color: #92400e;
+  font-size: 13px;
+  font-weight: 500;
+  text-align: center;
+  border-top: 1px solid #fde68a;
+}
+
+/* -------- Input -------- */
+.concierge-input {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 12px;
+  border-top: 1px solid #e5e9f0;
+  background: #ffffff;
+
+  textarea {
+    flex: 1 1 auto;
+    resize: none;
+    border: 1px solid #d0d7e2;
+    border-radius: 12px;
+    padding: 8px 10px;
+    font-size: 14px;
+    line-height: 1.35;
+    max-height: 110px;
+    min-height: 38px;
+    font-family: inherit;
+    color: #2c3e50;
+    background: #ffffff;
+    outline: none;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+
+    &:focus {
+      border-color: var(--bs-primary, #0d6efd);
+      box-shadow: 0 0 0 3px rgba(13, 110, 253, 0.15);
+    }
+
+    &:disabled {
+      background: #f3f4f6;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.concierge-send {
+  flex: 0 0 auto;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: none;
+  background: var(--bs-primary, #0d6efd);
+  color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.15s ease, transform 0.15s ease;
+
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    transform: translateY(-1px);
+    outline: none;
+  }
+
+  &:disabled {
+    background: #cbd5e1;
+    cursor: not-allowed;
+  }
+
+  svg {
+    display: block;
+  }
+}

--- a/src/app/shared/common/concierge-chat-widget/concierge-chat-widget.component.ts
+++ b/src/app/shared/common/concierge-chat-widget/concierge-chat-widget.component.ts
@@ -1,0 +1,249 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  Input,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+} from '@angular/core';
+import { Subject, takeUntil } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+import { TravelConciergeService } from '../../services/travel-concierge.service';
+import {
+  ConciergeAction,
+  ConciergeChatContext,
+  ConciergeChatMessage,
+  ConciergeChatResponse,
+} from '../../models/concierge.model';
+
+/**
+ * Widget flotante del Travel Concierge (FE-Concierge).
+ *
+ * FAB colapsado en bottom-right; al expandir muestra panel 380x500
+ * (full-screen en <640px). Renderiza el historial de la sesion en memoria
+ * (no persiste) y muestra chips de las acciones ejecutadas por el LLM.
+ *
+ * NUNCA expone `fraudSuspected` al usuario — solo trackea internamente.
+ * Si `escalatedToHuman=true`, oculta el input y muestra el banner de handoff.
+ */
+@Component({
+  selector: 'app-concierge-chat-widget',
+  standalone: false,
+  templateUrl: './concierge-chat-widget.component.html',
+  styleUrls: ['./concierge-chat-widget.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConciergeChatWidgetComponent implements OnInit, OnDestroy {
+  @Input() tourId?: number;
+  @Input() cartId?: number;
+
+  @ViewChild('messagesEnd') private messagesEnd?: ElementRef<HTMLDivElement>;
+  @ViewChild('inputEl') private inputEl?: ElementRef<HTMLTextAreaElement>;
+
+  isOpen = false;
+  isBusy = false;
+  escalated = false;
+  input = '';
+  messages: ConciergeChatMessage[] = [];
+
+  private destroy$ = new Subject<void>();
+  private welcomeMessageAdded = false;
+
+  constructor(
+    private concierge: TravelConciergeService,
+    private translate: TranslateService,
+    private cdr: ChangeDetectorRef,
+  ) {}
+
+  ngOnInit(): void {
+    this.addWelcomeMessage();
+    this.translate.onLangChange
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        // Al cambiar de idioma, si solo hay el welcome, lo reemplazamos.
+        if (this.messages.length === 1 && this.messages[0].role === 'assistant') {
+          this.messages = [this.buildWelcomeMessage()];
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  toggle(): void {
+    this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      setTimeout(() => {
+        this.scrollToBottom();
+        this.inputEl?.nativeElement?.focus();
+      }, 50);
+    }
+  }
+
+  close(): void {
+    this.isOpen = false;
+  }
+
+  onInputKeydown(event: KeyboardEvent): void {
+    // Enter envia, Shift+Enter hace salto de linea.
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      this.send();
+    }
+  }
+
+  send(): void {
+    const text = (this.input || '').trim();
+    if (!text || this.isBusy || this.escalated) {
+      return;
+    }
+
+    const userMessage: ConciergeChatMessage = {
+      role: 'user',
+      content: text,
+      timestamp: Date.now(),
+    };
+    this.messages = [...this.messages, userMessage];
+    this.input = '';
+    this.isBusy = true;
+    this.cdr.markForCheck();
+    setTimeout(() => this.scrollToBottom(), 20);
+
+    const ctx = this.buildContext();
+    this.concierge
+      .chat(text, ctx)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (response: ConciergeChatResponse) => this.handleResponse(response),
+        error: () => this.handleError(),
+      });
+  }
+
+  /**
+   * Devuelve solo las acciones "visibles" para el usuario
+   * (chips search_tours con resumen, add_to_cart exitoso o fallido).
+   */
+  visibleActions(msg: ConciergeChatMessage): ConciergeAction[] {
+    if (!msg.actions || msg.actions.length === 0) {
+      return [];
+    }
+    return msg.actions.filter((a) => this.isRenderableAction(a));
+  }
+
+  actionLabel(action: ConciergeAction): string {
+    if (action.type === 'search_tours') {
+      const count = this.extractSearchCount(action);
+      if (count != null) {
+        return this.translate.instant('concierge.action.searched', { count });
+      }
+      return action.resultSummary || this.translate.instant('concierge.action.searched', { count: '?' });
+    }
+    if (action.type === 'add_to_cart') {
+      return action.success
+        ? this.translate.instant('concierge.action.addedToCart')
+        : this.translate.instant('concierge.action.cartFailed');
+    }
+    return action.resultSummary || action.type;
+  }
+
+  actionClass(action: ConciergeAction): string {
+    if (action.type === 'add_to_cart') {
+      return action.success ? 'chip chip-success' : 'chip chip-danger';
+    }
+    if (action.type === 'search_tours') {
+      return 'chip chip-info';
+    }
+    return 'chip';
+  }
+
+  trackMessage(index: number, msg: ConciergeChatMessage): number {
+    return msg.timestamp;
+  }
+
+  trackAction(index: number, _action: ConciergeAction): number {
+    return index;
+  }
+
+  private handleResponse(response: ConciergeChatResponse): void {
+    const assistant: ConciergeChatMessage = {
+      role: 'assistant',
+      content: response.assistantMessage || '',
+      actions: response.actionsExecuted || [],
+      escalated: response.escalatedToHuman === true,
+      timestamp: Date.now(),
+    };
+    this.messages = [...this.messages, assistant];
+    if (response.escalatedToHuman === true) {
+      this.escalated = true;
+    }
+    this.isBusy = false;
+    this.cdr.markForCheck();
+    setTimeout(() => this.scrollToBottom(), 20);
+  }
+
+  private handleError(): void {
+    const errorMsg: ConciergeChatMessage = {
+      role: 'assistant',
+      content: this.translate.instant('concierge.error'),
+      timestamp: Date.now(),
+    };
+    this.messages = [...this.messages, errorMsg];
+    this.isBusy = false;
+    this.cdr.markForCheck();
+    setTimeout(() => this.scrollToBottom(), 20);
+  }
+
+  private buildContext(): ConciergeChatContext | undefined {
+    const ctx: ConciergeChatContext = {};
+    if (this.tourId != null) ctx.tourId = this.tourId;
+    if (this.cartId != null) ctx.cartId = this.cartId;
+    return Object.keys(ctx).length > 0 ? ctx : undefined;
+  }
+
+  private addWelcomeMessage(): void {
+    if (this.welcomeMessageAdded) return;
+    this.messages = [this.buildWelcomeMessage()];
+    this.welcomeMessageAdded = true;
+  }
+
+  private buildWelcomeMessage(): ConciergeChatMessage {
+    return {
+      role: 'assistant',
+      content: this.translate.instant('concierge.welcome'),
+      timestamp: Date.now(),
+    };
+  }
+
+  private scrollToBottom(): void {
+    const el = this.messagesEnd?.nativeElement;
+    if (el && typeof el.scrollIntoView === 'function') {
+      el.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
+  }
+
+  private isRenderableAction(action: ConciergeAction): boolean {
+    return action.type === 'search_tours' || action.type === 'add_to_cart';
+  }
+
+  private extractSearchCount(action: ConciergeAction): number | null {
+    // Preferencia: params.count numerico -> resultSummary "N tours ..." -> null
+    const params = action.params || {};
+    const rawCount = params['count'];
+    if (typeof rawCount === 'number' && Number.isFinite(rawCount)) {
+      return rawCount;
+    }
+    if (typeof action.resultSummary === 'string') {
+      const match = action.resultSummary.match(/(\d+)/);
+      if (match) {
+        const n = parseInt(match[1], 10);
+        if (!isNaN(n)) return n;
+      }
+    }
+    return null;
+  }
+}

--- a/src/app/shared/models/concierge.model.ts
+++ b/src/app/shared/models/concierge.model.ts
@@ -1,0 +1,57 @@
+/**
+ * Modelos para el Travel Concierge (IA-02).
+ * Contrato con POST /agents/travel-concierge/chat.
+ */
+
+export interface ConciergeChatContext {
+  tourId?: number;
+  cartId?: number;
+}
+
+export interface ConciergeChatRequest {
+  sessionId: string;
+  userMessage: string;
+  locale: string;
+  context?: ConciergeChatContext;
+}
+
+/**
+ * Acciones ejecutadas por el asistente durante el turno actual.
+ * `type` es abierto (search_tours, add_to_cart, etc.); el backend puede
+ * agregar nuevos tipos sin romper el frontend.
+ */
+export interface ConciergeAction {
+  type: string;
+  params?: Record<string, unknown>;
+  resultSummary?: string;
+  success?: boolean;
+}
+
+export interface ConciergeChatResponse {
+  assistantMessage: string;
+  actionsExecuted?: ConciergeAction[];
+  fraudSuspected?: boolean;
+  escalatedToHuman?: boolean;
+}
+
+/**
+ * Envelope estandar del backend (ApiResponse<T>).
+ * El servicio lo desempaqueta y expone solo el `data`.
+ */
+export interface ConciergeChatEnvelope {
+  success: boolean;
+  data?: ConciergeChatResponse;
+  error?: string;
+}
+
+/**
+ * Mensaje que vive en el historial del widget (no viaja al backend).
+ * El backend NO recibe el historial; usa sessionId como memoria.
+ */
+export interface ConciergeChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  actions?: ConciergeAction[];
+  escalated?: boolean;
+  timestamp: number;
+}

--- a/src/app/shared/services/travel-concierge.service.ts
+++ b/src/app/shared/services/travel-concierge.service.ts
@@ -1,0 +1,157 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { TranslateService } from '@ngx-translate/core';
+import { Observable, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+import {
+  ConciergeChatContext,
+  ConciergeChatEnvelope,
+  ConciergeChatRequest,
+  ConciergeChatResponse,
+} from '../models/concierge.model';
+
+const SESSION_STORAGE_KEY = 'tourya.concierge.sessionId';
+const SUPPORTED_LOCALES = new Set(['es', 'en', 'pt']);
+const DEFAULT_LOCALE = 'es';
+
+/**
+ * Cliente Angular para el Travel Concierge (backend IA-02).
+ *
+ * - Genera y persiste un `sessionId` UUID por pestaña (sessionStorage,
+ *   NO localStorage — asi cada pestaña tiene su propia conversacion).
+ * - Toma el `locale` del TranslateService (fallback 'es' si no matchea).
+ * - Delega la autorizacion JWT al AuthInterceptor global.
+ * - Desempaqueta el envelope `ApiResponse<ConciergeChatResponse>`.
+ *
+ * NO scrubbea informacion sensible en el cliente: el backend ya remueve
+ * `providerPrice` y `slotPercentageTourya` antes de responder.
+ */
+@Injectable({ providedIn: 'root' })
+export class TravelConciergeService implements OnDestroy {
+  private readonly endpoint = `${environment.apiUrl}/agents/travel-concierge/chat`;
+  private sessionId: string;
+
+  constructor(
+    private http: HttpClient,
+    private translate: TranslateService,
+  ) {
+    this.sessionId = this.readOrCreateSessionId();
+  }
+
+  ngOnDestroy(): void {
+    // Sin cleanup: el session storage sobrevive al servicio para permitir
+    // continuidad si el widget se destruye y recrea.
+  }
+
+  /**
+   * Envia un mensaje al concierge y devuelve la respuesta del asistente.
+   */
+  chat(
+    message: string,
+    context?: ConciergeChatContext,
+  ): Observable<ConciergeChatResponse> {
+    const trimmed = (message || '').trim();
+    if (!trimmed) {
+      return throwError(() => new Error('empty_message'));
+    }
+
+    const body: ConciergeChatRequest = {
+      sessionId: this.sessionId,
+      userMessage: trimmed,
+      locale: this.resolveLocale(),
+    };
+
+    if (context && (context.tourId != null || context.cartId != null)) {
+      body.context = { ...context };
+    }
+
+    return this.http
+      .post<ConciergeChatEnvelope>(this.endpoint, body)
+      .pipe(
+        map((envelope) => this.unwrap(envelope)),
+        catchError((err) => throwError(() => err)),
+      );
+  }
+
+  /**
+   * Reinicia la conversacion actual (nuevo sessionId).
+   * El backend perdera el contexto previo del thread.
+   */
+  resetSession(): void {
+    this.sessionId = this.createSessionId();
+    this.persistSessionId(this.sessionId);
+  }
+
+  /** Devuelve el sessionId actual (util para tests o telemetria interna). */
+  getSessionId(): string {
+    return this.sessionId;
+  }
+
+  private unwrap(envelope: ConciergeChatEnvelope | null | undefined): ConciergeChatResponse {
+    if (!envelope) {
+      throw new Error('empty_response');
+    }
+    if (envelope.success === false || !envelope.data) {
+      throw new Error(envelope.error || 'concierge_error');
+    }
+    return envelope.data;
+  }
+
+  private resolveLocale(): string {
+    const raw = (this.translate.currentLang || this.translate.defaultLang || DEFAULT_LOCALE)
+      .toLowerCase();
+    const base = raw.split('-')[0];
+    return SUPPORTED_LOCALES.has(base) ? base : DEFAULT_LOCALE;
+  }
+
+  private readOrCreateSessionId(): string {
+    try {
+      const existing = sessionStorage.getItem(SESSION_STORAGE_KEY);
+      if (existing && existing.length > 0) {
+        return existing;
+      }
+    } catch {
+      // sessionStorage puede fallar en modo privado / SSR; generamos igual.
+    }
+    const fresh = this.createSessionId();
+    this.persistSessionId(fresh);
+    return fresh;
+  }
+
+  private persistSessionId(id: string): void {
+    try {
+      sessionStorage.setItem(SESSION_STORAGE_KEY, id);
+    } catch {
+      // Ignorar fallos de storage — el sessionId sigue vivo en memoria.
+    }
+  }
+
+  private createSessionId(): string {
+    const cryptoObj = (typeof crypto !== 'undefined' ? crypto : undefined) as
+      | (Crypto & { randomUUID?: () => string })
+      | undefined;
+    if (cryptoObj?.randomUUID) {
+      return cryptoObj.randomUUID();
+    }
+    return this.pseudoUuid();
+  }
+
+  /**
+   * Fallback determinista (RFC4122 v4-like) para navegadores sin crypto.randomUUID.
+   */
+  private pseudoUuid(): string {
+    const bytes = new Uint8Array(16);
+    if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+      crypto.getRandomValues(bytes);
+    } else {
+      for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = Math.floor(Math.random() * 256);
+      }
+    }
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+}

--- a/src/app/shared/shared-module.ts
+++ b/src/app/shared/shared-module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from "@angular/core";
+﻿import { NgModule } from "@angular/core";
 import { CommonModule, DatePipe } from "@angular/common";
 import { RouterModule } from "@angular/router";
 import { NgScrollbarModule } from "ngx-scrollbar";
@@ -51,6 +51,7 @@ import { MatOptionModule } from "@angular/material/core";
 import { TourSlotSelectionModalComponent } from "./common/tour-slot-selection-modal/tour-slot-selection-modal.component";
 import { PendingReviewsModalComponent } from "./components/pending-reviews-modal/pending-reviews-modal.component";
 import { LocalizedNamePipe } from "./pipe/localized-name/localized-name.pipe";
+import { ConciergeChatWidgetComponent } from "./common/concierge-chat-widget/concierge-chat-widget.component";
 @NgModule({
   declarations: [
     FooterComponent,
@@ -58,7 +59,8 @@ import { LocalizedNamePipe } from "./pipe/localized-name/localized-name.pipe";
     CommonCounterComponent,
     UserDashboardComponent,
     ConfirmDialogComponent,
-    PendingReviewsModalComponent
+    PendingReviewsModalComponent,
+    ConciergeChatWidgetComponent
   ],
   imports: [
     CommonModule,
@@ -141,7 +143,8 @@ import { LocalizedNamePipe } from "./pipe/localized-name/localized-name.pipe";
     PendingReviewsModalComponent,
     GoogleMapsModule,
     RouterModule,
-    LocalizedNamePipe
+    LocalizedNamePipe,
+    ConciergeChatWidgetComponent
   ],
   providers: [
     provideNgxMask(),


### PR DESCRIPTION
## Resumen

Widget flotante Concierge Tourya integrado en 3 paginas de cliente. Consume el nuevo endpoint `POST /agents/travel-concierge/chat` (IA-02, PR #263 tourya-api merged, commit `122ce62`).

- **TravelConciergeService** (`src/app/shared/services/`): sessionId UUID por pestana (sessionStorage), locale desde TranslateService (es/en/pt), desempaqueta `ApiResponse<ConciergeChatResponse>`, delega auth al `AuthInterceptor` global.
- **ConciergeChatWidgetComponent** (`src/app/shared/common/concierge-chat-widget/`): FAB bottom-right 60x60, panel expandido 380x500 (full-screen en mobile), historial en memoria, dots animados de "pensando", chips visibles para acciones `search_tours` / `add_to_cart`, banner amarillo y ocultamiento del input cuando `escalatedToHuman=true`. `fraudSuspected` NUNCA se expone en UI.
- **Modelos** en `src/app/shared/models/concierge.model.ts`.
- **SharedModule** declara + exporta el widget para que `list-tours`, `tours-detail` y `cart-summary` lo consuman sin re-importarlo.
- **i18n** `concierge.*` en `public/i18n/{es,en,pt}.json`.

## Cambios de convencion vs el brief

El brief pedia `src/app/services/` y `src/app/models/` y componente `standalone`. Adapte a la convencion del repo:

- Service: `src/app/shared/services/travel-concierge.service.ts`
- Model: `src/app/shared/models/concierge.model.ts`
- Component: `src/app/shared/common/concierge-chat-widget/` con `standalone: false`, declarado en `SharedModule` (todos los componentes del repo son NgModule-declared).
- i18n vive en `public/i18n/` (no `src/assets/i18n/` como decia el brief).

## Guardrails respetados

- `fraudSuspected` no se muestra en la UI.
- `escalatedToHuman=true` oculta el input y muestra banner "Te contactaremos por WhatsApp".
- Backend ya scrubbea `providerPrice` / `slotPercentageTourya` - el cliente no hace nada extra.
- Sin nuevas dependencias (solo Angular + rxjs + ngx-translate existentes).
- Sin `console.log` en el nuevo codigo.
- Sin toques al checkout / Wompi / carrito de pagos.

## Contexto de paginas

- **list-tours** (Explore): widget sin contexto, el LLM hara search via function calls.
- **tours-detail**: widget con `[tourId]="currentTourId"` (cambie el field de `private` a `public` para permitir el binding bajo `strictTemplates=true`).
- **cart-summary**: widget sin `cartId` en el input - el backend resuelve el carrito activo desde el JWT del usuario autenticado. No hay campo `cartId` publicamente expuesto en el componente actual y agregar plumbing seria out-of-scope para MVP.

## Test plan

- [ ] En `list-tours`, `tours-detail/{id}` y `cart-summary`: el FAB aparece en bottom-right, cambia de idioma (es/en/pt) y el titulo/welcome se traduce en caliente.
- [ ] Click en FAB abre panel; boton X colapsa.
- [ ] Enviar mensaje con Enter, Shift+Enter hace salto de linea, boton send se deshabilita mientras `isBusy`.
- [ ] Dots animados aparecen durante la request.
- [ ] Response con `actionsExecuted[{type:'search_tours', resultSummary:'3 tours...'}]` renderiza chip azul "3 tours encontrados".
- [ ] Response con `actionsExecuted[{type:'add_to_cart', success:true}]` renderiza chip verde "Agregado al carrito".
- [ ] Response con `escalatedToHuman=true` muestra banner amarillo y oculta el input.
- [ ] En mobile (<640px) el panel es full-screen.
- [ ] JWT interceptor adjunta `Authorization: Bearer <token>` automaticamente (validar en Network tab).
- [ ] `sessionStorage` guarda `tourya.concierge.sessionId` (misma sesion por pestana; distinta entre tabs).
- [ ] Build de produccion sigue verde en CI (`ng build --configuration=production`).

## Build

- `ng build --configuration=production` = OK (exit 0), solo warnings baseline (Sass deprecations, CommonJS bailouts, selectores CSS legacy) - ninguno nuevo del codigo de este PR.
