### PR TITLE
feat(fe): FE Operator Support integracion IA-07 (4 touchpoints)

### DIFF
--- a/public/i18n/en.json
+++ b/public/i18n/en.json
@@ -2212,5 +2212,45 @@
       "addedToCart": "Added to cart",
       "cartFailed": "Could not add to cart"
     }
+  },
+  "operatorSupport": {
+    "error": "The assistant could not process your request",
+    "suggest": {
+      "button": "Suggest with AI",
+      "title": "AI Assistant Suggestions",
+      "loading": "Generating suggestions...",
+      "names": "Suggested names",
+      "namesHint": "Tap a name to replace the current one",
+      "description": "Suggested description",
+      "tags": "Suggested tags",
+      "addSelectedTags": "Add selected to my tags",
+      "use": "Use this suggestion",
+      "dismiss": "Close",
+      "incomplete": "Please complete first: {{fields}}"
+    },
+    "pricing": {
+      "ok": "Within market range",
+      "warn": "Price {{percent}}% above average",
+      "critical": "Price {{percent}}% above, may reduce sales",
+      "range": "Range: {{min}} - {{max}}",
+      "medianHint": "median {{median}}"
+    },
+    "gallery": {
+      "recommendations": "Assistant recommendations",
+      "issue": {
+        "imageVertical": "Vertical image detected — horizontal is recommended",
+        "imageTooLarge": "Image exceeds 5MB",
+        "tooManyImages": "Maximum 7 images"
+      }
+    },
+    "reviewReply": {
+      "button": "Draft with AI",
+      "toneDetected": "Detected tone: {{tone}}",
+      "tone": {
+        "PROFESSIONAL": "Professional",
+        "WARM": "Warm",
+        "APOLOGETIC": "Apologetic"
+      }
+    }
   }
 }

--- a/public/i18n/es.json
+++ b/public/i18n/es.json
@@ -2213,5 +2213,45 @@
       "addedToCart": "Agregado al carrito",
       "cartFailed": "No se pudo agregar al carrito"
     }
+  },
+  "operatorSupport": {
+    "error": "El asistente no pudo procesar tu solicitud",
+    "suggest": {
+      "button": "Sugerir con IA",
+      "title": "Sugerencias del asistente",
+      "loading": "Generando sugerencias...",
+      "names": "Nombres sugeridos",
+      "namesHint": "Tocá un nombre para reemplazar el actual",
+      "description": "Descripción sugerida",
+      "tags": "Tags sugeridos",
+      "addSelectedTags": "Agregar seleccionados a mis tags",
+      "use": "Usar esta sugerencia",
+      "dismiss": "Cerrar",
+      "incomplete": "Completá primero: {{fields}}"
+    },
+    "pricing": {
+      "ok": "Dentro del rango de mercado",
+      "warn": "Precio {{percent}}% arriba del promedio",
+      "critical": "Precio {{percent}}% arriba, puede inhibir compras",
+      "range": "Rango: {{min}} - {{max}}",
+      "medianHint": "mediana {{median}}"
+    },
+    "gallery": {
+      "recommendations": "Recomendaciones del asistente",
+      "issue": {
+        "imageVertical": "Imagen vertical detectada — recomendado horizontal",
+        "imageTooLarge": "Imagen excede 5MB",
+        "tooManyImages": "Máximo 7 imágenes"
+      }
+    },
+    "reviewReply": {
+      "button": "Borrador con IA",
+      "toneDetected": "Tono detectado: {{tone}}",
+      "tone": {
+        "PROFESSIONAL": "Profesional",
+        "WARM": "Cálido",
+        "APOLOGETIC": "Disculpa"
+      }
+    }
   }
 }

--- a/public/i18n/pt.json
+++ b/public/i18n/pt.json
@@ -2213,5 +2213,45 @@
       "addedToCart": "Adicionado ao carrinho",
       "cartFailed": "Nao foi possivel adicionar ao carrinho"
     }
+  },
+  "operatorSupport": {
+    "error": "O assistente nao pode processar sua solicitacao",
+    "suggest": {
+      "button": "Sugerir com IA",
+      "title": "Sugestoes do assistente",
+      "loading": "Gerando sugestoes...",
+      "names": "Nomes sugeridos",
+      "namesHint": "Toque em um nome para substituir o atual",
+      "description": "Descricao sugerida",
+      "tags": "Tags sugeridas",
+      "addSelectedTags": "Adicionar selecionadas as minhas tags",
+      "use": "Usar esta sugestao",
+      "dismiss": "Fechar",
+      "incomplete": "Preencha primeiro: {{fields}}"
+    },
+    "pricing": {
+      "ok": "Dentro da faixa de mercado",
+      "warn": "Preco {{percent}}% acima da media",
+      "critical": "Preco {{percent}}% acima, pode reduzir vendas",
+      "range": "Faixa: {{min}} - {{max}}",
+      "medianHint": "mediana {{median}}"
+    },
+    "gallery": {
+      "recommendations": "Recomendacoes do assistente",
+      "issue": {
+        "imageVertical": "Imagem vertical detectada — recomendado horizontal",
+        "imageTooLarge": "Imagem excede 5MB",
+        "tooManyImages": "Maximo 7 imagens"
+      }
+    },
+    "reviewReply": {
+      "button": "Rascunho com IA",
+      "toneDetected": "Tom detectado: {{tone}}",
+      "tone": {
+        "PROFESSIONAL": "Profissional",
+        "WARM": "Caloroso",
+        "APOLOGETIC": "Desculpe"
+      }
+    }
   }
 }

--- a/src/app/pages/providers/provider-reviews/provider-reviews.component.html
+++ b/src/app/pages/providers/provider-reviews/provider-reviews.component.html
@@ -263,10 +263,23 @@
                         <div class="d-flex align-items-center gap-2">
                             <!-- Botón Responder solo para Proveedor -->
                             @if (isProveedor && canRespondToReview(review)) {
-                                <button 
+                                <button
                                     class="btn btn-sm btn-outline-primary"
                                     (click)="respondToReview(review.id!)">
                                     <i class="isax isax-message-text me-1"></i>{{'provider-reviews.actions.respond' | translate}}
+                                </button>
+                                <!-- IA-07: borrador con IA. Reusa el TextEditor existente. -->
+                                <button
+                                    class="btn btn-sm btn-outline-primary ai-suggest-btn"
+                                    (click)="draftReviewReply(review.id!)"
+                                    [disabled]="isDraftingReply(review.id!)">
+                                    <ng-container *ngIf="!isDraftingReply(review.id!)">
+                                        {{'operatorSupport.reviewReply.button' | translate}}
+                                    </ng-container>
+                                    <ng-container *ngIf="isDraftingReply(review.id!)">
+                                        <span class="spinner-border spinner-border-sm me-1"></span>
+                                        {{'operatorSupport.suggest.loading' | translate}}
+                                    </ng-container>
                                 </button>
                             }
                             
@@ -290,14 +303,18 @@
                                 <i class="isax isax-message-text me-2 text-primary"></i>{{'provider-reviews.replyForm.title' | translate}}
                             </h6>
                             <div class="mb-3">
-                                <textarea 
+                                <textarea
                                     [(ngModel)]="replyText"
                                     class="form-control"
                                     rows="4"
                                     [placeholder]="'provider-reviews.replyForm.placeholder' | translate"
                                     maxlength="500"></textarea>
-                                <div class="d-flex justify-content-between align-items-center mt-2">
+                                <div class="d-flex justify-content-between align-items-center mt-2 flex-wrap gap-2">
                                     <small class="text-muted">{{ replyText.length }}/500 {{'provider-reviews.replyForm.charactersCount' | translate}}</small>
+                                    <!-- IA-07: badge del tono detectado (solo si venimos del borrador con IA) -->
+                                    <small *ngIf="aiDraftTone" class="badge bg-info-transparent text-info">
+                                        {{ 'operatorSupport.reviewReply.toneDetected' | translate: { tone: getToneLabel(aiDraftTone) } }}
+                                    </small>
                                 </div>
                                 <div class="mt-3">
                                     <label class="form-label fs-14 fw-medium text-gray-7">

--- a/src/app/pages/providers/provider-reviews/provider-reviews.component.ts
+++ b/src/app/pages/providers/provider-reviews/provider-reviews.component.ts
@@ -5,6 +5,8 @@ import { AuthService } from '../../../core/services/auth.service';
 import { ReviewsService } from '../../../core/services/reviews.service';
 import { I18nFieldService } from '../../../shared/services/i18n-field.service';
 import { ProviderPanelStateService } from '../../../shared/services/provider-panel-state.service';
+import { OperatorSupportService } from '../../../shared/services/operator-support.service';
+import { ReviewReplyTone } from '../../../shared/models/operator-support.model';
 import { TranslateService } from '@ngx-translate/core';
 import Swal from 'sweetalert2';
 
@@ -90,12 +92,20 @@ export class ProviderReviewsComponent implements OnInit, OnChanges {
   public reviewReasonsNegative: ReviewReason[] = [];
   public reviewReasonsLoading: boolean = false;
 
+  // IA-07 (Operator Support) — borrador de respuesta de resenas.
+  // aiDraftingReviewId: id de la resena para la que se esta pidiendo el draft
+  // (para mostrar el spinner solo en ese boton). aiDraftTone: tono detectado
+  // por el backend, solo se muestra si el editor esta abierto para esa resena.
+  public aiDraftingReviewId: string | null = null;
+  public aiDraftTone: ReviewReplyTone | null = null;
+
   constructor(
     private authService: AuthService,
     public i18nService: I18nFieldService,
     private panelStateService: ProviderPanelStateService,
     private reviewsService: ReviewsService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private operatorSupport: OperatorSupportService
   ) {}
 
   get currentLang(): string {
@@ -583,6 +593,64 @@ export class ProviderReviewsComponent implements OnInit, OnChanges {
   public cancelReply(): void {
     this.replyingToReviewId = null;
     this.replyText = '';
+    this.aiDraftTone = null;
+  }
+
+  // -------------------------------------------------------------------------
+  // IA-07 Operator Support — borrador de respuesta con IA para una resena
+  // (POST /agents/operator-support/draft-review-reply/{reviewId}).
+  // -------------------------------------------------------------------------
+
+  /**
+   * Devuelve el label traducido del tono detectado por el backend.
+   * Tolerante a tonos futuros: si no hay traduccion, devuelve el raw.
+   */
+  public getToneLabel(tone: ReviewReplyTone | null | undefined): string {
+    if (!tone) return '';
+    const key = `operatorSupport.reviewReply.tone.${tone}`;
+    const translated = this.translate.instant(key);
+    // Si i18n no tiene la key devuelve la key literal — evitamos mostrar eso.
+    return translated === key ? String(tone) : translated;
+  }
+
+  /**
+   * Estado de loading solo para el boton del review que esta pidiendo el draft.
+   */
+  public isDraftingReply(reviewId: string): boolean {
+    return this.aiDraftingReviewId === reviewId;
+  }
+
+  /**
+   * Llama IA-07 draft-review-reply y abre el editor con el texto sugerido
+   * pre-cargado. El provider puede editar antes de publicar. Nunca publica
+   * automaticamente — la publicacion sigue por el flujo `submitReply` existente.
+   */
+  public draftReviewReply(reviewId: string): void {
+    if (!reviewId || this.aiDraftingReviewId) return;
+    const numericId = Number(reviewId);
+    if (!Number.isFinite(numericId) || numericId <= 0) {
+      return;
+    }
+    this.aiDraftingReviewId = reviewId;
+    this.operatorSupport.draftReviewReply(numericId).subscribe({
+      next: (draft) => {
+        this.aiDraftingReviewId = null;
+        // Abrimos el editor de esta resena (mismo TextEditor existente) con el draft.
+        this.replyingToReviewId = reviewId;
+        this.replyText = draft.draftText || '';
+        this.aiDraftTone = draft.tone || null;
+      },
+      error: (err) => {
+        this.aiDraftingReviewId = null;
+        console.error('Error drafting review reply', err);
+        Swal.fire({
+          icon: 'error',
+          title: this.translate.instant('operatorSupport.reviewReply.button'),
+          text: this.translate.instant('operatorSupport.error'),
+          confirmButtonText: 'OK',
+        });
+      },
+    });
   }
 
   /**

--- a/src/app/pages/providers/tours/add-tour/add-tour.component.html
+++ b/src/app/pages/providers/tours/add-tour/add-tour.component.html
@@ -231,7 +231,19 @@
 
                     <div class="card shadow-none" id="description">
                         <div class="card-header">
-                            <h5 class="fs-18">{{ 'tour-form.sections.description' | translate }}</h5>
+                            <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+                                <h5 class="fs-18 mb-0">{{ 'tour-form.sections.description' | translate }}</h5>
+                                <button type="button"
+                                    class="btn btn-sm btn-outline-primary ai-suggest-btn"
+                                    (click)="openAiSuggestModal(aiSuggestModal)"
+                                    [disabled]="!canEdit || aiSuggestionLoading">
+                                    <span *ngIf="!aiSuggestionLoading">{{ 'operatorSupport.suggest.button' | translate }}</span>
+                                    <span *ngIf="aiSuggestionLoading" class="d-inline-flex align-items-center">
+                                        <span class="spinner-border spinner-border-sm me-2"></span>
+                                        {{ 'operatorSupport.suggest.loading' | translate }}
+                                    </span>
+                                </button>
+                            </div>
                         </div>
                         <div class="card-body text-editor">
                             <ngx-editor [editor]="editor" formControlName="description"
@@ -1007,4 +1019,77 @@
 
 <!-- Modal Backdrop para Confirmación -->
 <div class="modal-backdrop fade" [class.show]="showSubmitConfirmModal" [style.display]="showSubmitConfirmModal ? 'block' : 'none'"></div>
+
+<!-- IA-07 Operator Support — Sugerencias del asistente (nombre/descripcion/tags) -->
+<ng-template #aiSuggestModal>
+    <div class="modal-header">
+        <h5 class="modal-title">{{ 'operatorSupport.suggest.title' | translate }}</h5>
+        <button type="button" aria-label="close" class="btn-close" (click)="closeAiSuggestModal()"></button>
+    </div>
+    <div class="modal-body">
+        <div *ngIf="aiSuggestionLoading" class="text-center py-4">
+            <div class="spinner-border text-primary" role="status"></div>
+            <p class="mt-2 mb-0 text-muted">{{ 'operatorSupport.suggest.loading' | translate }}</p>
+        </div>
+
+        <ng-container *ngIf="!aiSuggestionLoading && aiSuggestion">
+            <!-- Nombres sugeridos -->
+            <div class="mb-4" *ngIf="aiSuggestion.nameSuggestions?.length">
+                <h6 class="fw-medium mb-2">{{ 'operatorSupport.suggest.names' | translate }}</h6>
+                <div class="d-flex flex-wrap gap-2">
+                    <button type="button"
+                        class="btn btn-sm btn-outline-primary ai-suggest-chip"
+                        *ngFor="let name of aiSuggestion.nameSuggestions"
+                        (click)="applySuggestedName(name)">
+                        {{ name }}
+                    </button>
+                </div>
+                <small class="text-muted d-block mt-1">{{ 'operatorSupport.suggest.namesHint' | translate }}</small>
+            </div>
+
+            <!-- Descripcion sugerida -->
+            <div class="mb-4" *ngIf="aiSuggestion.descriptionSuggestion">
+                <h6 class="fw-medium mb-2">{{ 'operatorSupport.suggest.description' | translate }}</h6>
+                <textarea class="form-control mb-2" rows="8" readonly>{{ aiSuggestion.descriptionSuggestion }}</textarea>
+                <div class="d-flex gap-2">
+                    <button type="button" class="btn btn-sm btn-primary" (click)="applySuggestedDescription()">
+                        {{ 'operatorSupport.suggest.use' | translate }}
+                    </button>
+                </div>
+            </div>
+
+            <!-- Tags sugeridos -->
+            <div class="mb-4" *ngIf="aiSuggestion.tagSuggestions?.length">
+                <h6 class="fw-medium mb-2">{{ 'operatorSupport.suggest.tags' | translate }}</h6>
+                <div class="d-flex flex-wrap gap-2 mb-2">
+                    <button type="button"
+                        class="btn btn-sm ai-suggest-chip"
+                        [class.btn-primary]="isSuggestedTagSelected(tag)"
+                        [class.btn-outline-primary]="!isSuggestedTagSelected(tag)"
+                        *ngFor="let tag of aiSuggestion.tagSuggestions"
+                        (click)="toggleSuggestedTag(tag)">
+                        {{ tag }}
+                    </button>
+                </div>
+                <button type="button"
+                    class="btn btn-sm btn-primary"
+                    [disabled]="!aiSelectedTagCodes.length"
+                    (click)="applySelectedTags()">
+                    {{ 'operatorSupport.suggest.addSelectedTags' | translate }}
+                </button>
+            </div>
+
+            <!-- Reasoning (opcional, contextual) -->
+            <div class="alert alert-light border" *ngIf="aiSuggestion.reasoning">
+                <small class="text-muted">{{ aiSuggestion.reasoning }}</small>
+            </div>
+        </ng-container>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-sm btn-secondary" (click)="closeAiSuggestModal()">
+            {{ 'operatorSupport.suggest.dismiss' | translate }}
+        </button>
+    </div>
+</ng-template>
+<!-- /IA-07 Operator Support -->
 <!-- /Modal de Confirmación -->

--- a/src/app/pages/providers/tours/add-tour/add-tour.component.ts
+++ b/src/app/pages/providers/tours/add-tour/add-tour.component.ts
@@ -29,6 +29,12 @@ import { I18nFieldService } from "../../../../shared/services/i18n-field.service
 import { PriceType } from "../../../../shared/enums/price-type.enum";
 import { SearchToursService } from "../../../clients/list-tours/search-tours.service";
 import { TagDto } from "../../../../shared/dto/search-tour-response.dto";
+import { OperatorSupportService } from "../../../../shared/services/operator-support.service";
+import {
+  SuggestTourContentDraft,
+  TourContentSuggestion,
+} from "../../../../shared/models/operator-support.model";
+import Swal from "sweetalert2";
 
 
 @Component({
@@ -112,6 +118,12 @@ export class AddTourComponent {
   // Forzar envío en la siguiente guardada (usar el mismo endpoint de guardado con status 'submitted')
   forceSubmit: boolean = false;
 
+  // IA-07 (Operator Support) — sugerencias de nombre/descripcion/tags.
+  aiSuggestionLoading: boolean = false;
+  aiSuggestion: TourContentSuggestion | null = null;
+  aiSelectedTagCodes: string[] = [];
+  aiSuggestModalRef?: BsModalRef;
+
   constructor(
     private router: Router,
     private fb: FormBuilder,
@@ -124,7 +136,8 @@ export class AddTourComponent {
     private _snackBar: MatSnackBar,
     private i18nService: I18nFieldService,
     private searchToursService: SearchToursService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private operatorSupport: OperatorSupportService
   ) {
     this.tourId = +(this.route.snapshot.paramMap.get("id") || 0);
 
@@ -1405,6 +1418,206 @@ export class AddTourComponent {
     } else {
       this.isSubmitting = false;
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // IA-07 Operator Support — sugerencias de contenido del tour
+  // (POST /agents/operator-support/suggest-tour-content).
+  // -------------------------------------------------------------------------
+
+  /**
+   * Traduce el enum de duration del form a minutos (midpoint aproximado).
+   * El backend usa este dato solo como contexto para el LLM.
+   */
+  private durationEnumToMinutes(value: string | null | undefined): number {
+    switch (value) {
+      case '1_a_2_horas':
+        return 90;
+      case '2_a_4_horas':
+        return 180;
+      case '4_a_6_horas':
+        return 300;
+      case 'hasta_1_dia':
+        return 480;
+      case 'hasta_3_dias':
+        return 2880;
+      case 'hasta_5_dias':
+        return 4320;
+      default:
+        return 0;
+    }
+  }
+
+  /**
+   * Valida que los campos requeridos por el endpoint suggest-tour-content estén
+   * completos. Devuelve la lista de labels traducidos de los que faltan.
+   */
+  private missingSuggestFields(): string[] {
+    const missing: string[] = [];
+    const name = this.tourForm.get('name')?.value;
+    const category = this.tourForm.get('category')?.value;
+    const priceType = this.tourForm.get('priceType')?.value;
+    const duration = this.tourForm.get('duration')?.value;
+    const minAge = this.tourForm.get('minAge')?.value;
+
+    if (!name || String(name).trim().length < 3) {
+      missing.push(this.translate.instant('tour-form.fields.name.label'));
+    }
+    if (!category) {
+      missing.push(this.translate.instant('tour-form.fields.category.label'));
+    }
+    if (!priceType) {
+      missing.push(this.translate.instant('tour-form.fields.priceType.label'));
+    }
+    if (!duration) {
+      missing.push(this.translate.instant('tour-form.fields.duration.label'));
+    }
+    if (minAge === null || minAge === undefined || minAge === '') {
+      missing.push(this.translate.instant('tour-form.fields.minAge.label'));
+    }
+    return missing;
+  }
+
+  /**
+   * Handler del boton "Sugerir con IA". Valida draft, llama endpoint,
+   * abre el modal con las sugerencias. El provider decide que aplicar.
+   */
+  openAiSuggestModal(template: TemplateRef<any>): void {
+    const missing = this.missingSuggestFields();
+    if (missing.length > 0) {
+      Swal.fire({
+        icon: 'info',
+        title: this.translate.instant('operatorSupport.suggest.title'),
+        text: this.translate.instant('operatorSupport.suggest.incomplete', {
+          fields: missing.join(', '),
+        }),
+        confirmButtonText: 'OK',
+      });
+      return;
+    }
+
+    const priceTypeValue = this.tourForm.get('priceType')?.value;
+    const priceTypeStr =
+      priceTypeValue === PriceType.GROUP ? 'grupo' : 'individual';
+
+    const draft: SuggestTourContentDraft = {
+      name: String(this.tourForm.get('name')?.value || '').trim(),
+      categoryId: +this.tourForm.get('category')?.value,
+      subcategoryId: null,
+      durationMinutes: this.durationEnumToMinutes(
+        this.tourForm.get('duration')?.value
+      ),
+      minAge: +this.tourForm.get('minAge')?.value,
+      priceType: priceTypeStr,
+      isUnlimitedCapacity: !!this.tourForm.get('isUnlimited')?.value,
+      currentDescription: String(
+        this.tourForm.get('description')?.value || ''
+      ).trim() || undefined,
+    };
+
+    this.aiSuggestionLoading = true;
+    this.aiSuggestion = null;
+    this.aiSelectedTagCodes = [];
+    this.aiSuggestModalRef = this.modalService.show(template);
+
+    this.operatorSupport
+      .suggestTourContent({ tourId: this.tourId || null, draft })
+      .subscribe({
+        next: (data) => {
+          this.aiSuggestionLoading = false;
+          this.aiSuggestion = data;
+        },
+        error: (err) => {
+          this.aiSuggestionLoading = false;
+          console.error('Error suggesting tour content.', err);
+          this.aiSuggestModalRef?.hide();
+          Swal.fire({
+            icon: 'error',
+            title: this.translate.instant('operatorSupport.suggest.title'),
+            text: this.translate.instant('operatorSupport.error'),
+            confirmButtonText: 'OK',
+          });
+        },
+      });
+  }
+
+  closeAiSuggestModal(): void {
+    this.aiSuggestModalRef?.hide();
+    this.aiSuggestion = null;
+    this.aiSelectedTagCodes = [];
+  }
+
+  /**
+   * Aplica uno de los nombres sugeridos al FormControl `name`.
+   */
+  applySuggestedName(name: string): void {
+    if (!name) return;
+    this.tourForm.get('name')?.setValue(name);
+    this.tourForm.get('name')?.markAsDirty();
+  }
+
+  /**
+   * Reemplaza la descripcion del form por la sugerencia.
+   */
+  applySuggestedDescription(): void {
+    const description = this.aiSuggestion?.descriptionSuggestion;
+    if (!description) return;
+    this.tourForm.get('description')?.setValue(description);
+    this.tourForm.get('description')?.markAsDirty();
+  }
+
+  /**
+   * Toggle en la lista de tags sugeridos por el LLM (que llegan por code/nombre).
+   * Se guardan por code — al aplicar, se resuelve contra `tagsList`.
+   */
+  toggleSuggestedTag(tag: string): void {
+    const idx = this.aiSelectedTagCodes.indexOf(tag);
+    if (idx >= 0) {
+      this.aiSelectedTagCodes.splice(idx, 1);
+    } else {
+      this.aiSelectedTagCodes.push(tag);
+    }
+  }
+
+  isSuggestedTagSelected(tag: string): boolean {
+    return this.aiSelectedTagCodes.indexOf(tag) >= 0;
+  }
+
+  /**
+   * Agrega los tags sugeridos+seleccionados al FormControl `tags` del wizard.
+   * Solo agrega los que el backend/catalogo de tagsList reconoce (match case-insensitive
+   * por code o por nombre localizado).
+   */
+  applySelectedTags(): void {
+    if (!this.aiSelectedTagCodes.length) return;
+    const currentTagIds: number[] = [...(this.tourForm.get('tags')?.value || [])];
+    let added = 0;
+    this.aiSelectedTagCodes.forEach((sugg) => {
+      const normalized = (sugg || '').toString().trim().toLowerCase();
+      if (!normalized) return;
+      const match = this.tagsList.find((t: any) => {
+        const code = (t?.code || t?.name?.es || t?.name || '')
+          .toString()
+          .toLowerCase();
+        if (code === normalized) return true;
+        // Match por cualquier variante localizada del nombre.
+        if (t?.name && typeof t.name === 'object') {
+          return Object.values(t.name as Record<string, string>).some(
+            (v) => (v || '').toString().toLowerCase() === normalized
+          );
+        }
+        return false;
+      });
+      if (match && !currentTagIds.includes(match.id)) {
+        currentTagIds.push(match.id);
+        added++;
+      }
+    });
+    if (added > 0) {
+      this.tourForm.get('tags')?.setValue(currentTagIds);
+      this.tourForm.get('tags')?.markAsDirty();
+    }
+    this.aiSelectedTagCodes = [];
   }
 }
 

--- a/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.html
+++ b/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.html
@@ -67,6 +67,29 @@
                   </div>
                 </div>
               </div>
+
+              <!-- IA-07 validate-gallery: issues WARN inline (los CRITICAL bloquean el
+                   upload y disparan Swal en el flujo existente). Suggestions no-bloqueantes. -->
+              <div *ngIf="aiGalleryInlineIssues.length > 0 || aiGallerySuggestions.length > 0"
+                class="mt-3 border rounded p-3 bg-light">
+                <div class="d-flex align-items-center justify-content-between mb-2">
+                  <strong class="text-warning">
+                    <i class="isax isax-info-circle me-1"></i>{{ 'operatorSupport.gallery.recommendations' | translate }}
+                  </strong>
+                  <button type="button" class="btn-close" aria-label="close"
+                    (click)="dismissGalleryAiSuggestions()"></button>
+                </div>
+                <ul *ngIf="aiGalleryInlineIssues.length > 0" class="mb-2 ps-3">
+                  <li *ngFor="let issue of aiGalleryInlineIssues" class="small text-warning">
+                    {{ issue.message || issue.code }}
+                  </li>
+                </ul>
+                <ul *ngIf="aiGallerySuggestions.length > 0" class="mb-0 ps-3">
+                  <li *ngFor="let suggestion of aiGallerySuggestions" class="small text-muted">
+                    {{ suggestion }}
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
 

--- a/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.ts
+++ b/src/app/pages/providers/tours/tour-gallery/tour-gallery.component.ts
@@ -15,6 +15,11 @@ import {
   AppConfigService,
   RawConfigValue,
 } from "../../../../shared/services/app-config.service";
+import { OperatorSupportService } from "../../../../shared/services/operator-support.service";
+import {
+  GalleryValidationIssue,
+  ImageMetadata,
+} from "../../../../shared/models/operator-support.model";
 
 interface GalleryLimits {
   maxSizeMb: number;
@@ -26,6 +31,7 @@ interface GalleryIssue {
   fileName: string;
   code: string;
   message?: string;
+  severity?: string;
 }
 
 const DEFAULT_LIMITS: GalleryLimits = {
@@ -54,6 +60,10 @@ export class TourGalleryComponent implements OnInit {
 
   limits: GalleryLimits = { ...DEFAULT_LIMITS };
 
+  // IA-07 (Operator Support) — sugerencias del backend post-validate-gallery.
+  aiGallerySuggestions: string[] = [];
+  aiGalleryInlineIssues: GalleryValidationIssue[] = [];
+
   constructor(
     private router: Router,
     private fb: FormBuilder,
@@ -62,7 +72,8 @@ export class TourGalleryComponent implements OnInit {
     private _snackBar: MatSnackBar,
     public i18nService: I18nFieldService,
     private appConfigService: AppConfigService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private operatorSupport: OperatorSupportService
   ) {
     this.tourId = +(this.route.snapshot.paramMap.get("id") || 0);
 
@@ -284,15 +295,95 @@ export class TourGalleryComponent implements OnInit {
     Promise.all(
       asyncCandidates.map((file) => this.validateDimensions(file))
     ).then((results) => {
+      const passed: { file: File; width: number; height: number }[] = [];
       results.forEach((result) => {
         if (result.issue) {
           rejectedIssues.push(result.issue);
-        } else {
-          this.attachFileToForm(result.file);
+        } else if (result.width && result.height) {
+          passed.push({ file: result.file, width: result.width, height: result.height });
         }
       });
-      finish();
+
+      // IA-07: valida los candidatos que pasaron los checks locales contra el
+      // backend antes de adjuntarlos al formulario. El backend puede detectar
+      // reglas adicionales (proporcion, cantidad, warnings) que el cliente no
+      // reimplementa. Ver validate-gallery en IA-07.
+      this.remoteValidateGallery(passed).then((result) => {
+        // Issues CRITICAL rechazan el archivo correspondiente antes del upload.
+        // Los WARN se muestran inline (no bloquean el flujo).
+        const inlineIssues: GalleryValidationIssue[] = [];
+        result.issues.forEach((iss) => {
+          if (iss.severity === 'CRITICAL' && typeof iss.fileIndex === 'number') {
+            const bad = passed[iss.fileIndex];
+            rejectedIssues.push({
+              fileName: bad?.file?.name || `#${iss.fileIndex + 1}`,
+              code: iss.code || 'IMAGE_INVALID',
+              message: iss.message,
+              severity: 'CRITICAL',
+            });
+          } else {
+            inlineIssues.push(iss);
+          }
+        });
+
+        // Attach solo los que no quedaron marcados como CRITICAL por el backend.
+        const criticalIndexes = new Set(
+          result.issues
+            .filter((i) => i.severity === 'CRITICAL' && typeof i.fileIndex === 'number')
+            .map((i) => i.fileIndex as number)
+        );
+        passed.forEach((candidate, idx) => {
+          if (!criticalIndexes.has(idx)) {
+            this.attachFileToForm(candidate.file);
+          }
+        });
+
+        this.aiGalleryInlineIssues = inlineIssues;
+        this.aiGallerySuggestions = result.suggestions;
+        finish();
+      });
     });
+  }
+
+  /**
+   * IA-07: llama POST /agents/operator-support/validate-gallery con la metadata
+   * de los archivos que pasaron los checks locales. NO reimplementa la validacion
+   * en el cliente (regla del brief).
+   *
+   * Fallo silencioso: si el endpoint no responde, no bloquea el flujo original.
+   */
+  private remoteValidateGallery(
+    candidates: { file: File; width: number; height: number }[]
+  ): Promise<{ issues: GalleryValidationIssue[]; suggestions: string[] }> {
+    if (candidates.length === 0) {
+      return Promise.resolve({ issues: [], suggestions: [] });
+    }
+    const metadata: ImageMetadata[] = candidates.map((c) => ({
+      filename: c.file.name,
+      sizeBytes: c.file.size,
+      widthPx: c.width,
+      heightPx: c.height,
+      format: (c.file.type || '').replace(/^image\//, '') || 'jpg',
+    }));
+    return new Promise((resolve) => {
+      this.operatorSupport.validateGallery(metadata).subscribe({
+        next: (data) => {
+          resolve({
+            issues: data.issues || [],
+            suggestions: data.suggestions || [],
+          });
+        },
+        error: (err) => {
+          console.warn('validate-gallery failed, continuing with local checks only', err);
+          resolve({ issues: [], suggestions: [] });
+        },
+      });
+    });
+  }
+
+  dismissGalleryAiSuggestions(): void {
+    this.aiGalleryInlineIssues = [];
+    this.aiGallerySuggestions = [];
   }
 
   private validateSyncRules(file: File): GalleryIssue | null {
@@ -308,7 +399,7 @@ export class TourGalleryComponent implements OnInit {
 
   private validateDimensions(
     file: File
-  ): Promise<{ file: File; issue: GalleryIssue | null; dataUrl?: string }> {
+  ): Promise<{ file: File; issue: GalleryIssue | null; dataUrl?: string; width?: number; height?: number }> {
     return new Promise((resolve) => {
       const reader = new FileReader();
       reader.onload = (e: any) => {
@@ -320,6 +411,8 @@ export class TourGalleryComponent implements OnInit {
             resolve({
               file,
               issue: { fileName: file.name, code: "NOT_LANDSCAPE" },
+              width,
+              height,
             });
             return;
           }
@@ -327,10 +420,12 @@ export class TourGalleryComponent implements OnInit {
             resolve({
               file,
               issue: { fileName: file.name, code: "WIDTH_TOO_SMALL" },
+              width,
+              height,
             });
             return;
           }
-          resolve({ file, issue: null, dataUrl });
+          resolve({ file, issue: null, dataUrl, width, height });
         };
         image.onerror = () => {
           resolve({

--- a/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.html
+++ b/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.html
@@ -372,6 +372,36 @@
 
                                             <div class="card-body pb-1">
 
+                                                <!-- IA-07 price alert badge. Se refresca en cada blur del providerPrice.
+                                                     El backend nunca modifica el precio, solo informa. -->
+                                                <div *ngIf="priceAlert && !priceAlertLoading" class="mb-3">
+                                                    <div class="d-inline-flex align-items-center gap-2 px-3 py-2 rounded"
+                                                        [ngClass]="priceAlertBadgeClass()">
+                                                        <i class="isax isax-info-circle"></i>
+                                                        <div>
+                                                            <div class="fw-medium">
+                                                                <ng-container [ngSwitch]="priceAlert.severity">
+                                                                    <ng-container *ngSwitchCase="'OK'">
+                                                                        {{ 'operatorSupport.pricing.ok' | translate }}
+                                                                        <span *ngIf="priceAlert.comparablePriceRange?.median != null">
+                                                                            &nbsp;({{ 'operatorSupport.pricing.medianHint' | translate: { median: priceAlert.comparablePriceRange!.median } }})
+                                                                        </span>
+                                                                    </ng-container>
+                                                                    <ng-container *ngSwitchCase="'WARN'">
+                                                                        {{ 'operatorSupport.pricing.warn' | translate: { percent: priceAlertPercentAboveMedian || 0 } }}
+                                                                    </ng-container>
+                                                                    <ng-container *ngSwitchCase="'CRITICAL'">
+                                                                        {{ 'operatorSupport.pricing.critical' | translate: { percent: priceAlertPercentAboveMedian || 0 } }}
+                                                                    </ng-container>
+                                                                </ng-container>
+                                                            </div>
+                                                            <small *ngIf="priceAlert.comparablePriceRange?.min != null && priceAlert.comparablePriceRange?.max != null" class="d-block">
+                                                                {{ 'operatorSupport.pricing.range' | translate: { min: priceAlert.comparablePriceRange!.min, max: priceAlert.comparablePriceRange!.max } }}
+                                                            </small>
+                                                        </div>
+                                                    </div>
+                                                </div>
+
                                                 <div formArrayName="prices">
                                                     <ng-container *ngFor="let price of prices(i).controls; let j=index"
                                                         [formGroupName]="j">

--- a/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.ts
+++ b/src/app/pages/providers/tours/tour-schedule/tour-schedule.component.ts
@@ -29,6 +29,8 @@ import { AuthService } from "../../../../core/services/auth.service";
 import { TourScheduleConfigResponseDto } from "../../../../shared/dto/tour-schedule.response.dto";
 import { I18nFieldService } from "../../../../shared/services/i18n-field.service";
 import { TranslateService } from "@ngx-translate/core";
+import { OperatorSupportService } from "../../../../shared/services/operator-support.service";
+import { PriceAlert } from "../../../../shared/models/operator-support.model";
 @Component({
   selector: "app-tour-schedule",
   standalone: false,
@@ -97,6 +99,11 @@ export class TourScheduleComponent {
   showAnyModal = false;
   pendingSlotIndex: number | null = null;
 
+  // IA-07 (Operator Support) — price alert (OK/WARN/CRITICAL). Se refresca on-blur
+  // en cualquier providerPrice de la seccion Prices; el backend lee el precio del tour.
+  priceAlert: PriceAlert | null = null;
+  priceAlertLoading: boolean = false;
+
   constructor(
     private router: Router,
     private fb: FormBuilder,
@@ -106,7 +113,8 @@ export class TourScheduleComponent {
     private templateService: TemplateService,
     private authService: AuthService,
     public i18nService: I18nFieldService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private operatorSupport: OperatorSupportService
   ) {
     this.tourId = +(this.route.snapshot.paramMap.get("id") || 0);
 
@@ -260,6 +268,62 @@ export class TourScheduleComponent {
       displayPrice = parseFloat(price);
     }
     priceControl?.setValue(displayPrice);
+
+    // IA-07: dispara la alerta pricing cuando el provider deja un precio > 0.
+    // El backend lee el providerPrice del propio tour (no lo enviamos), asi que
+    // multiples blur simplemente refrescan la misma respuesta.
+    if (displayPrice > 0) {
+      this.refreshPriceAlert();
+    }
+  }
+
+  /**
+   * IA-07: solicita al backend la alerta de precio para este tour.
+   * NO se dispara si no hay tourId (creacion nueva sin guardar). Guardrail
+   * server-side: el endpoint solo alerta, nunca modifica el precio.
+   */
+  refreshPriceAlert(): void {
+    if (!this.tourId || this.priceAlertLoading) return;
+    this.priceAlertLoading = true;
+    this.operatorSupport.getPriceAlert(this.tourId).subscribe({
+      next: (data) => {
+        this.priceAlertLoading = false;
+        this.priceAlert = data;
+      },
+      error: (err) => {
+        this.priceAlertLoading = false;
+        // Silencioso: el badge simplemente no se muestra. La alerta es opcional.
+        console.warn('Price alert unavailable', err);
+        this.priceAlert = null;
+      },
+    });
+  }
+
+  /**
+   * IA-07: porcentaje del precio del provider vs la mediana comparable.
+   * Redondeado sin decimales. Devuelve null si no hay datos suficientes.
+   */
+  get priceAlertPercentAboveMedian(): number | null {
+    const provider = this.priceAlert?.providerPrice;
+    const median = this.priceAlert?.comparablePriceRange?.median;
+    if (!provider || !median || median <= 0) return null;
+    return Math.round(((provider - median) / median) * 100);
+  }
+
+  /**
+   * Clase CSS del badge de alerta segun severity (OK/WARN/CRITICAL).
+   */
+  priceAlertBadgeClass(): string {
+    switch (this.priceAlert?.severity) {
+      case 'OK':
+        return 'bg-success-transparent text-success';
+      case 'WARN':
+        return 'bg-warning-transparent text-warning';
+      case 'CRITICAL':
+        return 'bg-danger-transparent text-danger';
+      default:
+        return 'bg-secondary-transparent text-secondary';
+    }
   }
 
   onLabelBlur(event: FocusEvent) {

--- a/src/app/shared/models/operator-support.model.ts
+++ b/src/app/shared/models/operator-support.model.ts
@@ -1,0 +1,104 @@
+﻿/**
+ * Modelos para el Operator Support Agent (IA-07).
+ * Contrato con POST /agents/operator-support/*
+ * (suggest-tour-content, price-alert, draft-review-reply, validate-gallery).
+ */
+
+// ---------------------------------------------------------------------------
+// suggest-tour-content
+// ---------------------------------------------------------------------------
+
+export interface SuggestTourContentDraft {
+  name: string;
+  categoryId: number;
+  subcategoryId?: number | null;
+  durationMinutes: number;
+  minAge: number;
+  priceType: string;
+  isUnlimitedCapacity?: boolean;
+  currentDescription?: string;
+}
+
+export interface SuggestTourContentRequest {
+  tourId?: number | null;
+  draft: SuggestTourContentDraft;
+}
+
+export interface TourContentSuggestion {
+  nameSuggestions?: string[];
+  descriptionSuggestion?: string;
+  tagSuggestions?: string[];
+  reasoning?: string;
+}
+
+// ---------------------------------------------------------------------------
+// price-alert
+// ---------------------------------------------------------------------------
+
+export type PriceAlertSeverity = 'OK' | 'WARN' | 'CRITICAL';
+
+export interface ComparablePriceRange {
+  min?: number;
+  max?: number;
+  median?: number;
+}
+
+export interface PriceAlert {
+  severity: PriceAlertSeverity;
+  providerPrice?: number;
+  comparablePriceRange?: ComparablePriceRange;
+  reasoning?: string;
+}
+
+// ---------------------------------------------------------------------------
+// draft-review-reply
+// ---------------------------------------------------------------------------
+
+export type ReviewReplyTone = 'PROFESSIONAL' | 'WARM' | 'APOLOGETIC' | string;
+
+export interface DraftReviewReplyResponse {
+  draftText: string;
+  tone?: ReviewReplyTone;
+  reasoning?: string;
+}
+
+// ---------------------------------------------------------------------------
+// validate-gallery
+// ---------------------------------------------------------------------------
+
+export interface ImageMetadata {
+  filename: string;
+  sizeBytes: number;
+  widthPx: number;
+  heightPx: number;
+  format: string;
+}
+
+export interface ValidateGalleryRequest {
+  images: ImageMetadata[];
+}
+
+export type GalleryIssueSeverity = 'WARN' | 'CRITICAL' | string;
+
+export interface GalleryValidationIssue {
+  severity: GalleryIssueSeverity;
+  code: string;
+  message?: string;
+  fileIndex?: number;
+}
+
+export interface ValidateGalleryResponse {
+  isValid: boolean;
+  issues?: GalleryValidationIssue[];
+  suggestions?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// envelope (ApiResponse<T>)
+// ---------------------------------------------------------------------------
+
+export interface OperatorSupportEnvelope<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}

--- a/src/app/shared/services/operator-support.service.ts
+++ b/src/app/shared/services/operator-support.service.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+import { environment } from '../../../environments/environment';
+import {
+  DraftReviewReplyResponse,
+  ImageMetadata,
+  OperatorSupportEnvelope,
+  PriceAlert,
+  SuggestTourContentRequest,
+  TourContentSuggestion,
+  ValidateGalleryRequest,
+  ValidateGalleryResponse,
+} from '../models/operator-support.model';
+
+/**
+ * Cliente Angular para el Operator Support Agent (backend IA-07).
+ *
+ * Expone los 4 endpoints action-specific bajo /agents/operator-support:
+ *  - suggest-tour-content: sugerencias de nombre/descripcion/tags para un tour.
+ *  - price-alert/{tourId}: alerta pricing (OK/WARN/CRITICAL) sin modificar precio.
+ *  - draft-review-reply/{reviewId}: borrador de respuesta a una resena.
+ *  - validate-gallery: valida metadata de imagenes (formato/tamano/dimensiones).
+ *
+ * Todos los metodos:
+ *  - Delegan la autorizacion JWT al AuthInterceptor global.
+ *  - Desempaquetan el envelope ApiResponse<T> y solo exponen `data`.
+ *  - Propagan errores del backend via Observable.throwError.
+ */
+@Injectable({ providedIn: 'root' })
+export class OperatorSupportService {
+  private readonly base = `${environment.apiUrl}/agents/operator-support`;
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Sugiere nombres candidatos, descripcion y tags para un tour a partir del
+   * draft del provider (campos basicos del wizard).
+   */
+  suggestTourContent(
+    request: SuggestTourContentRequest,
+  ): Observable<TourContentSuggestion> {
+    return this.http
+      .post<OperatorSupportEnvelope<TourContentSuggestion>>(
+        `${this.base}/suggest-tour-content`,
+        request,
+      )
+      .pipe(
+        map((envelope) => this.unwrap(envelope)),
+        catchError((err) => throwError(() => err)),
+      );
+  }
+
+  /**
+   * Devuelve una alerta de precio (OK/WARN/CRITICAL) para el tour indicado.
+   * El backend lee el providerPrice del propio tour (no lo enviamos).
+   * Guardrail server-side: nunca modifica el precio, solo alerta.
+   */
+  getPriceAlert(tourId: number): Observable<PriceAlert> {
+    return this.http
+      .post<OperatorSupportEnvelope<PriceAlert>>(
+        `${this.base}/price-alert/${tourId}`,
+        {},
+      )
+      .pipe(
+        map((envelope) => this.unwrap(envelope)),
+        catchError((err) => throwError(() => err)),
+      );
+  }
+
+  /**
+   * Genera un borrador de respuesta para la resena indicada.
+   * Guardrail server-side: verifica ownership; 401 si el review no pertenece
+   * a un tour del provider autenticado.
+   */
+  draftReviewReply(reviewId: number): Observable<DraftReviewReplyResponse> {
+    return this.http
+      .post<OperatorSupportEnvelope<DraftReviewReplyResponse>>(
+        `${this.base}/draft-review-reply/${reviewId}`,
+        {},
+      )
+      .pipe(
+        map((envelope) => this.unwrap(envelope)),
+        catchError((err) => throwError(() => err)),
+      );
+  }
+
+  /**
+   * Valida la metadata de una galeria (dimensiones/tamano/formato/cantidad).
+   * Endpoint sin LLM (regla dura del backend); rapido y gratis.
+   */
+  validateGallery(
+    images: ImageMetadata[],
+  ): Observable<ValidateGalleryResponse> {
+    const body: ValidateGalleryRequest = { images };
+    return this.http
+      .post<OperatorSupportEnvelope<ValidateGalleryResponse>>(
+        `${this.base}/validate-gallery`,
+        body,
+      )
+      .pipe(
+        map((envelope) => this.unwrap(envelope)),
+        catchError((err) => throwError(() => err)),
+      );
+  }
+
+  private unwrap<T>(envelope: OperatorSupportEnvelope<T> | null | undefined): T {
+    if (!envelope) {
+      throw new Error('empty_response');
+    }
+    if (envelope.success === false || envelope.data == null) {
+      throw new Error(envelope.error || 'operator_support_error');
+    }
+    return envelope.data;
+  }
+}


### PR DESCRIPTION
## Summary

Integracion FE del backend Operator Support Agent (IA-07, tourya-api #265) con 4 touchpoints en el panel del provider:

- **`OperatorSupportService`** en `src/app/shared/services/` con los 4 metodos: `suggestTourContent`, `getPriceAlert`, `draftReviewReply`, `validateGallery`. Modelos en `src/app/shared/models/operator-support.model.ts`.
- **add-tour**: boton "Sugerir con IA" en la seccion Descripcion del wizard; modal con nombres candidatos, descripcion sugerida y tags seleccionables. Nada se aplica sin click explicito del provider.
- **tour-schedule** (donde vive `providerPrice`): badge OK/WARN/CRITICAL en la seccion Prices, refrescado on-blur en cualquier input `providerPrice`. Nunca modifica el precio (guardrail server-side reflejado en cliente).
- **tour-gallery**: valida metadata (`filename/sizeBytes/width/height/format`) contra el backend antes de subir; issues CRITICAL bloquean el archivo, WARN se muestran inline debajo de la galeria, sugerencias no-bloqueantes.
- **provider-reviews**: boton "Borrador con IA" junto a "Responder" en cada card sin responder; pre-carga el TextEditor existente con `draftText` y muestra badge "Tono detectado". El publish sigue por `submitReply` existente.
- **i18n**: nuevas keys `operatorSupport.*` en `es/en/pt`.

## Adaptaciones vs brief

- **Wizard tour = `pages/providers/tours/add-tour/`** (component monolitico, no wizard multi-step). El boton "Sugerir con IA" se coloca en la seccion Descripcion (donde el brief indica) y valida antes que `name/category/priceType/duration/minAge` esten completos.
- **Precio del tour = per-slot per-age** (no un unico input `providerPrice`). El badge se renderiza una vez arriba de la seccion Prices en `tour-schedule` — cada blur refresca la misma respuesta del endpoint (`POST /price-alert/{tourId}`), que lee el `providerPrice` del propio tour.
- **subcategoryId no viaja al request** (el codebase usa `subCategory: code` string, no id numerico). Pasa `null`; el LLM del backend infiere del nombre + categoryId.
- **validate-gallery**: solo se envia metadata de archivos NUEVOS pasando los checks locales (los existentes ya se validaron al subir). Fallo silencioso — si el endpoint no responde, no bloquea el upload local.

## Restricciones respetadas

- **NO se toca** `travel-concierge.service.ts` ni `ConciergeChatWidget`.
- **NO se cambia** el binding de `providerPrice` — solo lectura, alerta informativa.
- **NO se reimplementa** validacion de galeria en cliente — se pasa metadata al backend y renderizamos los issues estructurados.
- **NO se agregan dependencias nuevas**.

## Test plan

- [ ] Como PROVIDER, en `add-tour` completar nombre/categoria/priceType/duration/minAge y click "Sugerir con IA" -> modal aparece con nombres, descripcion, tags.
- [ ] Aplicar nombre sugerido (chip) -> reemplaza `name` en el form.
- [ ] Aplicar descripcion sugerida -> reemplaza el textarea.
- [ ] Seleccionar tags sugeridos + "Agregar seleccionados" -> se agregan al FormArray de tags (match por code/nombre).
- [ ] Sin campos completos -> Swal info con lista de campos faltantes.
- [ ] En `tour-schedule/:tourId` editar un `providerPrice`, blur -> badge OK/WARN/CRITICAL aparece en el header de Prices con rango y mediana.
- [ ] En `tour-gallery/:tourId`, subir imagen -> issues WARN aparecen inline, CRITICAL disparan Swal y bloquean el upload, suggestions se muestran debajo.
- [ ] En `provider-reviews` (proveedor con resenas sin responder) click "Borrador con IA" -> spinner, luego se abre el TextEditor pre-cargado + badge tono.
- [ ] Editar el draft y publicar via el flujo existente (`submitReply`) -> funciona sin cambios.
